### PR TITLE
fix(security): add authentication to all ML governance endpoints

### DIFF
--- a/backend/routers/governance.py
+++ b/backend/routers/governance.py
@@ -1,5 +1,6 @@
 """ML Governance Router - Drift, shadow eval, versioning"""
 from fastapi import APIRouter, HTTPException, Request, Query
+from firebase_admin import auth as firebase_auth
 from pydantic import BaseModel, Field
 from typing import Optional, Dict, Any
 
@@ -22,8 +23,75 @@ def init_governance(dd, se, vm):
     shadow_evaluator = se
     version_manager = vm
 
+
+# ---------------------------------------------------------------------------
+# Auth helpers
+# ---------------------------------------------------------------------------
+
+def _require_auth(request: Request) -> str:
+    """
+    Verify the Firebase ID token from the Authorization header.
+    Returns the caller's uid on success.
+    Raises HTTP 401 if the token is missing or invalid.
+
+    All governance endpoints require authentication — unauthenticated callers
+    must not be able to promote/rollback models, poison drift baselines, or
+    start shadow evaluations.
+    """
+    auth_header = request.headers.get("Authorization", "")
+    if not auth_header.startswith("Bearer "):
+        raise HTTPException(status_code=401, detail="Missing or invalid authentication token")
+    token = auth_header.split(" ", 1)[1]
+    try:
+        decoded = firebase_auth.verify_id_token(token)
+        return decoded["uid"]
+    except Exception:
+        raise HTTPException(status_code=401, detail="Authentication failed")
+
+
+def _require_admin_auth(request: Request) -> str:
+    """
+    Verify the Firebase ID token AND check that the caller has the 'admin'
+    role in Firestore. Used for destructive write operations (promote,
+    rollback, register, set baseline) that must be restricted to admins.
+
+    Falls back to uid-only check when Firestore is unavailable so the
+    endpoint still rejects unauthenticated callers even in degraded state.
+    """
+    uid = _require_auth(request)
+
+    # Best-effort role check — import lazily to avoid circular imports
+    try:
+        import firebase_admin
+        from firebase_admin import firestore as _fs
+        if firebase_admin._apps:
+            db = _fs.client()
+            user_doc = db.collection("users").document(uid).get()
+            if user_doc.exists:
+                role = user_doc.to_dict().get("role", "farmer")
+                if role not in ("admin", "expert"):
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Access denied: admin or expert role required"
+                    )
+    except HTTPException:
+        raise
+    except Exception:
+        # Firestore unavailable — token is still verified; allow through
+        # rather than blocking legitimate admins during an outage.
+        pass
+
+    return uid
+
+
+# ---------------------------------------------------------------------------
+# Drift detection endpoints
+# ---------------------------------------------------------------------------
+
 @router.post("/drift/baseline")
 async def set_drift_baseline(request: Request, model_name: str, predictions: list[float]):
+    """Set drift baseline. Requires admin or expert role."""
+    _require_admin_auth(request)
     if drift_detector is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     drift_detector.set_baseline(model_name, predictions)
@@ -31,6 +99,8 @@ async def set_drift_baseline(request: Request, model_name: str, predictions: lis
 
 @router.post("/drift/check")
 async def check_drift(request: Request, model_name: str, prediction: float, actual_value: float):
+    """Check for model drift. Requires authentication."""
+    _require_auth(request)
     if drift_detector is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     drift_info = drift_detector.check_prediction_drift(model_name, prediction, actual_value)
@@ -38,13 +108,22 @@ async def check_drift(request: Request, model_name: str, prediction: float, actu
 
 @router.get("/drift/alerts")
 async def get_drift_alerts(request: Request, model_name: str = None, limit: int = Query(10, ge=1, le=100)):
+    """Get drift alerts. Requires authentication."""
+    _require_auth(request)
     if drift_detector is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     alerts = drift_detector.get_alerts(model_name) if model_name else []
     return {"success": True, "alerts": alerts[:limit]}
 
+
+# ---------------------------------------------------------------------------
+# Shadow evaluation endpoints
+# ---------------------------------------------------------------------------
+
 @router.post("/shadow/start")
 async def start_shadow_evaluation(request: Request, production_model: str, candidate_model: str):
+    """Start a shadow evaluation. Requires admin or expert role."""
+    _require_admin_auth(request)
     if shadow_evaluator is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     eval_id = shadow_evaluator.start_shadow_evaluation(production_model, candidate_model)
@@ -52,6 +131,8 @@ async def start_shadow_evaluation(request: Request, production_model: str, candi
 
 @router.post("/shadow/record")
 async def record_shadow_predictions(request: Request, eval_id: str, production_prediction: float, candidate_prediction: float, actual_value: float):
+    """Record shadow predictions. Requires authentication."""
+    _require_auth(request)
     if shadow_evaluator is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     shadow_evaluator.record_predictions(eval_id, production_prediction, candidate_prediction, actual_value)
@@ -60,6 +141,8 @@ async def record_shadow_predictions(request: Request, eval_id: str, production_p
 
 @router.post("/shadow/evaluate")
 async def evaluate_candidate_model(request: Request, eval_id: str):
+    """Evaluate a candidate model. Requires admin or expert role."""
+    _require_admin_auth(request)
     if shadow_evaluator is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     result = shadow_evaluator.evaluate_candidate(eval_id)
@@ -67,13 +150,22 @@ async def evaluate_candidate_model(request: Request, eval_id: str):
 
 @router.get("/shadow/status/{eval_id}")
 async def get_shadow_eval_status(request: Request, eval_id: str):
+    """Get shadow evaluation status. Requires authentication."""
+    _require_auth(request)
     if shadow_evaluator is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     status = shadow_evaluator.get_evaluation_status(eval_id)
     return {"success": True, "eval_id": eval_id, "status": status}
 
+
+# ---------------------------------------------------------------------------
+# Model version management endpoints
+# ---------------------------------------------------------------------------
+
 @router.post("/versions/register")
 async def register_model_version(request: Request, data: RegisterModelVersionRequest):
+    """Register a new model version. Requires admin or expert role."""
+    _require_admin_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     version_id = version_manager.register_version(data.model_name, data.model_path, data.rmse, data.r2_score, data.metadata)
@@ -81,6 +173,8 @@ async def register_model_version(request: Request, data: RegisterModelVersionReq
 
 @router.post("/versions/promote")
 async def promote_model_version(request: Request, version_id: str):
+    """Promote a model version to production. Requires admin role."""
+    _require_admin_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     version_manager.promote_version(version_id)
@@ -89,6 +183,8 @@ async def promote_model_version(request: Request, version_id: str):
 
 @router.post("/versions/rollback")
 async def rollback_model_version(request: Request, version_id: str):
+    """Roll back to a previous model version. Requires admin role."""
+    _require_admin_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     version_manager.rollback_to_version(version_id)
@@ -97,6 +193,8 @@ async def rollback_model_version(request: Request, version_id: str):
 
 @router.get("/versions/production")
 async def get_production_version(request: Request):
+    """Get current production version. Requires authentication."""
+    _require_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     prod_version = version_manager.get_production_version()
@@ -104,6 +202,8 @@ async def get_production_version(request: Request):
 
 @router.get("/versions/list")
 async def list_model_versions(request: Request, model_name: str = None):
+    """List model versions. Requires authentication."""
+    _require_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     versions = version_manager.list_versions(model_name) if model_name else []
@@ -111,6 +211,8 @@ async def list_model_versions(request: Request, model_name: str = None):
 
 @router.get("/versions/compare")
 async def compare_model_versions(request: Request, v1: str, v2: str):
+    """Compare two model versions. Requires authentication."""
+    _require_auth(request)
     if version_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     comparison = version_manager.compare_versions(v1, v2)
@@ -118,6 +220,8 @@ async def compare_model_versions(request: Request, v1: str, v2: str):
 
 @router.get("/status")
 async def get_governance_status(request: Request):
+    """Get overall governance status. Requires authentication."""
+    _require_auth(request)
     if not all([drift_detector, shadow_evaluator, version_manager]):
         raise HTTPException(status_code=500, detail="Not fully initialized")
     return {


### PR DESCRIPTION
All 13 governance endpoints accepted a Request parameter but never used it for authentication. An unauthenticated attacker could:
  - Promote a degraded model to production (wrong yield predictions for every farmer)
  - Roll back to a known-bad model version
  - Poison the drift baseline to suppress legitimate drift alerts
  - Start shadow evaluations that consume server resources

Two auth tiers added:

_require_auth(request) — verifies the Firebase ID token, raises 401 if missing or invalid. Applied to read-only and low-risk write endpoints: drift/check, drift/alerts, shadow/record, shadow/status, versions/production, versions/list, versions/compare, status.

_require_admin_auth(request) — verifies the token AND checks that the caller's Firestore role is 'admin' or 'expert', raises 403 otherwise. Applied to destructive/privileged endpoints: drift/baseline, shadow/start, shadow/evaluate, versions/register, versions/promote, versions/rollback.

The Firestore role check degrades gracefully: if Firestore is unavailable the token is still verified so unauthenticated callers are always rejected, but legitimate admins are not blocked during a database outage.

Closes #872 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * New explicit endpoint for shadow model evaluation added.

* **Security & Authorization**
  * User authentication now required for drift monitoring, version queries, and governance status access.
  * Admin/expert authorization required for model version management and shadow evaluation operations.
  * Role-based access control enhanced across all governance operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/885?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->