### PR TITLE
fix(security): replace CORS wildcard origin with explicit allowlist

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,6 +2,17 @@
 # Get this from https://aistudio.google.com/app/apikey
 GEMINI_API_KEY=your_gemini_api_key_here
 
+# ============================================================================
+# CORS Configuration
+# ============================================================================
+# Primary frontend URL — added to the CORS allowlist automatically.
+# Set this to your production deployment URL (e.g. https://fasal-saathi.vercel.app).
+# Local development origins (localhost:5173, localhost:3000) are always allowed.
+FRONTEND_URL=https://your-frontend-domain.com
+
+# Optional: comma-separated list of additional allowed origins (e.g. staging/preview URLs).
+# ADDITIONAL_ALLOWED_ORIGINS=https://preview.your-domain.com,https://staging.your-domain.com
+
 # Twilio WhatsApp Credentials
 # Get these from your Twilio Console: https://console.twilio.com/
 TWILIO_ACCOUNT_SID=ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/main.py
+++ b/main.py
@@ -934,12 +934,44 @@ limiter = Limiter(key_func=get_remote_address)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, _rate_limit_exceeded_handler)
 
+# ---------------------------------------------------------------------------
+# CORS — explicit origin allowlist
+#
+# allow_origins=["*"] combined with allow_credentials=True is forbidden by
+# the CORS specification and rejected by browsers. It would also allow any
+# origin on the internet to make credentialed requests on behalf of a
+# logged-in farmer if a non-browser client ever relaxed the check.
+#
+# Origins are built from:
+#   1. Hard-coded local development origins (always included).
+#   2. FRONTEND_URL env var — set this to the production deployment URL.
+#   3. ADDITIONAL_ALLOWED_ORIGINS env var — comma-separated list for staging
+#      or preview deployments (e.g. Vercel preview URLs).
+# ---------------------------------------------------------------------------
+_CORS_ORIGINS: list[str] = [
+    "http://localhost:5173",
+    "http://127.0.0.1:5173",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
+]
+
+_frontend_url = os.getenv("FRONTEND_URL", "").strip()
+if _frontend_url and _frontend_url not in _CORS_ORIGINS:
+    _CORS_ORIGINS.append(_frontend_url)
+
+_extra_origins = os.getenv("ADDITIONAL_ALLOWED_ORIGINS", "").strip()
+if _extra_origins:
+    for _origin in _extra_origins.split(","):
+        _origin = _origin.strip()
+        if _origin and _origin not in _CORS_ORIGINS:
+            _CORS_ORIGINS.append(_origin)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=_CORS_ORIGINS,
     allow_credentials=True,
-    allow_methods=["*"],
-    allow_headers=["*"],
+    allow_methods=["GET", "POST", "PUT", "DELETE", "OPTIONS", "PATCH"],
+    allow_headers=["Authorization", "Content-Type", "Accept", "Origin", "X-Requested-With"],
 )
 app.add_middleware(RBACMiddleware)
 logger.info(print_rbac_matrix())


### PR DESCRIPTION
allow_origins=['*'] combined with allow_credentials=True is forbidden by the CORS specification. Browsers reject this combination and refuse to send cookies or Authorization headers, silently breaking every credentialed cross-origin request from the frontend. If a non-browser client ever relaxed the check, any origin on the internet could make authenticated API calls on behalf of a logged-in farmer.

Changes:

main.py:
- Build _CORS_ORIGINS from three sources:
    1. Hard-coded local dev origins (localhost:5173, localhost:3000)
    2. FRONTEND_URL env var (production deployment URL)
    3. ADDITIONAL_ALLOWED_ORIGINS env var (comma-separated, for staging or Vercel preview deployments)
- Replace allow_methods=['*'] with an explicit verb list
- Replace allow_headers=['*'] with the specific headers the frontend actually sends (Authorization, Content-Type, Accept, Origin, X-Requested-With)

.env.example:
- Document FRONTEND_URL and ADDITIONAL_ALLOWED_ORIGINS with usage notes

Closes #870 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Configuration**
  * CORS policy updated to require explicit origin allowlisting instead of accepting all origins
  * Added FRONTEND_URL environment variable for primary frontend origin configuration
  * Added ADDITIONAL_ALLOWED_ORIGINS environment variable for comma-separated supplementary origins
  * Allowed HTTP methods and headers are now restricted to commonly-needed values

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/884?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->