### PR TITLE
fix(consultation): require authentication and ownership checks on all consultation endpoints

### DIFF
--- a/main.py
+++ b/main.py
@@ -1963,6 +1963,7 @@ async def get_expert_slots(expert_id: str, date: str):
 
 
 @app.post("/api/consultation/book")
+@limiter.limit("5/minute")
 async def book_consultation(
     request: ConsultationBookRequest,
     raw_request: Request,
@@ -1970,6 +1971,10 @@ async def book_consultation(
 ):
     """
     Book a consultation with an expert.
+
+    Authentication required — any logged-in user may book.
+    The caller's identity is derived from the verified Firebase token;
+    the client-supplied user_id is never trusted.
     """
     # Idempotency check: prevent duplicate bookings on retry
     idem_key = raw_request.headers.get("X-Idempotency-Key")
@@ -1978,7 +1983,7 @@ async def book_consultation(
             if idem_key in _IDEMPOTENCY_CACHE:
                 logger.info(f"Idempotency: Returning cached consultation for key {idem_key}")
                 return _IDEMPOTENCY_CACHE[idem_key]
-    
+
     """
     Request body:
     - expert_id: Expert's ID
@@ -1991,27 +1996,29 @@ async def book_consultation(
     """
     try:
         db = validate_firestore_ready()
-        user_data = None
 
-        if authorization:
-            try:
-                token = authorization.replace("Bearer ", "")
-                decoded_token = firebase_auth.verify_id_token(token)
-                user_id = decoded_token.get("uid")
+        # Require authentication — derive identity from the verified token,
+        # never from the request body.  Previously authorization was Optional
+        # and the entire auth block was wrapped in a try/except that silently
+        # fell through, writing bookings with user_id="anonymous".
+        token_data = await verify_role(raw_request)
+        uid = token_data["uid"]
 
-                user_ref = db.collection("users").document(user_id)
-                user_doc = user_ref.get()
-                if user_doc.exists:
-                    user_data = user_doc.to_dict()
-            except Exception as e:
-                logger.warning(f"Auth verification failed: {e}")
+        # Fetch the user's display name from Firestore for the booking record.
+        user_name = "Farmer"
+        try:
+            user_doc = db.collection("users").document(uid).get()
+            if user_doc.exists:
+                user_name = user_doc.to_dict().get("displayName", "Farmer") or "Farmer"
+        except Exception as e:
+            logger.warning("Could not fetch display name for uid=%s: %s", uid, e)
 
         consultation_data = {
             "expert_id": request.expert_id,
             "expert_name": request.expert_name,
             "expert_specialization": request.expert_specialization,
-            "user_id": user_data.get("uid") if user_data else "anonymous",
-            "user_name": user_data.get("displayName") if user_data else "Guest Farmer",
+            "user_id": uid,
+            "user_name": user_name,
             "date": request.date,
             "time": request.time,
             "notes": request.notes,
@@ -2047,25 +2054,33 @@ async def book_consultation(
 async def update_consultation(
     consultation_id: str,
     request: ConsultationUpdateRequest,
+    raw_request: Request,
     authorization: Optional[str] = None
 ):
     """
     Update consultation status.
-    
-    Path parameters:
-    - consultation_id: ID of the consultation
-    
-    Request body:
-    - status: New status (scheduled, completed, cancelled, in-progress)
-    - notes: Optional notes
+    Only the owner of the consultation may update it.
     """
     try:
         db = validate_firestore_ready()
+
+        # Require authentication and verify ownership.
+        token_data = await verify_role(raw_request)
+        uid = token_data["uid"]
+
         doc_ref = db.collection("consultations").document(consultation_id)
         doc = doc_ref.get()
 
         if not doc.exists:
             raise HTTPException(status_code=404, detail="Consultation not found")
+
+        # Prevent one user from updating another user's consultation.
+        owner_uid = doc.to_dict().get("user_id")
+        if owner_uid != uid and token_data.get("role") not in ("admin", "expert"):
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to update this consultation"
+            )
 
         update_data = {
             "status": request.status,
@@ -2093,24 +2108,27 @@ async def update_consultation(
 
 @app.get("/api/consultations")
 async def get_user_consultations(
+    raw_request: Request,
     user_id: Optional[str] = None,
     status: Optional[str] = None,
     authorization: Optional[str] = None
 ):
     """
-    Get user's consultation history.
-    
-    Query parameters:
-    - user_id: User ID (optional, will use auth if provided)
-    - status: Filter by status (scheduled, completed, cancelled)
+    Get the authenticated user's consultation history.
+    Results are always scoped to the caller's own uid — the client-supplied
+    user_id parameter is ignored to prevent IDOR enumeration.
     """
     try:
         db = validate_firestore_ready()
-        consultations_ref = db.collection("consultations")
-        query = consultations_ref
 
-        if user_id:
-            query = query.where("user_id", "==", user_id)
+        # Require authentication and scope results to the caller's own uid.
+        # Previously user_id was accepted from the query string with no auth
+        # check, allowing any caller to read any user's consultation history.
+        token_data = await verify_role(raw_request)
+        uid = token_data["uid"]
+
+        consultations_ref = db.collection("consultations")
+        query = consultations_ref.where("user_id", "==", uid)
 
         docs = query.get()
         consultations = []
@@ -2140,21 +2158,32 @@ async def get_user_consultations(
 @app.delete("/api/consultation/{consultation_id}")
 async def cancel_consultation(
     consultation_id: str,
+    raw_request: Request,
     authorization: Optional[str] = None
 ):
     """
     Cancel a consultation.
-    
-    Path parameters:
-    - consultation_id: ID of the consultation to cancel
+    Only the owner of the consultation may cancel it.
     """
     try:
         db = validate_firestore_ready()
+
+        # Require authentication and verify ownership.
+        token_data = await verify_role(raw_request)
+        uid = token_data["uid"]
+
         doc_ref = db.collection("consultations").document(consultation_id)
         doc = doc_ref.get()
 
         if not doc.exists:
             raise HTTPException(status_code=404, detail="Consultation not found")
+
+        owner_uid = doc.to_dict().get("user_id")
+        if owner_uid != uid and token_data.get("role") not in ("admin", "expert"):
+            raise HTTPException(
+                status_code=403,
+                detail="You do not have permission to cancel this consultation"
+            )
 
         doc_ref.update({
             "status": "cancelled",


### PR DESCRIPTION
Four consultation endpoints accepted authorization as Optional[str] = None and either ignored it entirely or wrapped the auth check in a try/except that silently fell through on any failure.

Problems fixed:

POST /api/consultation/book
  - No rate limit (added @limiter.limit('5/minute'))
  - Auth was optional — unauthenticated callers wrote bookings with user_id='anonymous', indistinguishable from real bookings
  - Attacker could flood any expert's calendar with phantom appointments Fix: verify_role(raw_request) required; uid derived from verified token; user display name fetched from Firestore, never from request body.

PUT /api/consultation/{id}
  - No auth check — anyone could mark any consultation as completed/cancelled Fix: verify_role required; ownership check (doc.user_id == uid) enforced; admins and experts may update any consultation.

GET /api/consultations
  - No auth check — user_id accepted from query string, allowing any caller to read any user's full consultation history (IDOR)
  - With no user_id, returned ALL consultations in the database Fix: verify_role required; results always scoped to token uid; client-supplied user_id parameter ignored entirely.

DELETE /api/consultation/{id}
  - No auth check — anyone could cancel any consultation by ID Fix: verify_role required; ownership check enforced; admins and experts may cancel any consultation.

Closes #750

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Authentication is now required for all consultation operations (booking, updating, viewing, and canceling).
  * Users can only access and modify their own consultations.
  * Rate limiting added to the consultation booking endpoint to prevent abuse.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/781?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->