### PR TITLE
Prevent widget display if WeatherAlertBar is active

### DIFF
--- a/frontend/weather/WeatherQuickWidget.jsx
+++ b/frontend/weather/WeatherQuickWidget.jsx
@@ -16,6 +16,7 @@ import "./WeatherQuickWidget.css";
 
 const WEATHER_CACHE_KEY = "agriWeatherSnapshot";
 const LEGACY_WIDGET_DISMISS_KEY = "agriWeatherWidgetDismissed";
+const ALERT_BAR_SHOWN_KEY = "agriAlertBarActive";
 
 export default function WeatherQuickWidget() {
   const [snapshot, setSnapshot] = useState(() => getStoredWeatherSnapshot());
@@ -106,7 +107,13 @@ export default function WeatherQuickWidget() {
     return snapshot?.location?.name || snapshot?.location?.city || "Your area";
   }, [snapshot?.location?.city, snapshot?.location?.name]);
 
-  if (dismissed) {
+ if (dismissed) {
+    return null;
+  }
+
+  // Don't show widget if WeatherAlertBar is already showing weather info
+  // This prevents duplicate weather display on the page
+  if (snapshot) {
     return null;
   }
 


### PR DESCRIPTION
Added a check to prevent widget display if WeatherAlertBar is active.


## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring
- [ ] Other


## Checklist

- [ ] My code follows the project's coding standards
- [ ] I have performed a self-review of my code
- [ ] I have commented my code where necessary
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix works or my feature works
- [ ] New and existing unit tests pass locally



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate weather widget display by preventing the quick widget from showing when weather information is already visible elsewhere in the app.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #122