### PR TITLE
feat: add searchable language dropdown in navbar (NSoC'26)

### DIFF
--- a/frontend/App.css
+++ b/frontend/App.css
@@ -668,7 +668,7 @@ iframe.goog-te-banner-frame.skiptranslate {
   color: #000;
   font-size: 0.95rem;
   font-weight: 700;
-  font-family: "Poppins", sans-serif;
+  font-family: Poppins, sans-serif;
   padding: 8px 14px;
   border-radius: 8px;
   border: 2px solid transparent;
@@ -702,7 +702,7 @@ iframe.goog-te-banner-frame.skiptranslate {
   border: none;
   border-bottom: 1px solid #eee;
   font-size: 0.9rem;
-  font-family: "Poppins", sans-serif;
+  font-family: Poppins, sans-serif;
   outline: none;
   background: #fff;
   color: #000;
@@ -723,7 +723,7 @@ iframe.goog-te-banner-frame.skiptranslate {
   align-items: center;
   padding: 10px 14px;
   font-size: 0.92rem;
-  font-family: "Poppins", sans-serif;
+  font-family: Poppins, sans-serif;
   color: #111;
   cursor: pointer;
   transition: background 0.15s ease;
@@ -775,4 +775,13 @@ iframe.goog-te-banner-frame.skiptranslate {
 
 .theme-dark .lang-dropdown-item--selected {
   background: #1b5e20;
+}
+.lang-dropdown-item--focused {
+  background: #d4edda;
+  outline: 2px solid #2e7d32;
+}
+
+.theme-dark .lang-dropdown-item--focused {
+  background: #1b5e20;
+  outline: 2px solid #66bb6a;
 }

--- a/frontend/App.css
+++ b/frontend/App.css
@@ -654,3 +654,125 @@ iframe.goog-te-banner-frame.skiptranslate {
     display: block;
   }
 }
+/* ── Language Dropdown ── */
+.lang-dropdown {
+  position: relative;
+  display: inline-block;
+}
+
+.lang-dropdown-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background-color: #f5a623;
+  color: #000;
+  font-size: 0.95rem;
+  font-weight: 700;
+  font-family: "Poppins", sans-serif;
+  padding: 8px 14px;
+  border-radius: 8px;
+  border: 2px solid transparent;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: filter 0.3s ease, transform 0.3s ease;
+  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.15);
+}
+
+.lang-dropdown-btn:hover {
+  filter: brightness(1.1);
+  transform: translateY(-2px);
+}
+
+.lang-dropdown-panel {
+  position: absolute;
+  top: calc(100% + 8px);
+  right: 0;
+  z-index: 9999;
+  background: #ffffff;
+  border: 1px solid #ddd;
+  border-radius: 10px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.15);
+  min-width: 210px;
+  overflow: hidden;
+}
+
+.lang-dropdown-search {
+  width: 100%;
+  padding: 10px 12px;
+  border: none;
+  border-bottom: 1px solid #eee;
+  font-size: 0.9rem;
+  font-family: "Poppins", sans-serif;
+  outline: none;
+  background: #fff;
+  color: #000;
+  box-sizing: border-box;
+}
+
+.lang-dropdown-list {
+  list-style: none;
+  margin: 0;
+  padding: 4px 0;
+  max-height: 220px;
+  overflow-y: auto;
+}
+
+.lang-dropdown-item {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 10px 14px;
+  font-size: 0.92rem;
+  font-family: "Poppins", sans-serif;
+  color: #111;
+  cursor: pointer;
+  transition: background 0.15s ease;
+  list-style: none;
+}
+
+.lang-dropdown-item:hover {
+  background: #f0fdf4;
+}
+
+.lang-dropdown-item--selected {
+  background: #e6f4ea;
+  font-weight: 600;
+}
+
+.lang-dropdown-check {
+  color: #2e7d32;
+  font-weight: 700;
+  margin-left: 8px;
+}
+
+.lang-dropdown-empty {
+  padding: 12px 14px;
+  font-size: 0.88rem;
+  color: #999;
+  text-align: center;
+  list-style: none;
+}
+
+/* Dark theme */
+.theme-dark .lang-dropdown-panel {
+  background: #1a2e1a;
+  border-color: #2e7d32;
+}
+
+.theme-dark .lang-dropdown-search {
+  background: #1a2e1a;
+  color: #fff;
+  border-bottom-color: #2e7d32;
+}
+
+.theme-dark .lang-dropdown-item {
+  color: #eee;
+}
+
+.theme-dark .lang-dropdown-item:hover {
+  background: #243d24;
+}
+
+.theme-dark .lang-dropdown-item--selected {
+  background: #1b5e20;
+}

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -22,18 +22,18 @@ import LanguageDropdown from "./LanguageDropdown";
 /* ---------------- LANGUAGE ---------------- */
 
 const LANGUAGE_OPTIONS = [
-  { value: "en", label: "🌍 English" },
-  { value: "hi", label: "🇮🇳 हिंदी" },
-  { value: "mr", label: "🇮🇳 मराठी" },
-  { value: "bn", label: "🇮🇳 বাংলা" },
-  { value: "ta", label: "🇮🇳 தமிழ்" },
-  { value: "te", label: "🇮🇳 తెలుగు" },
-  { value: "gu", label: "🇮🇳 ગુજરાતી" },
-  { value: "pa", label: "🇮🇳 ਪੰਜਾਬੀ" },
-  { value: "kn", label: "🇮🇳 ಕನ್ನಡ" },
-  { value: "ml", label: "🇮🇳 മലയാളം" },
-  { value: "or", label: "🇮🇳 ଓଡ଼ିଆ" },
-  { value: "as", label: "🇮🇳 অসমীয়া" },
+  { value: "en", label: "🌍 English", englishName: "english" },
+  { value: "hi", label: "🇮🇳 हिंदी", englishName: "hindi" },
+  { value: "mr", label: "🇮🇳 मराठी", englishName: "marathi" },
+  { value: "bn", label: "🇮🇳 বাংলা", englishName: "bengali" },
+  { value: "ta", label: "🇮🇳 தமிழ்", englishName: "tamil" },
+  { value: "te", label: "🇮🇳 తెలుగు", englishName: "telugu" },
+  { value: "gu", label: "🇮🇳 ગુજરાતી", englishName: "gujarati" },
+  { value: "pa", label: "🇮🇳 ਪੰਜਾਬੀ", englishName: "punjabi" },
+  { value: "kn", label: "🇮🇳 ಕನ್ನಡ", englishName: "kannada" },
+  { value: "ml", label: "🇮🇳 മലയാളം", englishName: "malayalam" },
+  { value: "or", label: "🇮🇳 ଓଡ଼ିଆ", englishName: "odia" },
+  { value: "as", label: "🇮🇳 অসমীয়া", englishName: "assamese" },
 ];
 
 const getInitialLanguage = () => {
@@ -164,7 +164,7 @@ function App() {
             <button onClick={handleThemeToggle}>
               {theme === "dark" ? "☀️" : "🌙"}
             </button>
-            
+
             <LanguageDropdown
               options={LANGUAGE_OPTIONS}
               value={preferredLang}

--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -17,6 +17,7 @@ import How from "./How";
 import { NavLink } from "react-router-dom";
 
 import "./App.css";
+import LanguageDropdown from "./LanguageDropdown";
 
 /* ---------------- LANGUAGE ---------------- */
 
@@ -163,20 +164,12 @@ function App() {
             <button onClick={handleThemeToggle}>
               {theme === "dark" ? "☀️" : "🌙"}
             </button>
-
-            <select
-              className="lang-select notranslate"
+            
+            <LanguageDropdown
+              options={LANGUAGE_OPTIONS}
               value={preferredLang}
-              onChange={(e) =>
-                syncLanguage(e.target.value, setPreferredLang)
-              }
-            >
-              {LANGUAGE_OPTIONS.map((l) => (
-                <option key={l.value} value={l.value}>
-                  {l.label}
-                </option>
-              ))}
-            </select>
+              onChange={(val) => syncLanguage(val, setPreferredLang)}
+            />
 
             <div className="nav-user">
               {name ? (

--- a/frontend/LanguageDropdown.jsx
+++ b/frontend/LanguageDropdown.jsx
@@ -1,0 +1,92 @@
+import React, { useState, useRef, useEffect } from "react";
+
+function LanguageDropdown({ options, value, onChange }) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [search, setSearch] = useState("");
+  const containerRef = useRef(null);
+
+  const selected = options.find((o) => o.value === value);
+
+  // Search works by both English name (value) and native label
+  const filtered = options.filter(
+    (o) =>
+      o.label.toLowerCase().includes(search.toLowerCase()) ||
+      o.value.toLowerCase().includes(search.toLowerCase())
+  );
+
+  // Selected language always appears at top
+  const sorted = [
+    ...filtered.filter((o) => o.value === value),
+    ...filtered.filter((o) => o.value !== value),
+  ];
+
+  // Close on outside click
+  useEffect(() => {
+    const handleOutsideClick = (e) => {
+      if (containerRef.current && !containerRef.current.contains(e.target)) {
+        setIsOpen(false);
+        setSearch("");
+      }
+    };
+    document.addEventListener("mousedown", handleOutsideClick);
+    return () => document.removeEventListener("mousedown", handleOutsideClick);
+  }, []);
+
+  const handleSelect = (val) => {
+    onChange(val);
+    setIsOpen(false);
+    setSearch("");
+  };
+
+  return (
+    <div className="lang-dropdown notranslate" ref={containerRef}>
+      <button
+        type="button"
+        className="lang-dropdown-btn"
+        onClick={() => setIsOpen((prev) => !prev)}
+        aria-haspopup="listbox"
+        aria-expanded={isOpen}
+      >
+        {selected ? selected.label : "Language"} ▾
+      </button>
+
+      {isOpen && (
+        <div className="lang-dropdown-panel" role="listbox">
+          <input
+            type="text"
+            className="lang-dropdown-search"
+            placeholder="Search language..."
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            autoFocus
+          />
+
+          <ul className="lang-dropdown-list">
+            {sorted.length > 0 ? (
+              sorted.map((o) => (
+                <li
+                  key={o.value}
+                  role="option"
+                  aria-selected={o.value === value}
+                  className={`lang-dropdown-item ${
+                    o.value === value ? "lang-dropdown-item--selected" : ""
+                  }`}
+                  onClick={() => handleSelect(o.value)}
+                >
+                  {o.label}
+                  {o.value === value && (
+                    <span className="lang-dropdown-check">✓</span>
+                  )}
+                </li>
+              ))
+            ) : (
+              <li className="lang-dropdown-empty">No results found</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default LanguageDropdown;

--- a/frontend/LanguageDropdown.jsx
+++ b/frontend/LanguageDropdown.jsx
@@ -3,18 +3,20 @@ import React, { useState, useRef, useEffect } from "react";
 function LanguageDropdown({ options, value, onChange }) {
   const [isOpen, setIsOpen] = useState(false);
   const [search, setSearch] = useState("");
+  const [focusedIndex, setFocusedIndex] = useState(-1);
   const containerRef = useRef(null);
+  const listRef = useRef(null);
+  const searchRef = useRef(null);
 
   const selected = options.find((o) => o.value === value);
 
-  // Search works by both English name (value) and native label
   const filtered = options.filter(
-    (o) =>
-      o.label.toLowerCase().includes(search.toLowerCase()) ||
-      o.value.toLowerCase().includes(search.toLowerCase())
-  );
+  (o) =>
+    o.label.toLowerCase().includes(search.toLowerCase()) ||
+    o.value.toLowerCase().includes(search.toLowerCase()) ||
+    (o.englishName && o.englishName.toLowerCase().includes(search.toLowerCase()))
+);
 
-  // Selected language always appears at top
   const sorted = [
     ...filtered.filter((o) => o.value === value),
     ...filtered.filter((o) => o.value !== value),
@@ -26,16 +28,57 @@ function LanguageDropdown({ options, value, onChange }) {
       if (containerRef.current && !containerRef.current.contains(e.target)) {
         setIsOpen(false);
         setSearch("");
+        setFocusedIndex(-1);
       }
     };
     document.addEventListener("mousedown", handleOutsideClick);
     return () => document.removeEventListener("mousedown", handleOutsideClick);
   }, []);
 
+  // Reset focused index when search changes
+  useEffect(() => {
+    setFocusedIndex(-1);
+  }, [search]);
+
   const handleSelect = (val) => {
     onChange(val);
     setIsOpen(false);
     setSearch("");
+    setFocusedIndex(-1);
+  };
+
+  const handleButtonKeyDown = (e) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      setIsOpen((prev) => !prev);
+    } else if (e.key === "Escape") {
+      setIsOpen(false);
+      setSearch("");
+    }
+  };
+
+  const handleSearchKeyDown = (e) => {
+    if (e.key === "Escape") {
+      setIsOpen(false);
+      setSearch("");
+      setFocusedIndex(-1);
+    } else if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.min(i + 1, sorted.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setFocusedIndex((i) => Math.max(i - 1, 0));
+    } else if (e.key === "Enter" && focusedIndex >= 0) {
+      e.preventDefault();
+      handleSelect(sorted[focusedIndex].value);
+    }
+  };
+
+  const handleItemKeyDown = (e, val) => {
+    if (e.key === "Enter" || e.key === " ") {
+      e.preventDefault();
+      handleSelect(val);
+    }
   };
 
   return (
@@ -44,43 +87,59 @@ function LanguageDropdown({ options, value, onChange }) {
         type="button"
         className="lang-dropdown-btn"
         onClick={() => setIsOpen((prev) => !prev)}
+        onKeyDown={handleButtonKeyDown}
         aria-haspopup="listbox"
         aria-expanded={isOpen}
+        aria-controls="lang-dropdown-list"
+        aria-label="Select language"
       >
         {selected ? selected.label : "Language"} ▾
       </button>
 
       {isOpen && (
-        <div className="lang-dropdown-panel" role="listbox">
+        <div className="lang-dropdown-panel">
           <input
+            ref={searchRef}
             type="text"
             className="lang-dropdown-search"
             placeholder="Search language..."
             value={search}
             onChange={(e) => setSearch(e.target.value)}
+            onKeyDown={handleSearchKeyDown}
+            aria-label="Search language"
             autoFocus
           />
 
-          <ul className="lang-dropdown-list">
+          <ul
+            id="lang-dropdown-list"
+            ref={listRef}
+            className="lang-dropdown-list"
+            role="listbox"
+            aria-label="Languages"
+          >
             {sorted.length > 0 ? (
-              sorted.map((o) => (
+              sorted.map((o, index) => (
                 <li
                   key={o.value}
                   role="option"
                   aria-selected={o.value === value}
+                  tabIndex={0}
                   className={`lang-dropdown-item ${
                     o.value === value ? "lang-dropdown-item--selected" : ""
-                  }`}
+                  } ${focusedIndex === index ? "lang-dropdown-item--focused" : ""}`}
                   onClick={() => handleSelect(o.value)}
+                  onKeyDown={(e) => handleItemKeyDown(e, o.value)}
                 >
                   {o.label}
                   {o.value === value && (
-                    <span className="lang-dropdown-check">✓</span>
+                    <span className="lang-dropdown-check" aria-hidden="true">✓</span>
                   )}
                 </li>
               ))
             ) : (
-              <li className="lang-dropdown-empty">No results found</li>
+              <li className="lang-dropdown-empty" role="option" aria-selected="false">
+                No results found
+              </li>
             )}
           </ul>
         </div>

--- a/frontend/LanguageDropdown.jsx
+++ b/frontend/LanguageDropdown.jsx
@@ -68,7 +68,7 @@ function LanguageDropdown({ options, value, onChange }) {
     } else if (e.key === "ArrowUp") {
       e.preventDefault();
       setFocusedIndex((i) => Math.max(i - 1, 0));
-    } else if (e.key === "Enter" && focusedIndex >= 0) {
+    } else if (e.key === "Enter" && focusedIndex >= 0 && sorted.length > 0) {
       e.preventDefault();
       handleSelect(sorted[focusedIndex].value);
     }


### PR DESCRIPTION
Replaces the native language `<select>` dropdown in the navbar with a custom searchable dropdown component for better usability.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other

## Changes Made
- Created `LanguageDropdown.jsx` — a reusable searchable dropdown component
- Replaced native `<select>` in navbar with the new component
- Added CSS styles for both light and dark themes

## Features Added
- 🔍 Search input to filter languages dynamically
- ✅ Selected language shown at top with checkmark
- ❌ "No results found" message when no match
- 🌙 Dark theme support

## Testing
- Tested locally using `npm run dev`
- Searched languages by typing (e.g. "hin", "ben", "tamil") — works correctly
- Verified selected language appears at top with checkmark
- Verified "No results found" message appears for invalid search
- Tested in both light and dark theme

## Checklist
- [x] My code follows the project's coding standards
- [x] I have performed a self-review of my code
- [x] I have commented my code where necessary
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix works or my feature works
- [ ] New and existing unit tests pass locally

## Related Issue
Closes #31

## Screenshots
<!-- Drag and drop your screenshot here -->
<img width="1886" height="894" alt="Screenshot (44)" src="https://github.com/user-attachments/assets/8dbb7f63-a789-46e5-9c82-55c3250ef8d7" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Replaced the language selector with a searchable, accessible dropdown for quick language lookup and switching.
  * Search filters results (case-insensitive) and promotes the current selection to the top.
  * Added keyboard navigation, focus handling, outside-click close, and clear visual feedback (selected state and checkmark).
  * Shows a friendly "No results" message when a search yields nothing.

* **Style**
  * Added themed styling including dark-mode overrides for the language dropdown.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->