### PR TITLE
fix: center navbar menu items using absolute positioning

### DIFF
--- a/frontend/App.css
+++ b/frontend/App.css
@@ -193,10 +193,11 @@ body,
    display: flex;
    gap: 12px;
    align-items: center;
-   flex: 1;
-   justify-content: center;
+   position: absolute;
+   left: 50%;
+   transform: translateX(-50%);
    flex-wrap: nowrap;
-   margin: 0 20px;
+   margin: 0;
  }
 
  .nav-center a {


### PR DESCRIPTION
Fixes #269

## Problem
The navbar menu items (Home, Works, Guide, Resources, About, Contact) were not centered on the screen. The previous approach used flex: 1 with justify-content: center on .nav-center, which only centers within the remaining space between nav-left and nav-right — not within the full navbar width. Since nav-left (logo) and nav-right (buttons) have different widths, the center point of the remaining space is not the true center of the screen.

## Root Cause
justify-content: center on a flex child only centers content within that child's allocated space. When the siblings have unequal widths, the visual center shifts toward the narrower side.

## Fix
Applied absolute positioning to .nav-center:
- position: absolute
- left: 50%
- transform: translateX(-50%)

This anchors the nav items to exactly 50% of the navbar width and shifts them back by half their own width, placing them at the true horizontal center of the screen regardless of what is on the left or right side.

## Changes
- frontend/App.css only (3 lines changed)
  - Replaced flex: 1 and justify-content: center with position: absolute + left: 50% + transform: translateX(-50%)
  - Removed margin: 0 20px (not needed with absolute positioning)

## Testing
1. Open the app on desktop
2. Navbar items should appear exactly centered on the screen
3. Logo on left and action buttons on right remain unaffected
4. Responsive behavior on mobile is unchanged

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Navigation layout styling was optimized for improved rendering performance without affecting visual appearance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->