### PR TITLE
fix(whatsapp): require auth token and derive uid from token in subscriber endpoint

### DIFF
--- a/frontend/Dashboard.jsx
+++ b/frontend/Dashboard.jsx
@@ -29,6 +29,7 @@ import {
 } from "recharts";
 import { getHistoricalWeatherData } from "./weather/weatherService";
 import ErrorBoundary from "./ErrorBoundary";
+import apiClient from "./lib/apiClient";
 
 export default function Dashboard() {
   const name = localStorage.getItem("farmerName") || "Farmer";
@@ -70,18 +71,16 @@ export default function Dashboard() {
     setIsUpdating(true);
     setUpdateMsg("");
     try {
-      const response = await fetch("/api/whatsapp/subscribe", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          user_id: localStorage.getItem("userId") || "user_" + name,
-          phone_number: phoneNumber,
-          name: name,
-          enabled: whatsappAlerts
-        }),
+      // Use apiClient instead of raw fetch() so the Firebase auth token is
+      // automatically injected via the Axios request interceptor in
+      // services/api.js.  The backend now derives user identity from the
+      // verified token — we no longer send user_id from localStorage, which
+      // could be spoofed to overwrite another user's subscription.
+      const response = await apiClient.post("/api/whatsapp/subscribe", {
+        phone_number: phoneNumber,
+        name: name,
       });
-      const data = await response.json();
-      if (data.success) {
+      if (response.data?.success) {
         localStorage.setItem("farmerPhone", phoneNumber);
         localStorage.setItem("whatsappAlerts", whatsappAlerts.toString());
         setUpdateMsg("Settings saved successfully!");

--- a/main.py
+++ b/main.py
@@ -257,8 +257,11 @@ class PredictResponse(BaseModel):
 
 class WhatsAppSubscribeRequest(BaseModel):
     phone_number: str
-    user_id: str
     name: str
+    # user_id is accepted for backward compatibility but is IGNORED by the
+    # endpoint — the authoritative user identity is always derived from the
+    # verified Firebase ID token, never from client-supplied data.
+    user_id: Optional[str] = None
 
 class YieldInput(BaseModel):
     data: list[float]
@@ -552,14 +555,21 @@ def get_notifications(
 @app.post("/api/whatsapp/subscribe")
 @limiter.limit("2/minute")
 async def subscribe_whatsapp(data: WhatsAppSubscribeRequest, request: Request):
-    user_id = data.user_id if data.user_id else str(datetime.now().timestamp())
+    # Require authentication so the subscriber's identity is always derived
+    # from the verified Firebase token — never from client-supplied data.
+    # Previously the endpoint accepted user_id from the request body, which
+    # allowed any caller to overwrite another user's subscription by sending
+    # a known user_id with an attacker-controlled phone number.
+    token_data = await verify_role(request)
+    uid = token_data["uid"]
+
     subscriber = {
         "phone_number": data.phone_number,
         "name": data.name,
         "subscribed_at": datetime.now().isoformat(),
     }
     try:
-        subscriber_store.upsert(user_id, subscriber)
+        subscriber_store.upsert(uid, subscriber)
     except OSError as exc:
         raise HTTPException(
             status_code=500,


### PR DESCRIPTION
Two bugs in the WhatsApp subscription flow:

1. No authentication on the backend endpoint POST /api/whatsapp/subscribe accepted any request with no token. The user_id key in the subscriber store was taken directly from the request body, so any caller who knew another user's user_id could overwrite their phone number subscription — silently redirecting that farmer's weather and pest alerts to an attacker-controlled number.

2. Frontend sent localStorage user_id with no auth header Dashboard.jsx used raw fetch() with no Authorization header, and constructed user_id from localStorage.getItem('userId') with a fallback of 'user_' + farmerName — both values readable and writable by any JavaScript on the page.

Fixes:

main.py:
  - subscribe_whatsapp now calls verify_role(request) at the start, requiring a valid Firebase ID token.
  - uid is derived from the verified token (token_data['uid']), never from the request body.
  - WhatsAppSubscribeRequest.user_id changed to Optional[str] = None (accepted for backward compatibility but ignored by the endpoint).
  - subscriber_store.upsert(uid, ...) uses the token-verified uid as the store key, so a subscriber entry is always owned by the authenticated user and cannot be overwritten by another caller.

frontend/Dashboard.jsx:
  - Replaced raw fetch('/api/whatsapp/subscribe', ...) with apiClient.post('/api/whatsapp/subscribe', ...) which automatically injects the Firebase auth token via the Axios request interceptor in services/api.js.
  - Removed user_id from the request payload entirely — the backend now derives identity from the verified token.
  - Imported apiClient from ./lib/apiClient.

Closes #547

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security for WhatsApp alert subscriptions with server-side authentication verification.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/551)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->