### PR TITLE
feat: Implement Bookmarking for Crops and Articles

### DIFF
--- a/frontend/Blog.css
+++ b/frontend/Blog.css
@@ -585,6 +585,42 @@
   to { opacity: 1; transform: translateY(0); }
 }
 
+.bookmark-btn {
+  border: 1px solid rgba(22, 125, 34, 0.16);
+  background: #f8faf5;
+  color: #166534;
+  padding: 8px 14px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.bookmark-btn:hover {
+  background: #ecfdf5;
+  border-color: #bbf7d0;
+}
+
+.bookmark-btn.active {
+  background: #16a34a;
+  color: #ffffff;
+  border-color: #16a34a;
+}
+
+.blog-card-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  align-items: center;
+}
+
+.detail-bookmark-btn {
+  margin: 12px 0 20px;
+}
+
 @media (max-width: 768px) {
   .blog-hero {
     padding: 60px 5% 50px;

--- a/frontend/Blog.jsx
+++ b/frontend/Blog.jsx
@@ -1,7 +1,8 @@
-import React, { useState } from "react";
+import React, { useState, useEffect } from "react";
 import { Link } from "react-router-dom";
-import { FaSearch, FaArrowRight, FaClock, FaUser, FaLeaf, FaCloudSun, FaLandmark, FaBug, FaTint, FaSeedling } from "react-icons/fa";
+import { FaSearch, FaArrowRight, FaClock, FaUser, FaLeaf, FaCloudSun, FaLandmark, FaBug, FaTint, FaSeedling, FaBookmark, FaRegBookmark } from "react-icons/fa";
 import "./Blog.css";
+import { getBookmarks, toggleBookmark } from "./utils/bookmarkStorage";
 
 const BLOG_POSTS = [
   {
@@ -99,6 +100,18 @@ const CATEGORY_ICONS = {
 export default function Blog() {
   const [activeCategory, setActiveCategory] = useState("All");
   const [searchTerm, setSearchTerm] = useState("");
+  const [bookmarkedArticleIds, setBookmarkedArticleIds] = useState(() =>
+    getBookmarks("articles").map((article) => article.id)
+  );
+
+  useEffect(() => {
+    setBookmarkedArticleIds(getBookmarks("articles").map((article) => article.id));
+  }, []);
+
+  const handleToggleArticleBookmark = (post) => {
+    const updated = toggleBookmark("articles", post);
+    setBookmarkedArticleIds(updated.map((item) => item.id));
+  };
 
   React.useEffect(() => {
     window.scrollTo(0, 0);
@@ -187,13 +200,22 @@ export default function Blog() {
                 </div>
                 <div className="blog-card-footer">
                   <span className="blog-card-date">{post.date}</span>
-                  <Link
-                    to={`/blog/${post.id}`}
-                    id={`blog-read-more-${post.id}`}
-                    className="btn-read-more"
-                  >
-                    Read More <FaArrowRight />
-                  </Link>
+                  <div className="blog-card-actions">
+                    <button
+                      className={`bookmark-btn ${bookmarkedArticleIds.includes(post.id) ? "active" : ""}`}
+                      onClick={() => handleToggleArticleBookmark(post)}
+                      aria-label={bookmarkedArticleIds.includes(post.id) ? "Remove bookmark" : "Bookmark article"}
+                    >
+                      {bookmarkedArticleIds.includes(post.id) ? <FaBookmark /> : <FaRegBookmark />} {bookmarkedArticleIds.includes(post.id) ? "Saved" : "Save"}
+                    </button>
+                    <Link
+                      to={`/blog/${post.id}`}
+                      id={`blog-read-more-${post.id}`}
+                      className="btn-read-more"
+                    >
+                      Read More <FaArrowRight />
+                    </Link>
+                  </div>
                 </div>
               </div>
             </article>

--- a/frontend/BlogDetail.jsx
+++ b/frontend/BlogDetail.jsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import { useParams, Link } from "react-router-dom";
-import { FaArrowLeft, FaClock, FaUser, FaCalendarAlt, FaLeaf, FaCloudSun, FaLandmark, FaBug, FaTint, FaSeedling } from "react-icons/fa";
+import { FaArrowLeft, FaClock, FaUser, FaCalendarAlt, FaLeaf, FaCloudSun, FaLandmark, FaBug, FaTint, FaSeedling, FaBookmark, FaRegBookmark } from "react-icons/fa";
 import "./Blog.css";
+import { getBookmarks, toggleBookmark } from "./utils/bookmarkStorage";
 
 const BLOG_POSTS = [
   {
@@ -269,6 +270,17 @@ const CATEGORY_ICONS = {
 export default function BlogDetail() {
   const { id } = useParams();
   const post = BLOG_POSTS.find((p) => p.id === parseInt(id, 10));
+  const [isBookmarked, setIsBookmarked] = useState(false);
+
+  useEffect(() => {
+    setIsBookmarked(getBookmarks("articles").some((item) => item.id === parseInt(id, 10)));
+  }, [id]);
+
+  const handleToggleArticleBookmark = () => {
+    if (!post) return;
+    const updated = toggleBookmark("articles", post);
+    setIsBookmarked(updated.some((item) => item.id === post.id));
+  };
 
   React.useEffect(() => {
     window.scrollTo(0, 0);
@@ -309,6 +321,13 @@ export default function BlogDetail() {
               {post.category}
             </div>
             <h1>{post.title}</h1>
+            <button
+              className={`detail-bookmark-btn ${isBookmarked ? "active" : ""}`}
+              onClick={handleToggleArticleBookmark}
+              aria-label={isBookmarked ? "Remove bookmark" : "Bookmark article"}
+            >
+              {isBookmarked ? <FaBookmark /> : <FaRegBookmark />} {isBookmarked ? "Saved" : "Bookmark"}
+            </button>
             <div className="blog-detail-meta">
               <span className="meta-item">
                 <FaUser /> {post.author}

--- a/frontend/CropGuide.css
+++ b/frontend/CropGuide.css
@@ -513,6 +513,47 @@
   cursor: pointer;
 }
 
+.crop-card-actions {
+  display: flex;
+  gap: 10px;
+  justify-content: center;
+  flex-wrap: wrap;
+  margin-top: 18px;
+}
+
+.bookmark-btn {
+  border: 1px solid #d1fae5;
+  background: #ecfdf5;
+  color: #166534;
+  padding: 8px 12px;
+  border-radius: 12px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.bookmark-btn:hover {
+  background: #dcfce7;
+}
+
+.bookmark-btn.active {
+  background: #16a34a;
+  color: #ffffff;
+  border-color: #16a34a;
+}
+
+.modal-header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  margin-bottom: 20px;
+}
+
+.modal-header-row h2 {
+  margin: 0;
+}
+
 /* 🚫 EMPTY STATE */
 .no-results {
   text-align: center;

--- a/frontend/CropGuide.jsx
+++ b/frontend/CropGuide.jsx
@@ -1,6 +1,7 @@
 "use client";
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect } from "react";
 import "./CropGuide.css";
+import { getBookmarks, toggleBookmark } from "./utils/bookmarkStorage";
 
 // 📦 DATA
 const CROPS = [
@@ -72,6 +73,18 @@ export default function CropGuide() {
   const [selectedSeason, setSelectedSeason] = useState("All");
   const [searchQuery, setSearchQuery] = useState("");
   const [activeCrop, setActiveCrop] = useState(null);
+  const [bookmarkedCropIds, setBookmarkedCropIds] = useState(() =>
+    getBookmarks("crops").map((crop) => crop.id)
+  );
+
+  useEffect(() => {
+    setBookmarkedCropIds(getBookmarks("crops").map((crop) => crop.id));
+  }, []);
+
+  const handleToggleCropBookmark = (crop) => {
+    const updated = toggleBookmark("crops", crop);
+    setBookmarkedCropIds(updated.map((item) => item.id));
+  };
 
   // 🔍 FILTER + SEARCH (memoized for performance)
   const filteredCrops = useMemo(() => {
@@ -134,9 +147,20 @@ export default function CropGuide() {
                 <p><strong>Water:</strong> {crop.water}</p>
               </div>
 
-              <button onClick={() => setActiveCrop(crop)}>
-                View Details
-              </button>
+              <div className="crop-card-actions">
+                <button onClick={() => setActiveCrop(crop)}>
+                  View Details
+                </button>
+                <button
+                  className={`bookmark-btn ${bookmarkedCropIds.includes(crop.id) ? "active" : ""}`}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    handleToggleCropBookmark(crop);
+                  }}
+                >
+                  {bookmarkedCropIds.includes(crop.id) ? "Saved" : "Bookmark"}
+                </button>
+              </div>
             </div>
           ))
         ) : (
@@ -158,7 +182,15 @@ export default function CropGuide() {
               ✖
             </button>
 
-            <h2>🌾 {activeCrop.name}</h2>
+            <div className="modal-header-row">
+              <h2>🌾 {activeCrop.name}</h2>
+              <button
+                className={`bookmark-btn modal-bookmark ${bookmarkedCropIds.includes(activeCrop.id) ? "active" : ""}`}
+                onClick={() => handleToggleCropBookmark(activeCrop)}
+              >
+                {bookmarkedCropIds.includes(activeCrop.id) ? "Saved" : "Bookmark"}
+              </button>
+            </div>
 
             <div className="modal-info">
               <p><strong>Season:</strong> {activeCrop.season}</p>

--- a/frontend/Dashboard.css
+++ b/frontend/Dashboard.css
@@ -755,12 +755,41 @@
   text-decoration: none;
 }
 
-.sunlight .dashboard-hero {
-  background: #000 !important;
-}
+  .saved-items-grid {
+    display: grid;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 18px;
+  }
 
-.sunlight .stat-card,
-.sunlight .dashboard-section-card {
+  .saved-items-block h3 {
+    margin-bottom: 12px;
+    font-size: 1rem;
+    color: #166534;
+  }
+
+  .saved-items-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: grid;
+    gap: 10px;
+  }
+
+  .saved-items-list li {
+    padding: 12px 14px;
+    background: #f8faf8;
+    border-radius: 12px;
+    color: #14532d;
+    font-size: 0.95rem;
+    border: 1px solid #d1fae5;
+  }
+
+  .saved-empty {
+    color: #6b7280;
+    font-size: 0.9rem;
+    line-height: 1.6;
+  }
+
   border: 3px solid #000 !important;
   box-shadow: none !important;
 }

--- a/frontend/Dashboard.jsx
+++ b/frontend/Dashboard.jsx
@@ -30,6 +30,7 @@ import {
 import { getHistoricalWeatherData } from "./weather/weatherService";
 import ErrorBoundary from "./ErrorBoundary";
 import apiClient from "./lib/apiClient";
+import { getBookmarks } from "./utils/bookmarkStorage";
 
 export default function Dashboard() {
   const name = localStorage.getItem("farmerName") || "Farmer";
@@ -45,6 +46,13 @@ export default function Dashboard() {
   const [selectedCrop, setSelectedCrop] = useState("");
   const [selectedRegion, setSelectedRegion] = useState("");
   const [selectedSeason, setSelectedSeason] = useState("");
+  const [savedCrops, setSavedCrops] = useState([]);
+  const [savedArticles, setSavedArticles] = useState([]);
+
+  useEffect(() => {
+    setSavedCrops(getBookmarks("crops"));
+    setSavedArticles(getBookmarks("articles"));
+  }, []);
 
   useEffect(() => {
     const timer = setInterval(() => setCurrentTime(new Date()), 60000);
@@ -305,6 +313,39 @@ export default function Dashboard() {
                    <FaArrowRight className="rec-arrow" aria-hidden="true" />
                  </div>
               ))}
+            </div>
+          </div>
+
+          <div className="dashboard-section-card saved-items-card">
+            <div className="section-card-header">
+              <h2>Saved Items</h2>
+              <span className="section-badge">{savedCrops.length + savedArticles.length} saved</span>
+            </div>
+            <div className="saved-items-grid">
+              <div className="saved-items-block">
+                <h3>Bookmarked Crops</h3>
+                {savedCrops.length > 0 ? (
+                  <ul className="saved-items-list">
+                    {savedCrops.slice(0, 4).map((crop) => (
+                      <li key={crop.id}>{crop.name}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="saved-empty">Save crops from the Crop Guide to see them here.</p>
+                )}
+              </div>
+              <div className="saved-items-block">
+                <h3>Bookmarked Articles</h3>
+                {savedArticles.length > 0 ? (
+                  <ul className="saved-items-list">
+                    {savedArticles.slice(0, 4).map((article) => (
+                      <li key={article.id}>{article.title}</li>
+                    ))}
+                  </ul>
+                ) : (
+                  <p className="saved-empty">Save articles from the Knowledge Hub to see them here.</p>
+                )}
+              </div>
             </div>
           </div>
 

--- a/frontend/utils/bookmarkStorage.js
+++ b/frontend/utils/bookmarkStorage.js
@@ -1,0 +1,47 @@
+/**
+ * Bookmark storage helper.
+ * Uses localStorage to persist bookmarked crops and articles.
+ */
+const STORAGE_KEYS = {
+  crops: "agri:bookmarkedCrops",
+  articles: "agri:bookmarkedArticles",
+};
+
+const safeParse = (value) => {
+  try {
+    return JSON.parse(value);
+  } catch (err) {
+    return null;
+  }
+};
+
+export const getBookmarks = (type) => {
+  const key = STORAGE_KEYS[type];
+  if (!key) return [];
+  const stored = typeof window !== "undefined" ? localStorage.getItem(key) : null;
+  return safeParse(stored) || [];
+};
+
+export const setBookmarks = (type, items) => {
+  const key = STORAGE_KEYS[type];
+  if (!key) return;
+  localStorage.setItem(key, JSON.stringify(items || []));
+};
+
+export const isBookmarked = (type, id) => {
+  const items = getBookmarks(type);
+  return items.some((item) => item.id === id);
+};
+
+export const toggleBookmark = (type, item) => {
+  const items = getBookmarks(type);
+  const exists = items.some((entry) => entry.id === item.id);
+  const updated = exists ? items.filter((entry) => entry.id !== item.id) : [...items, item];
+  setBookmarks(type, updated);
+  return updated;
+};
+
+export const getAllBookmarks = () => ({
+  crops: getBookmarks("crops"),
+  articles: getBookmarks("articles"),
+});


### PR DESCRIPTION

Closes #61

###  Overview
Added a complete bookmarking system that allows users to save crops 
and articles, with saved items displayed on the Dashboard.

###  Changes Made

#### `frontend/utils/bookmarkStorage.js` (New File)
- Centralized localStorage bookmark utility
- Functions: `getBookmarks`, `toggleBookmark`, `setBookmarks`, `isBookmarked`
- Supports separate namespaces for `crops` and `articles`

#### `frontend/CropGuide.jsx`
- Bookmark button added on each crop card
- Bookmark toggle button inside crop detail modal
- State synced with localStorage on every toggle

#### `frontend/Blog.jsx`
- Bookmark/Save button added on each article card
- Real-time state update on toggle
- Persisted to localStorage

#### `frontend/BlogDetail.jsx`
- Bookmark button on individual article detail page
- Uses shared `bookmarkStorage` utility
- Syncs correctly with bookmarks made from Blog list page

#### `frontend/Dashboard.jsx`
- New **"Saved Items"** section added to dashboard
- Shows bookmarked crops (up to 4) and bookmarked articles (up to 4)
- Displays count badge: "X saved"
- Empty states when nothing is bookmarked yet

#### CSS Updates
- `Blog.css` — `.bookmark-btn`, `.blog-card-actions`, `.detail-bookmark-btn`
- `CropGuide.css` — `.crop-card-actions`, `.bookmark-btn`, `.modal-header-row`
- `Dashboard.css` — `.saved-items-grid`, `.saved-items-block`, `.saved-items-list`, `.saved-empty`

###  Storage
- All bookmarks stored in browser `localStorage`
- No backend changes required
- Data persists across page refreshes and navigation

###  Acceptance Criteria
- [x] Users can bookmark crops from Crop Guide cards
- [x] Users can bookmark crops from the crop detail modal
- [x] Users can bookmark articles from Blog list page
- [x] Users can bookmark articles from article detail page
- [x] Saved items appear in Dashboard under "Saved Items"
- [x] Bookmark button toggles between saved/unsaved state
- [x] Data persists in localStorage across sessions

###  How to Test
1. Go to `/crop-guide` → click **Bookmark** on any crop card
2. Open a crop modal → click **Bookmark** inside modal
3. Go to `/blog` → click **Save** on any article card
4. Open any article → click **Bookmark** on detail page
5. Go to `/dashboard` → check **Saved Items** section shows saved crops & articles

@Eshajha19 please review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Users can bookmark and save articles and crops throughout the app
  * Saved items display on a dedicated dashboard section
  * Bookmark buttons include visual indicators (saved/unsaved states) with hover effects
  * Bookmarks persist locally across sessions

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/616)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->