### PR TITLE
fix(community): fix comment submission crash caused by undefined batch variable

### DIFF
--- a/frontend/Community.jsx
+++ b/frontend/Community.jsx
@@ -350,7 +350,13 @@ const Community = () => {
 
     const postId = showCommentsModal.id;
     try {
-      await addDoc(collection(db, "comments"), {
+      // Use a write batch so the comment document, the commenter's reputation
+      // increment, and the post's commentsCount increment are all committed
+      // atomically.
+      const batch = writeBatch(db);
+
+      const commentRef = doc(collection(db, "comments"));
+      batch.set(commentRef, {
         postId,
         userId: currentUser.uid,
         userName: currentUser.displayName || currentUser.email.split('@')[0],
@@ -372,7 +378,6 @@ const Community = () => {
 
       // Record the comment time for the local cooldown check.
       setLastCommentTime(Date.now());
-
 
       setNewComment("");
       openComments(showCommentsModal);


### PR DESCRIPTION
handleAddComment used addDoc() to create the comment document, then immediately called batch.update() and batch.commit() — but batch was never declared in the function. This caused a ReferenceError at runtime which was caught and displayed to users as 'Failed to post comment. Please try again.' making the entire comment/reply feature non-functional.

Root cause: a merge conflict between the writeBatch approach (from fix/community-reputation-race-condition) and the upstream version left the function in a broken hybrid state — addDoc for the comment creation but batch.update/commit for the reputation and count updates, with no writeBatch(db) call to initialise batch.

Fix: replace addDoc with writeBatch(db) so all three writes (comment document, reputation increment, commentsCount increment) are created and committed atomically in a single batch — consistent with the original intent of the atomic-writes fix and eliminating the ReferenceError.

Closes: #550

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced comment submission reliability through improved data persistence, ensuring consistent updates to comments, user reputation, and post metadata.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/568)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->