### PR TITLE
fix: Client-side storage of cryptographic private keys

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -25,6 +25,7 @@ import {
 } from "react-icons/fa";
 import { usePerformanceStore } from "./stores/performanceStore";
 import { useBrowserCacheBudget } from "./lib/cacheBudget";
+import { cryptoService } from "./utils/cryptoService";
 // Components
 import Loader from "./Loader";
 import LanguageDropdown from "./LanguageDropdown";
@@ -82,7 +83,7 @@ import {
 const Weather = React.lazy(() => import("./Weather"));
 
 // Libs
-import { auth, db, isFirebaseConfigured, doc, onSnapshot, setDoc } from "./lib/firebase";
+import { auth, db, isFirebaseConfigured, doc, onSnapshot, setDoc, getDoc } from "./lib/firebase";
 import { onAuthStateChanged, signOut } from "firebase/auth";
 
 // CSS
@@ -239,18 +240,18 @@ function App() {
 
     const ensurePublicKey = async () => {
       try {
-        let privateJwk = localStorage.getItem(`agri:ecdh_private_${user.uid}`);
-        let publicJwk = localStorage.getItem(`agri:ecdh_public_${user.uid}`);
-        
-        if (!privateJwk || !publicJwk) {
-          const { cryptoService } = await import("./utils/cryptoService");
-          const keyPair = await cryptoService.generateECDHKeyPair();
-          privateJwk = await cryptoService.exportKey(keyPair.privateKey);
-          publicJwk = await cryptoService.exportKey(keyPair.publicKey);
-          localStorage.setItem(`agri:ecdh_private_${user.uid}`, JSON.stringify(privateJwk));
-          localStorage.setItem(`agri:ecdh_public_${user.uid}`, JSON.stringify(publicJwk));
-        } else {
-          publicJwk = JSON.parse(publicJwk);
+        let { publicJwk } = await cryptoService.ensureKeys(user.uid);
+
+        if (!publicJwk) {
+          const publicKeySnap = await getDoc(doc(db, "public_keys", user.uid));
+          if (publicKeySnap.exists()) {
+            publicJwk = publicKeySnap.data().jwk;
+            await cryptoService.savePublicKey(user.uid, publicJwk);
+          }
+        }
+
+        if (!publicJwk) {
+          throw new Error("ECDH public key unavailable after initialization");
         }
 
         const pubKeyRef = doc(db, "public_keys", user.uid);

--- a/frontend/utils/cryptoService.js
+++ b/frontend/utils/cryptoService.js
@@ -3,8 +3,8 @@
  * Implements Elliptic Curve Diffie-Hellman (ECDH) and AES-GCM encryption
  *
  * Private keys are stored in IndexedDB as non-extractable CryptoKey objects.
- * This means the raw key material can never be read by JavaScript — not by
- * this code, not by third-party scripts, and not by an XSS attacker.
+ * Public keys are cached alongside them for reuse, but the private key raw
+ * material never leaves the Web Crypto subsystem.
  */
 
 // ---------------------------------------------------------------------------
@@ -89,11 +89,25 @@ async generateECDHKeyPair() {
   },
 
   /**
+   * Persist the public JWK for a user in IndexedDB.
+   */
+  async savePublicKey(uid, publicJwk) {
+    await idbSet(`ecdh_public_${uid}`, publicJwk);
+  },
+
+  /**
    * Load the private CryptoKey for a user from IndexedDB.
    * Returns null if no key exists yet.
    */
   async loadPrivateKey(uid) {
     return await idbGet(`ecdh_private_${uid}`);
+  },
+
+  /**
+   * Load the public JWK for a user from IndexedDB.
+   */
+  async loadPublicKey(uid) {
+    return await idbGet(`ecdh_public_${uid}`);
   },
 
   // ---------------------------------------------------------------------------
@@ -192,34 +206,40 @@ async generateECDHKeyPair() {
    */
   async ensureKeys(uid) {
     let privateKey = await this.loadPrivateKey(uid);
-    let publicJwk = null;
+    let publicJwk = await this.loadPublicKey(uid);
 
     // 1. Try migration from legacy localStorage (different possible prefixes)
-    if (!privateKey) {
-      const legacyKeys = [
-        `agri:ecdh_private_${uid}`,
-        `ecdh_private_${uid}`
-      ];
-      const legacyPublicKeys = [
-        `agri:ecdh_public_${uid}`,
-        `ecdh_public_${uid}`
-      ];
+    const legacyKeys = [
+      `agri:ecdh_private_${uid}`,
+      `ecdh_private_${uid}`
+    ];
+    const legacyPublicKeys = [
+      `agri:ecdh_public_${uid}`,
+      `ecdh_public_${uid}`
+    ];
 
+    if (!privateKey || !publicJwk) {
       for (let i = 0; i < legacyKeys.length; i++) {
         const priv = localStorage.getItem(legacyKeys[i]);
         const pub = localStorage.getItem(legacyPublicKeys[i]);
-        if (priv && pub) {
+        if (priv) {
           try {
             // Import the plaintext JWK from localStorage as a NON-EXTRACTABLE CryptoKey
-            privateKey = await this.importPrivateKey(JSON.parse(priv));
+            privateKey = privateKey || await this.importPrivateKey(JSON.parse(priv));
             await this.savePrivateKey(uid, privateKey);
-            publicJwk = JSON.parse(pub);
+
+            if (pub) {
+              publicJwk = publicJwk || JSON.parse(pub);
+              await this.savePublicKey(uid, publicJwk);
+            }
 
             // Cleanup insecure storage
             localStorage.removeItem(legacyKeys[i]);
             localStorage.removeItem(legacyPublicKeys[i]);
             console.info("Migrated ECDH keys from localStorage to IndexedDB.");
-            break;
+            if (privateKey && publicJwk) {
+              break;
+            }
           } catch (e) {
             console.error("Migration failed for key:", legacyKeys[i], e);
           }
@@ -232,8 +252,21 @@ async generateECDHKeyPair() {
       const keyPair = await this.generateECDHKeyPair();
       // Store in IDB (it will be stored as an opaque object handle)
       await this.savePrivateKey(uid, keyPair.privateKey);
-      privateKey = keyPair.privateKey;
       publicJwk = await this.exportKey(keyPair.publicKey);
+      await this.savePublicKey(uid, publicJwk);
+      privateKey = keyPair.privateKey;
+    } else if (!publicJwk) {
+      // Existing private keys from older app versions may not have a cached
+      // public JWK yet. Reconstruct it from legacy storage if possible.
+      for (let i = 0; i < legacyPublicKeys.length; i++) {
+        const pub = localStorage.getItem(legacyPublicKeys[i]);
+        if (pub) {
+          publicJwk = JSON.parse(pub);
+          await this.savePublicKey(uid, publicJwk);
+          localStorage.removeItem(legacyPublicKeys[i]);
+          break;
+        }
+      }
     }
 
     return { privateKey, publicJwk };


### PR DESCRIPTION
I removed the frontend’s direct ECDH private-key writes from App.jsx and routed initialization through the centralized crypto service instead. The private key now stays in IndexedDB as a non-extractable `CryptoKey`, while the public JWK is cached separately for republishing; legacy `localStorage` entries are still migrated and then deleted.

I also added a fallback so existing users with an IndexedDB private key but no cached public JWK can recover the public key from Firestore and persist it safely. Validation was clean on the touched files, and a search found no remaining ECDH `localStorage` use in App.jsx.

closes #787

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved encryption key initialization and fallback handling to ensure reliable end-to-end encryption synchronization across sessions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/793?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->