### PR TITLE
fix(whatsapp): eliminate race condition and crash data loss in subscriber storage

### DIFF
--- a/main.py
+++ b/main.py
@@ -39,6 +39,7 @@ from ml.router import ModelRouter
 # Other internal modules
 from alert_rules import generate_alerts
 from whatsapp_service import send_whatsapp_message, format_alert_message
+from whatsapp_store import subscriber_store
 
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
@@ -317,55 +318,58 @@ def get_notifications(
     return {"success": True, "data": static_notifications + dynamic_alerts}
 
 # --- WhatsApp Service Endpoints ---
-
-SUBSCRIBERS_FILE = "whatsapp_subscribers.json"
-
-def load_subscribers():
-    if os.path.exists(SUBSCRIBERS_FILE):
-        try:
-            with open(SUBSCRIBERS_FILE, "r") as f:
-                return json.load(f)
-        except Exception:
-            return {}
-    return {}
-
-def save_subscribers(subscribers):
-    with open(SUBSCRIBERS_FILE, "w") as f:
-        json.dump(subscribers, f)
+#
+# Subscriber persistence is handled by whatsapp_store.SubscriberStore, which
+# provides thread-safe, crash-safe read-modify-write operations via a
+# threading.Lock and atomic file replacement (write-to-tmp then os.replace).
+# The old load_subscribers / save_subscribers helpers have been removed because
+# they had no locking and used open(..., "w") directly, which could corrupt the
+# file on a concurrent write or a mid-write crash.
 
 @app.post("/api/whatsapp/subscribe")
 @limiter.limit("2/minute")
 async def subscribe_whatsapp(data: WhatsAppSubscribeRequest, request: Request):
-    subscribers = load_subscribers()
     user_id = data.user_id if data.user_id else str(datetime.now().timestamp())
-    subscribers[user_id] = {
+    subscriber = {
         "phone_number": data.phone_number,
         "name": data.name,
-        "subscribed_at": datetime.now().isoformat()
+        "subscribed_at": datetime.now().isoformat(),
     }
-    save_subscribers(subscribers)
-    
-    welcome_msg = f"Namaste {data.name}! 🙏\n\nWelcome to *Fasal Saathi WhatsApp Alerts*. You will now receive real-time updates directly here."
+    try:
+        subscriber_store.upsert(user_id, subscriber)
+    except OSError as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to save subscription. Please try again.",
+        ) from exc
+
+    welcome_msg = (
+        f"Namaste {data.name}! 🙏\n\n"
+        "Welcome to *Fasal Saathi WhatsApp Alerts*. "
+        "You will now receive real-time updates directly here."
+    )
     send_whatsapp_message(data.phone_number, welcome_msg)
     return {"success": True, "message": "Successfully subscribed"}
 
 @app.post("/api/whatsapp/trigger-alert")
 async def trigger_whatsapp_alert(data: AlertTriggerRequest):
-    subscribers = load_subscribers()
+    # get_all() acquires the lock and returns a stable snapshot, so this read
+    # cannot race with a concurrent subscription write.
+    subscribers = subscriber_store.get_all()
     results = []
     formatted_msg = format_alert_message(data.alert_type, data.message)
-    
+
     for user_id, info in subscribers.items():
         res = send_whatsapp_message(info["phone_number"], formatted_msg)
         results.append({"user_id": user_id, "success": res.get("success", False)})
-    
+
     static_notifications.append({
         "id": len(static_notifications) + 1,
         "type": data.alert_type,
         "message": data.message,
-        "time": datetime.now().isoformat()
+        "time": datetime.now().isoformat(),
     })
-    
+
     return {"success": True, "results": results}
 
 @app.post("/api/whatsapp/webhook")

--- a/whatsapp_store.py
+++ b/whatsapp_store.py
@@ -1,0 +1,194 @@
+"""
+whatsapp_store.py — Thread-safe, crash-safe subscriber persistence.
+
+Problems solved
+---------------
+1. Race condition (read-modify-write with no locking)
+   Two concurrent subscription requests both read the same snapshot,
+   each modify their own in-memory copy, and the second write silently
+   overwrites the first — permanently losing a subscriber.
+
+2. Corrupted reads during concurrent writes
+   open(..., "w") truncates the file immediately.  A concurrent reader
+   that opens the file between the truncation and the final flush sees
+   an empty or partial file, causing json.load() to throw.  The old
+   bare `except Exception: return {}` swallowed this silently, causing
+   trigger-alert to broadcast to zero subscribers.
+
+3. No crash durability
+   A process crash mid-write left the file empty or truncated with no
+   recovery path.
+
+Solutions
+---------
+- threading.Lock serialises every read and write.  FastAPI's async
+  endpoints run on a thread pool that shares the same process, so a
+  single in-process lock is sufficient.
+- Atomic write: data is written to a sibling `.tmp` file first, then
+  os.replace() swaps it in.  os.replace() is atomic on POSIX and
+  effectively atomic on Windows (same-volume rename), so readers always
+  see either the old complete file or the new complete file — never a
+  partial write.
+- Errors are logged with full tracebacks instead of being swallowed.
+"""
+
+import json
+import logging
+import os
+import threading
+from datetime import datetime
+from typing import Dict, Any
+
+logger = logging.getLogger(__name__)
+
+# Type alias for the subscriber dict stored per user_id.
+Subscriber = Dict[str, Any]
+
+
+class SubscriberStore:
+    """
+    Thread-safe, crash-safe persistence layer for WhatsApp subscribers.
+
+    All public methods acquire ``_lock`` before touching the file, so
+    concurrent FastAPI requests cannot interleave their reads and writes.
+
+    Parameters
+    ----------
+    filepath : str
+        Path to the JSON file used for persistence.
+    """
+
+    def __init__(self, filepath: str = "whatsapp_subscribers.json") -> None:
+        self._filepath = filepath
+        self._tmp_filepath = filepath + ".tmp"
+        self._lock = threading.Lock()
+
+    # ------------------------------------------------------------------
+    # Private helpers (must be called with _lock already held)
+    # ------------------------------------------------------------------
+
+    def _read_locked(self) -> Dict[str, Subscriber]:
+        """Read and parse the subscribers file.  Returns {} on any error."""
+        if not os.path.exists(self._filepath):
+            return {}
+        try:
+            with open(self._filepath, "r", encoding="utf-8") as fh:
+                return json.load(fh)
+        except json.JSONDecodeError as exc:
+            logger.error(
+                "Subscriber file '%s' contains invalid JSON and could not be "
+                "parsed: %s.  Returning empty subscriber list.",
+                self._filepath,
+                exc,
+            )
+            return {}
+        except OSError as exc:
+            logger.error(
+                "Could not read subscriber file '%s': %s.  "
+                "Returning empty subscriber list.",
+                self._filepath,
+                exc,
+            )
+            return {}
+
+    def _write_locked(self, subscribers: Dict[str, Subscriber]) -> None:
+        """
+        Atomically write *subscribers* to disk.
+
+        Writes to a sibling ``.tmp`` file first, then uses ``os.replace``
+        to swap it in.  This guarantees that readers always see a complete,
+        valid JSON file — never a partial write.
+
+        Raises
+        ------
+        OSError
+            If the write or rename fails.  The caller is responsible for
+            surfacing this as an HTTP 500.
+        """
+        try:
+            with open(self._tmp_filepath, "w", encoding="utf-8") as fh:
+                json.dump(subscribers, fh, indent=2, ensure_ascii=False)
+                fh.flush()
+                os.fsync(fh.fileno())  # flush OS buffers before rename
+            os.replace(self._tmp_filepath, self._filepath)
+        except OSError as exc:
+            logger.error(
+                "Failed to write subscriber file '%s': %s",
+                self._filepath,
+                exc,
+            )
+            # Clean up the temp file if it was created.
+            try:
+                if os.path.exists(self._tmp_filepath):
+                    os.remove(self._tmp_filepath)
+            except OSError:
+                pass
+            raise
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def get_all(self) -> Dict[str, Subscriber]:
+        """
+        Return a snapshot of all subscribers.
+
+        The returned dict is a copy — callers cannot accidentally mutate
+        the in-memory state.
+        """
+        with self._lock:
+            return dict(self._read_locked())
+
+    def upsert(self, user_id: str, subscriber: Subscriber) -> None:
+        """
+        Add or update a single subscriber atomically.
+
+        Parameters
+        ----------
+        user_id : str
+            Unique identifier for the subscriber.
+        subscriber : dict
+            Subscriber data (phone_number, name, subscribed_at, …).
+
+        Raises
+        ------
+        OSError
+            If the file cannot be written.
+        """
+        with self._lock:
+            subscribers = self._read_locked()
+            subscribers[user_id] = subscriber
+            self._write_locked(subscribers)
+            logger.info("Subscriber '%s' upserted successfully.", user_id)
+
+    def remove(self, user_id: str) -> bool:
+        """
+        Remove a subscriber by user_id.
+
+        Returns
+        -------
+        bool
+            True if the subscriber existed and was removed, False otherwise.
+
+        Raises
+        ------
+        OSError
+            If the file cannot be written.
+        """
+        with self._lock:
+            subscribers = self._read_locked()
+            if user_id not in subscribers:
+                return False
+            del subscribers[user_id]
+            self._write_locked(subscribers)
+            logger.info("Subscriber '%s' removed.", user_id)
+            return True
+
+    def count(self) -> int:
+        """Return the number of registered subscribers."""
+        with self._lock:
+            return len(self._read_locked())
+
+
+# Module-level singleton — created once at import time.
+subscriber_store = SubscriberStore()


### PR DESCRIPTION
Three bugs in the old load_subscribers / save_subscribers helpers:

1. Race condition (no locking) Two concurrent POST /api/whatsapp/subscribe requests both read the same file snapshot, each modify their own in-memory copy, and the second write silently overwrites the first — permanently losing a subscriber with no error or log.

2. Corrupted reads during concurrent writes open(..., 'w') truncates the file immediately before writing.  A concurrent reader that opens the file between truncation and flush sees empty or partial JSON, causing json.load() to throw.  The bare 'except Exception: return {}' swallowed this silently, so trigger-alert would broadcast to zero subscribers.

3. No crash durability A process crash mid-write left the file empty or truncated with no recovery path.

Fix — new whatsapp_store.py module:
- SubscriberStore wraps all file I/O behind a threading.Lock, so concurrent reads and writes are fully serialised within the process.
- Atomic write: data is written to a sibling .tmp file, fsynced, then swapped in with os.replace().  Readers always see a complete valid JSON file — never a partial write.
- Errors are logged with full context instead of being swallowed.
- Public API: upsert(), get_all(), remove(), count().  upsert() raises OSError on write failure so the endpoint can return HTTP 500 instead of silently confirming a subscription that was never saved.

main.py changes:
- Import subscriber_store singleton from whatsapp_store.
- subscribe_whatsapp: replace load/modify/save with subscriber_store.upsert(); catch OSError and return HTTP 500 with a user-facing message.
- trigger_whatsapp_alert: replace load_subscribers() with subscriber_store.get_all() which returns a stable snapshot under lock.
- Removed SUBSCRIBERS_FILE constant and both helper functions.

Closes #408


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * WhatsApp subscription system enhanced with centralized persistence layer featuring thread-safe access and atomic file operations, ensuring data stability during concurrent requests

* **Bug Fixes**
  * Resolved potential race conditions and data corruption during simultaneous subscriber modifications; improved error resilience with detailed logging for troubleshooting

<!-- end of auto-generated comment: release notes by coderabbit.ai -->