### PR TITLE
fix(security): prevent self-assignment of expert/vendor roles in ProfileSetup

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -66,6 +66,14 @@ service cloud.firestore {
         && (
           !("reputation" in request.resource.data.diff(resource.data).affectedKeys())
           || reputationCooldownOk(userId)
+        )
+        // Prevent privilege escalation: a user updating their own profile may
+        // not change their role to anything other than "farmer".
+        // Elevated roles (expert, vendor, admin) must be assigned by an admin
+        // via a separate admin-only write path, not through self-service setup.
+        && (
+          !("role" in request.resource.data.diff(resource.data).affectedKeys())
+          || request.resource.data.role == "farmer"
         );
     }
 

--- a/frontend/ProfileSetup.jsx
+++ b/frontend/ProfileSetup.jsx
@@ -132,7 +132,7 @@ const ProfileSetup = ({ user, profileCompleted }) => {
         await setDoc(doc(db, "users", currentUser.uid), {
           displayName: name,
           language: language,
-          role: role,
+          role: "farmer",   // always farmer — elevated roles are admin-assigned only
           cropType: cropType,
           location: location,
           address: address,
@@ -203,15 +203,18 @@ const ProfileSetup = ({ user, profileCompleted }) => {
             <label><FaUser /> I am a...</label>
             <div className="setup-input-wrapper">
               <span className="setup-icon">👤</span>
-              <select
-                value={role}
-                onChange={(e) => setRole(e.target.value)}
-              >
+              {/* Role is always "farmer" during self-service profile setup.
+                  Expert and vendor roles are assigned by admins only — they
+                  must not be self-assignable because they grant elevated
+                  backend permissions (report generation, finance read-all,
+                  consultation management). */}
+              <select value="farmer" disabled aria-label="Account role">
                 <option value="farmer">🚜 Farmer</option>
-                <option value="expert">🎓 Agri-Expert</option>
-                <option value="vendor">🏪 Marketplace Vendor</option>
               </select>
             </div>
+            <p style={{ fontSize: "0.78rem", color: "#6b7280", marginTop: "4px" }}>
+              Expert and vendor roles are assigned by administrators.
+            </p>
           </div>
 
           <div className="setup-group">


### PR DESCRIPTION
ProfileSetup.jsx exposed a role dropdown with 'expert' and 'vendor' options. The submit handler wrote the user-controlled value directly to Firestore. The /users/{userId} rule only checked isOwner() on update — it did not validate the role field. A user who set role='expert' in Firestore would pass verify_role(required_roles=['expert','admin']) on the backend, gaining access to signed report generation, finance read-all, and consultation management.

Two-layer fix:

frontend/ProfileSetup.jsx:
- Role dropdown replaced with a disabled single-option select showing 'Farmer'. The onChange handler and the expert/vendor options are removed entirely so there is no client-side path to submit a non-farmer role.
- The Firestore write hard-codes role: 'farmer' instead of reading from state, so even a crafted request that bypasses the UI cannot set an elevated role through this flow.
- Added a short explanatory note below the field so legitimate experts and vendors know to contact an administrator.

firestore.rules:
- Added a role-change guard to the /users/{userId} update rule: if the 'role' field is present in the diff, its new value must be 'farmer'. This is the server-side enforcement layer — it rejects any direct Firestore SDK write that attempts to escalate the role, regardless of what the frontend sends.

Closes #805