### PR TITLE
fix(security): use authenticated apiClient for WhatsApp subscribe in ProfileSetup

### DIFF
--- a/frontend/ProfileSetup.jsx
+++ b/frontend/ProfileSetup.jsx
@@ -3,6 +3,7 @@ import { auth, db, isFirebaseConfigured } from "./lib/firebase";
 import { doc, setDoc } from "firebase/firestore";
 import { useNavigate } from "react-router-dom";
 import { FaUser, FaGlobe, FaMapMarkerAlt, FaSeedling, FaArrowRight } from "react-icons/fa";
+import apiClient from "./lib/apiClient";
 import "./ProfileSetup.css";
 
 const LANGUAGE_OPTIONS = [
@@ -144,17 +145,17 @@ const ProfileSetup = ({ user, profileCompleted }) => {
           updatedAt: new Date().toISOString()
         }, { merge: true });
 
-        // If WhatsApp alerts are enabled, subscribe via backend
+        // If WhatsApp alerts are enabled, subscribe via backend.
+        // Use apiClient so the Firebase auth token is automatically injected
+        // via the Axios request interceptor — the backend derives the user's
+        // identity from the verified token, not from any client-supplied field.
         if (whatsappAlerts && phoneNumber) {
           try {
-            await fetch("/api/whatsapp/subscribe", {
-              method: "POST",
-              headers: { "Content-Type": "application/json" },
-              body: JSON.stringify({
-                phone_number: phoneNumber,
-                user_id: currentUser.uid,
-                name: name
-              })
+            await apiClient.post("/api/whatsapp/subscribe", {
+              phone_number: phoneNumber,
+              name: name
+              // user_id is intentionally omitted — the backend ignores it and
+              // uses the uid from the verified Firebase token instead.
             });
           } catch (whatsappErr) {
             console.error("WhatsApp subscription error:", whatsappErr);


### PR DESCRIPTION
ProfileSetup.jsx called /api/whatsapp/subscribe using raw fetch() with no Authorization header and sent user_id in the request body. The backend now requires a verified Firebase token and derives the uid from it, but the frontend was still sending an unauthenticated request that would be rejected with 401.

Changes:
- Import apiClient from ./lib/apiClient, which automatically injects the Firebase ID token via its Axios request interceptor.
- Replace the raw fetch() call with apiClient.post().
- Remove user_id from the request body — the backend ignores it and uses the token-derived uid, so sending it was misleading and unnecessary.



Closes #802 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced the WhatsApp subscription process in profile setup for improved backend integration and authentication handling.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/856?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->