### PR TITLE
fix(soil-analysis): replace always-true object literal condition to prevent crash on lead

### DIFF
--- a/frontend/SoilAnalysis.jsx
+++ b/frontend/SoilAnalysis.jsx
@@ -282,23 +282,24 @@ const [tipIndex, setTipIndex] = useState(0);
   };
 
   useEffect(() => {
-  if ({animatedScore}) {
-    let start = 0;
+    if (results) {
+      let start = 0;
+      setAnimatedScore(0);
 
-    const interval = setInterval(() => {
-      start += 1;
+      const interval = setInterval(() => {
+        start += 1;
 
-      if (start >= results.quality.score) {
-        start = results.quality.score;
-        clearInterval(interval);
-      }
+        if (start >= results.quality.score) {
+          start = results.quality.score;
+          clearInterval(interval);
+        }
 
-      setAnimatedScore(start);
-    }, 15);
+        setAnimatedScore(start);
+      }, 15);
 
-    return () => clearInterval(interval);
-  }
-}, [results]);
+      return () => clearInterval(interval);
+    }
+  }, [results]);
 
 useEffect(() => {
   const interval = setInterval(() => {


### PR DESCRIPTION

useEffect had if ({animatedScore}) — a JS object literal, always truthy. This caused setInterval to run immediately on first render when results is null, throwing TypeError: Cannot read properties of null (reading 'quality') and crashing the Soil Analysis page for every user on load.

Fix: replace with if (results) so the interval only starts after the user submits soil data. Also reset animatedScore to 0 at the start of each animation so re-runs after handleReset animate correctly.

Closes #557