### PR TITLE
fix(security): add authentication to /api/autopilot/generate-plan

### DIFF
--- a/main.py
+++ b/main.py
@@ -677,6 +677,42 @@ def health_check():
     return {"status": "healthy", "service": "Fasal Saathi Backend", "version": "2.0"}
 
 
+# --- Smart Farm Autopilot ---
+
+class SeasonPlanRequest(BaseModel):
+    farm_name: str = Field(default="My Farm", max_length=100)
+    state: str = Field(..., min_length=2, max_length=50)
+    district: str = Field(default="", max_length=100)
+    area_acres: float = Field(..., gt=0, le=10000)
+    soil_type: str = Field(..., min_length=2, max_length=50)
+    season: str = Field(..., pattern="^(Kharif|Rabi|Zaid)$")
+    water_source: str = Field(default="Canal", max_length=50)
+    budget_inr: Optional[float] = Field(default=None, ge=0)
+
+
+@app.post("/api/autopilot/generate-plan")
+@limiter.limit("5/minute")
+async def generate_farm_plan(request: Request, data: SeasonPlanRequest):
+    """
+    Smart Farm Autopilot — generate a complete seasonal farming plan.
+
+    Requires authentication. The planner is computationally intensive
+    (crop selection, sowing schedule, irrigation plan, fertilizer/pesticide
+    timeline, yield/profit projection) and must not be accessible to
+    unauthenticated callers.
+    """
+    await verify_role(request)   # raises 401/403 if token is missing or invalid
+    try:
+        from smart_farm_autopilot import generate_season_plan
+        plan = generate_season_plan(data.dict())
+        return {"success": True, "plan": plan}
+    except ValueError as e:
+        raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("Autopilot plan generation failed: %s", e)
+        raise HTTPException(status_code=500, detail="Failed to generate farm plan")
+
+
 # Include ML Model Management Router
 try:
     from routers.ml_models import router as ml_router


### PR DESCRIPTION
The endpoint had no auth check — any unauthenticated caller could invoke the computationally intensive SmartFarmAutopilot planner (crop selection, sowing schedule, irrigation plan, fertilizer timeline, yield projection) with only a 5/minute per-IP rate limit as protection, trivially bypassed with rotating proxies.

Changes:
- Added SeasonPlanRequest Pydantic model (matches the original feature commit schema: state, area_acres, soil_type, season, water_source, budget_inr with appropriate validation).
- Added POST /api/autopilot/generate-plan with await verify_role(request) as the first statement — raises HTTP 401 if the token is missing or invalid, HTTP 403 if the token is valid but the role check fails.
- generate_season_plan is imported lazily inside the handler so startup is not affected if smart_farm_autopilot.py is unavailable.
- Consistent with every other resource-intensive endpoint in the codebase (RAG query, Gemini proxy, report generation) which all require auth.
 
Closes #808 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Smart Farm Autopilot endpoint: Generate optimized seasonal farm plans with user authentication. Provide farm metadata, soil conditions, seasonal constraints, water source details, and optional budget information to receive customized planting recommendations tailored to your farm's unique operational needs.
  * Implemented per-IP rate limiting to ensure system stability and equitable access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/853?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->