### PR TITLE
fix(qr-traceability): replace 1000-value random ID with collision-resistant taimestamp +hex ID

### DIFF
--- a/frontend/QRTraceability.jsx
+++ b/frontend/QRTraceability.jsx
@@ -62,8 +62,30 @@ export default function QRTraceability() {
   const generateNewBatch = (e) => {
     e.preventDefault();
     const formData = new FormData(e.target);
+
+    // Generate a collision-resistant batch ID using the current year,
+    // a millisecond timestamp, and 4 random hex chars.
+    // Format: BATCH-YYYY-<13-digit ms timestamp>-<4 hex chars>
+    // Collision probability is astronomically low — the timestamp alone
+    // makes two IDs generated in the same millisecond extremely unlikely,
+    // and the random suffix eliminates the remaining risk.
+    // The year is derived from the current date so IDs remain accurate
+    // across years instead of being hardcoded to 2026.
+    const year = new Date().getFullYear();
+    const ts = Date.now();
+    const rand = Math.floor(Math.random() * 0xffff).toString(16).toUpperCase().padStart(4, '0');
+    const newId = `BATCH-${year}-${ts}-${rand}`;
+
+    // Guard: reject the (now astronomically unlikely) case where the ID
+    // already exists, so the user gets an actionable error instead of
+    // silent data loss.
+    if (batches.some(b => b.id === newId)) {
+      alert("ID generation collision — please try again.");
+      return;
+    }
+
     const newBatch = {
-      id: `BATCH-2026-${Math.floor(Math.random() * 1000).toString().padStart(3, '0')}`,
+      id: newId,
       crop: formData.get('crop'),
       variety: formData.get('variety'),
       harvestDate: formData.get('harvestDate'),


### PR DESCRIPTION
Batch IDs were generated as BATCH-2026-NNN where NNN was a random number 0-999 — only 1,000 possible values.  With no uniqueness check, a farmer registering 40 batches had a ~55% collision probability (birthday paradox).  On collision, setBatches prepended a duplicate ID, causing React to silently drop one entry from the rendered list and making that batch permanently inaccessible via its QR code URL.

The year was also hardcoded to 2026, making IDs misleading in future years and further constraining the namespace.

Fix:
- ID format: BATCH-{year}-{Date.now()}-{4 random hex chars} e.g. BATCH-2026-1747123456789-A3F2
- Year derived from new Date().getFullYear() — stays accurate across years
- Timestamp (13 digits, ms precision) makes same-millisecond collisions extremely unlikely; the 4-hex suffix (65536 values) eliminates the rest
- Uniqueness guard: batches.some(b => b.id === newId) rejects the astronomically unlikely collision with an actionable alert instead of silent data loss

Closes #558

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced batch ID generation to prevent duplicate IDs and improve uniqueness.
  * Added user notification when a duplicate batch ID is detected, prompting retry instead of silently proceeding.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/563)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->