### PR TITLE
fix: replace Chat button in navbar with About page link

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -311,7 +311,7 @@ function App() {
 
         <ul className={`nav-center ${isOpen ? "active" : ""}`}>
           <li><Link to="/" onClick={() => setIsOpen(false)}><FaHome /> Home</Link></li>
-          <li><Link to="/advisor" onClick={() => setIsOpen(false)}><FaComments /> Chat</Link></li>
+          <li><Link to="/about" onClick={() => setIsOpen(false)}><FaInfoCircle /> About</Link></li>
           <li><Link to="/how-it-works" onClick={() => setIsOpen(false)}><FaInfoCircle /> How It Works</Link></li>
           <li><Link to="/crop-guide" onClick={() => setIsOpen(false)}><GiThreeLeaves />Crop Guide</Link></li>
           <li><Link to="/resources" onClick={() => setIsOpen(false)}><GrResources />Resources</Link></li>


### PR DESCRIPTION
Fixes #622

## Problem
The navbar had a Chat button linking to /advisor which was redundant — a floating chat button already exists at the bottom-right of every page as the primary quick-access chat option. Having Chat in the navbar cluttered the navigation and created confusion about which entry point to use.

## Solution
- Removed the Chat nav link from the navbar center
- Added an About nav link (/about) in its place
- The floating chat button remains as the sole primary chat entry point

## Changes
- frontend/App.jsx only (1 line changed)

## Before vs After

**Before:** Home | Chat | How It Works | Crop Guide | Resources

**After:** Home | About | How It Works | Crop Guide | Resources

## Testing
1. Open the app
2. Verify Chat is no longer in the navbar
3. Verify About link appears and navigates to /about correctly
4. Verify the floating chat button at bottom-right still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Navigation**
  * Updated mobile navigation menu by replacing the "Chat" menu item with an "About" menu item for improved information access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/623)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->