### PR TITLE
fix(security): add Firestore rules for consultations collection

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -174,5 +174,53 @@ service cloud.firestore {
       allow delete: if isOwner(resource.data.reporterId) || hasRole('admin');
     }
 
+    // Consultations: records created when a farmer books an expert session.
+    //
+    // Sensitive fields: userId, userName, expertId, expertName, date, time,
+    // consultationType, notes, status.
+    //
+    // Read access:
+    //   - The farmer who owns the record (userId == caller uid).
+    //   - Experts can read records where they are the assigned expert.
+    //   - Admins can read all records.
+    //
+    // Write access:
+    //   - Create: authenticated caller only, and userId must equal the
+    //     caller's uid — prevents forging a booking under another user's id.
+    //   - Update: the owning farmer (status/notes changes) or an expert
+    //     assigned to the consultation (status updates), or an admin.
+    //   - Delete: admin only.
+    match /consultations/{consultationId} {
+      allow read: if isAuthed()
+        && (
+          resource.data.userId == request.auth.uid
+          || resource.data.expertId == request.auth.uid
+          || hasRole('admin')
+        );
+
+      allow create: if isAuthed()
+        // Bind the record to the authenticated caller — no forged userId.
+        && request.resource.data.userId == request.auth.uid
+        // notes must be a string capped at 1000 characters.
+        && (!("notes" in request.resource.data)
+            || (request.resource.data.notes is string
+                && request.resource.data.notes.size() <= 1000))
+        // status on creation must be "scheduled".
+        && request.resource.data.status == "scheduled";
+
+      allow update: if isAuthed()
+        && (
+          // Farmer can update their own record (e.g. cancel, add notes).
+          resource.data.userId == request.auth.uid
+          // Assigned expert can update status (e.g. mark completed).
+          || resource.data.expertId == request.auth.uid
+          || hasRole('admin')
+        )
+        // userId must never change after creation.
+        && request.resource.data.userId == resource.data.userId;
+
+      allow delete: if hasRole('admin');
+    }
+
   }
 }


### PR DESCRIPTION
The consultations collection had no security rules. While Firestore defaults to deny for unmatched paths, the absence of explicit rules meant there was no server-side enforcement of:
  - Ownership on reads: any authenticated user could query another user's consultation records via a direct SDK query (where('userId', '==', victim_uid)).
  - Ownership on writes: any authenticated user could create a consultation record with a forged userId, bypassing the backend's token-based identity check entirely.

Consultation records contain sensitive data: userId, userName, expertId, expertName, date, time, consultationType, notes, status.

New rules added:

read:  allowed for the record owner (userId == caller uid), the
       assigned expert (expertId == caller uid), and admins.

create: allowed for authenticated callers only when
        request.resource.data.userId == request.auth.uid (no forged
        ownership), notes are capped at 1000 chars, and initial status
        must be 'scheduled'.

update: allowed for the record owner (farmer cancels / adds notes),
        the assigned expert (marks completed), or an admin. The userId
        field is immutable after creation.

delete: admin only.

Closes #804 