### PR TITLE
fix(ml): raise on unknown categories and missing features instead of silent zero-fill

### DIFF
--- a/main.py
+++ b/main.py
@@ -35,6 +35,7 @@ from firebase_admin import credentials, auth as firebase_auth, firestore
 from ml.registry import ModelRegistry
 from ml.adapters.xgboost_adapter import XGBoostAdapter
 from ml.router import ModelRouter
+from ml.preprocessing import UnknownCategoryError, MissingFeatureError
 
 # Other internal modules
 from alert_rules import generate_alerts
@@ -237,18 +238,44 @@ def predict_get():
 @limiter.limit("5/minute")
 def predict_yield(data: PredictRequest, request: Request):
     """
-    Standardized prediction endpoint using ML Router for dynamic model selection.
+    Standardised prediction endpoint using ML Router for dynamic model selection.
+
+    Returns HTTP 422 when the input contains an unknown categorical value or a
+    missing required feature, so callers receive an actionable error message
+    rather than a silently corrupted prediction.
     """
     try:
-        input_data = data.model_dump() if hasattr(data, 'model_dump') else data.dict()
-        
+        input_data = data.model_dump() if hasattr(data, "model_dump") else data.dict()
+
         context = {
             "location": request.headers.get("X-User-Location", "Unknown"),
-            "crop": data.Crop
+            "crop": data.Crop,
         }
-        
+
         predicted_yield = router.predict(input_data, context)
         return {"predicted_ExpYield": float(predicted_yield)}
+
+    except UnknownCategoryError as e:
+        # The submitted categorical value was not in the training vocabulary.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "unknown_category",
+                "field": e.column,
+                "value": str(e.value),
+                "message": str(e),
+            },
+        )
+    except MissingFeatureError as e:
+        # Required feature columns are absent after encoding.
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "missing_features",
+                "missing": e.missing_columns,
+                "message": str(e),
+            },
+        )
     except Exception as e:
         print(f"Prediction Error: {e}")
         raise HTTPException(status_code=400, detail=str(e))

--- a/ml/adapters/xgboost_adapter.py
+++ b/ml/adapters/xgboost_adapter.py
@@ -27,14 +27,21 @@ class XGBoostAdapter(YieldModel):
     def predict(self, input_data: pd.DataFrame) -> float:
         if self.model is None:
             raise ValueError("Model not loaded. Call load() first.")
-        
-        # Ensure columns match what the model expects
+
+        # The FeaturePreprocessor is responsible for validating and aligning
+        # columns before this point.  We do a final shape check here as a
+        # safety net, but we do NOT silently fill missing columns with 0 —
+        # that would mask corrupt inputs and produce meaningless predictions.
         if self._feature_names:
-            for col in self._feature_names:
-                if col not in input_data.columns:
-                    input_data[col] = 0
+            missing = [c for c in self._feature_names if c not in input_data.columns]
+            if missing:
+                raise ValueError(
+                    f"XGBoostAdapter.predict() received a DataFrame that is "
+                    f"missing {len(missing)} expected column(s): {missing}. "
+                    "Ensure FeaturePreprocessor.preprocess() is called first."
+                )
             input_data = input_data[self._feature_names]
-            
+
         prediction = self.model.predict(input_data)
         return float(prediction[0])
 

--- a/ml/preprocessing.py
+++ b/ml/preprocessing.py
@@ -2,38 +2,158 @@ import pandas as pd
 import numpy as np
 from typing import List
 
+
+class UnknownCategoryError(ValueError):
+    """
+    Raised when a categorical input value was not seen during training.
+
+    The one-hot encoder (pd.get_dummies) silently drops unknown categories,
+    producing no encoded columns for that value.  If we then fill those
+    missing columns with 0 the model receives a row where *every* category
+    for that feature is 0 — a structurally invalid input that looks valid
+    but produces meaningless predictions.
+
+    Attributes
+    ----------
+    column : str
+        The original (pre-encoding) categorical column name.
+    value : object
+        The value that was not recognised.
+    expected_columns : list[str]
+        The one-hot columns the model expected for this feature group.
+    """
+
+    def __init__(self, column: str, value: object, expected_columns: List[str]):
+        self.column = column
+        self.value = value
+        self.expected_columns = expected_columns
+        super().__init__(
+            f"Unknown value '{value}' for categorical feature '{column}'. "
+            f"The model was not trained on this value. "
+            f"Expected one of the encoded columns: {expected_columns}"
+        )
+
+
+class MissingFeatureError(ValueError):
+    """
+    Raised when a required numeric feature column is absent from the input.
+
+    Attributes
+    ----------
+    missing_columns : list[str]
+        Feature columns that were expected but not present after encoding.
+    """
+
+    def __init__(self, missing_columns: List[str]):
+        self.missing_columns = missing_columns
+        super().__init__(
+            f"Input is missing {len(missing_columns)} required feature(s): "
+            f"{missing_columns}. "
+            "Provide all required fields or check that categorical values "
+            "match the training vocabulary."
+        )
+
+
 class FeaturePreprocessor:
     """
-    Standardizes and normalizes input features for yield prediction models.
+    Standardises and validates input features for yield prediction models.
+
+    Raises
+    ------
+    UnknownCategoryError
+        When a categorical column value was not present in the training data,
+        meaning pd.get_dummies produced no encoded column for it.
+    MissingFeatureError
+        When one or more required numeric feature columns are absent after
+        encoding and cannot be inferred from the input.
     """
-    
+
     def __init__(self, feature_cols: List[str] = None):
         self.feature_cols = feature_cols
-        self.dummy_cols = ['Crop', 'CNext', 'CLast', 'CTransp', 'IrriType', 'IrriSource', 'Season']
+        self.dummy_cols = [
+            "Crop", "CNext", "CLast", "CTransp",
+            "IrriType", "IrriSource", "Season",
+        ]
 
     def preprocess(self, input_data: dict) -> pd.DataFrame:
         """
-        Convert raw input dictionary to a processed DataFrame.
+        Convert a raw input dictionary to a validated, encoded DataFrame.
+
+        Parameters
+        ----------
+        input_data : dict
+            Raw feature dictionary from the API request.
+
+        Returns
+        -------
+        pd.DataFrame
+            A single-row DataFrame with columns matching ``self.feature_cols``.
+
+        Raises
+        ------
+        UnknownCategoryError
+            If a categorical value produces no encoded columns (unknown category).
+        MissingFeatureError
+            If required feature columns are absent after encoding.
         """
         df = pd.DataFrame([input_data])
-        
-        # Apply one-hot encoding for categorical variables
-        df = pd.get_dummies(df, columns=[col for col in self.dummy_cols if col in df.columns], drop_first=True)
-        
-        # Ensure all expected feature columns are present (fill with 0 if missing)
+
+        # --- One-hot encode categorical columns ---
+        categorical_cols_present = [
+            col for col in self.dummy_cols if col in df.columns
+        ]
+        df = pd.get_dummies(df, columns=categorical_cols_present, drop_first=True)
+
+        # --- Validate and align to expected feature schema ---
         if self.feature_cols:
-            for col in self.feature_cols:
-                if col not in df.columns:
-                    df[col] = 0
-            # Reorder columns to match model expectations
+            missing = [col for col in self.feature_cols if col not in df.columns]
+
+            if missing:
+                # Determine whether each missing column belongs to a categorical
+                # group that was present in the input (unknown category) or is a
+                # genuinely absent numeric feature.
+                unknown_category_errors = []
+                truly_missing = []
+
+                for col in missing:
+                    # e.g. "Crop_rice" → base column is "Crop"
+                    base_col = next(
+                        (c for c in self.dummy_cols if col.startswith(f"{c}_")),
+                        None,
+                    )
+                    if base_col and base_col in input_data:
+                        # The base categorical column was provided but its value
+                        # produced no encoded column → unknown category.
+                        expected_for_group = [
+                            c for c in self.feature_cols
+                            if c.startswith(f"{base_col}_")
+                        ]
+                        unknown_category_errors.append(
+                            UnknownCategoryError(
+                                column=base_col,
+                                value=input_data[base_col],
+                                expected_columns=expected_for_group,
+                            )
+                        )
+                    else:
+                        truly_missing.append(col)
+
+                # Report unknown categories first — they are the most actionable.
+                if unknown_category_errors:
+                    # Raise the first one; callers can catch and inspect .column / .value.
+                    raise unknown_category_errors[0]
+
+                if truly_missing:
+                    raise MissingFeatureError(truly_missing)
+
+            # Reorder columns to exactly match model expectations.
             df = df[self.feature_cols]
-        
+
         return df
 
     def normalize(self, df: pd.DataFrame) -> pd.DataFrame:
         """
-        Placeholder for normalization (e.g., MinMaxScaler or StandardScaler).
+        Placeholder for normalization (e.g. MinMaxScaler or StandardScaler).
         Can be extended for specific model requirements.
         """
-        # For now, just return as is or implement basic scaling if needed
         return df

--- a/ml/router.py
+++ b/ml/router.py
@@ -1,59 +1,111 @@
-from typing import Optional, Dict, Any
+import logging
+from typing import Optional, Dict, Any, Tuple
+
 from ml.registry import ModelRegistry
 from ml.preprocessing import FeaturePreprocessor
 
+logger = logging.getLogger(__name__)
+
+
 class ModelRouter:
     """
-    Handles dynamic routing to the appropriate model based on context.
+    Routes prediction requests to the appropriate registered model.
+
+    The router selects a model based on context (location, crop), then
+    delegates preprocessing and prediction to that model's adapter.
+
+    If the selected model is unavailable the router falls back to the
+    default model and logs a warning — it does NOT silently switch to a
+    model with a different feature schema without telling the caller.
     """
-    
+
     def __init__(self, default_model: str = "xgboost"):
         self.default_model = default_model
         self.preprocessor = FeaturePreprocessor()
 
     def route(self, context: Dict[str, Any]) -> str:
-        """
-        Logic to decide which model to use.
-        - Location-based selection
-        - Data availability based selection
-        - Random A/B testing
-        """
+        """Return the name of the model to use for this request."""
         location = context.get("location", "").lower()
         crop = context.get("crop", "").lower()
-        
-        # Example dynamic selection logic
+
         if "punjab" in location or "haryana" in location:
-            return "xgboost"  # XGBoost might be better for these regions
+            return "xgboost"
         elif "karnataka" in location and crop == "rice":
-            return "lstm"     # LSTM might be better for specific crops in specific regions
-        
+            return "lstm"
+
         return self.default_model
 
-    def predict(self, input_data: Dict[str, Any], context: Dict[str, Any] = None) -> float:
+    def predict(
+        self,
+        input_data: Dict[str, Any],
+        context: Dict[str, Any] = None,
+    ) -> float:
         """
-        The main entry point for predictions.
+        Preprocess input and run prediction through the selected model.
+
+        Parameters
+        ----------
+        input_data : dict
+            Raw feature dictionary from the API request.
+        context : dict, optional
+            Routing hints (e.g. ``location``, ``crop``).
+
+        Returns
+        -------
+        float
+            Predicted yield value.
+
+        Raises
+        ------
+        ml.preprocessing.UnknownCategoryError
+            If a categorical input value was not seen during training.
+        ml.preprocessing.MissingFeatureError
+            If required feature columns are absent after encoding.
+        ValueError
+            If no model is available (neither selected nor default).
         """
         if context is None:
             context = {}
-            
-        model_name = self.route(context)
-        model = ModelRegistry.get_model(model_name)
-        
-        if not model:
-            # Fallback to default if selected model is not available
-            model = ModelRegistry.get_model(self.default_model)
-            
-        if not model:
-            raise ValueError(f"No model found for routing: {model_name} or default: {self.default_model}")
 
-        # Standardize features using preprocessor
-        # If model adapter provides feature names, use them for preprocessing
-        if hasattr(model, 'feature_names'):
+        selected_name = self.route(context)
+        model = ModelRegistry.get_model(selected_name)
+        active_name = selected_name
+
+        if model is None and selected_name != self.default_model:
+            logger.warning(
+                "Model '%s' is not registered. Falling back to default model '%s'. "
+                "Note: the default model may have been trained on a different feature "
+                "schema — ensure inputs are compatible.",
+                selected_name,
+                self.default_model,
+            )
+            model = ModelRegistry.get_model(self.default_model)
+            active_name = self.default_model
+
+        if model is None:
+            raise ValueError(
+                f"No model available: '{selected_name}' was selected but is not "
+                f"registered, and the default model '{self.default_model}' is also "
+                "not registered. Check that init_ml_pipeline() completed successfully."
+            )
+
+        # Bind the preprocessor to this model's expected feature schema.
+        # Each model adapter exposes the exact column list it was trained on.
+        if hasattr(model, "feature_names") and model.feature_names:
             self.preprocessor.feature_cols = model.feature_names
-            
+        else:
+            logger.warning(
+                "Model '%s' does not expose feature_names. "
+                "Preprocessing will not validate column alignment.",
+                active_name,
+            )
+
+        # Raises UnknownCategoryError or MissingFeatureError on bad input —
+        # never silently fills missing columns with 0.
         processed_df = self.preprocessor.preprocess(input_data)
-        
-        # Log which model was used (Monitoring)
-        print(f"[ML Router] Routing to model: {model_name} ({model.model_type})")
-        
+
+        logger.info(
+            "[ML Router] Routing to model: %s (%s)", active_name, model.model_type
+        )
+
         return model.predict(processed_df)


### PR DESCRIPTION
Previously FeaturePreprocessor.preprocess() silently filled any column that was absent after one-hot encoding with 0.  This meant:

- An unknown crop/irrigation/season value produced a row where every encoded column for that feature group was 0 — structurally valid but semantically meaningless.
- The model returned a number that appeared authoritative but was computed from fabricated input, with no indication to the caller.

Changes:
- ml/preprocessing.py: introduce UnknownCategoryError and MissingFeatureError; preprocess() now raises instead of filling. Unknown-category detection distinguishes between 'base column was provided but value is unknown' vs 'column is genuinely absent'.
- ml/adapters/xgboost_adapter.py: remove duplicate silent zero-fill in predict(); add a hard assertion that columns are aligned before calling model.predict().
- ml/router.py: replace print() with logging; emit an explicit warning when falling back to the default model (different feature schema); propagate UnknownCategoryError / MissingFeatureError to the caller.
- main.py: import the new error types; catch them in predict_yield() and return HTTP 422 with a structured error body so callers receive an actionable message instead of a silent corrupt prediction.

Closes #409


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prediction endpoint now returns clearer error messages when input contains unknown categorical values or missing required features.
  * Enhanced input validation to ensure data schema matches model requirements before processing.
  * Improved error reporting with standardized response codes for validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->