### PR TITLE
fix(whatsapp): add auth, rate limit, and input validation to trigger-alert endpoint

### DIFF
--- a/main.py
+++ b/main.py
@@ -267,8 +267,8 @@ class YieldInput(BaseModel):
     data: list[float]
 
 class AlertTriggerRequest(BaseModel):
-    alert_type: str  # 'weather', 'pest', 'advisory'
-    message: str
+    alert_type: str = Field(..., pattern=r'^(weather|pest|advisory)$')
+    message: str = Field(..., min_length=1, max_length=500)
 
 class ReportRequest(BaseModel):
     name: str = Field(..., max_length=100)
@@ -597,7 +597,22 @@ async def subscribe_whatsapp(data: WhatsAppSubscribeRequest, request: Request):
     return {"success": True, "message": "Successfully subscribed"}
 
 @app.post("/api/whatsapp/trigger-alert")
-async def trigger_whatsapp_alert(data: AlertTriggerRequest):
+@limiter.limit("10/minute")
+async def trigger_whatsapp_alert(data: AlertTriggerRequest, request: Request):
+    """
+    Broadcast a WhatsApp alert to all subscribers.
+
+    Requires authentication — admin or expert role only.
+
+    Previously this endpoint had no authentication check, no rate limit,
+    and no input constraints.  Any unauthenticated caller could send
+    arbitrary messages to every subscribed farmer, enabling social
+    engineering attacks (fake market alerts, fake pest warnings) and
+    consuming Twilio API credits at the attacker's discretion.
+    """
+    # RBAC: only admins and experts may broadcast alerts to all farmers.
+    await verify_role(request, required_roles=["admin", "expert"])
+
     # get_all() acquires the lock and returns a stable snapshot, so this read
     # cannot race with a concurrent subscription write.
     subscribers = subscriber_store.get_all()
@@ -608,12 +623,12 @@ async def trigger_whatsapp_alert(data: AlertTriggerRequest):
         res = send_whatsapp_message(info["phone_number"], formatted_msg)
         results.append({"user_id": user_id, "success": res.get("success", False)})
 
-    static_notifications.append({
-        "id": len(static_notifications) + 1,
-        "type": data.alert_type,
-        "message": data.message,
-        "time": datetime.now().isoformat(),
-    })
+    # Use the bounded, thread-safe NotificationStore instead of the bare
+    # static_notifications list (which had no size cap and racy ID generation).
+    _notification_store.append(
+        alert_type=data.alert_type,
+        message=data.message,
+    )
 
     return {"success": True, "results": results}
 


### PR DESCRIPTION
POST /api/whatsapp/trigger-alert had three compounding problems:

1. No authentication Any unauthenticated HTTP client could POST to the endpoint and immediately broadcast an arbitrary WhatsApp message to every subscribed farmer.  An attacker could send fake market alerts ('Sell all your crops now!'), fake pest warnings, or malicious links — all attributed to Fasal Saathi with no way for farmers to distinguish them from legitimate alerts.

2. No rate limiting Unlike every other sensitive endpoint in main.py, this one had no @limiter.limit() decorator.  An attacker could trigger thousands of broadcasts per second, exhausting Twilio API credits and spamming farmers' phones.

3. No input constraints on AlertTriggerRequest alert_type and message were bare str fields with no length limits or allowed-value restrictions.  An attacker could send a 10MB message body or an arbitrary alert_type string.

Fixes:

AlertTriggerRequest model:
  - alert_type: restricted to '^(weather|pest|advisory)$' via Field pattern — rejects any value outside the three known types.
  - message: Field(min_length=1, max_length=500) — prevents empty messages and caps payload size.

trigger_whatsapp_alert endpoint:
  - @limiter.limit('10/minute') — consistent with other endpoints.
  - request: Request parameter added (required by verify_role and the rate limiter key function).
  - await verify_role(request, required_roles=['admin', 'expert']) at the top of the handler — unauthenticated callers receive 401, non-admin/expert roles receive 403.

Also replaced the bare static_notifications.append() call with _notification_store.append() — the old list had no size cap and used a racy len()+1 ID generation pattern that was fixed in an earlier commit but not applied to this endpoint.

Closes #556

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes & Security**
  * Added role-based access control—only admin and expert users can trigger alerts.
  * Implemented rate limiting (10 requests per minute) on the alert endpoint.
  * Enhanced input validation: alert types now restricted to weather, pest, or advisory; message length constrained to 1–500 characters.
  * Improved notification storage reliability.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/561)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->