### PR TITLE
fix(security): add authentication to all crop quality endpoints

### DIFF
--- a/backend/routers/quality.py
+++ b/backend/routers/quality.py
@@ -55,8 +55,15 @@ def init_quality(cqg, rbac, perm):
 
 @router.post("/assess-single")
 async def assess_single_crop(request: Request, data: CropQualityGradingRequest):
-    if crop_quality_grader is None:
+    """Assess a single crop image. Requires QUALITY_ASSESS permission."""
+    if crop_quality_grader is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    try:
+        await rbac_manager.raise_if_unauthorized(request, [Permission.QUALITY_ASSESS], require_all=False)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=403, detail=str(e))
     try:
         import base64
         image_bytes = base64.b64decode(data.image_base64)
@@ -68,8 +75,15 @@ async def assess_single_crop(request: Request, data: CropQualityGradingRequest):
 
 @router.post("/assess-batch")
 async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
-    if crop_quality_grader is None:
+    """Assess a batch of crop images. Requires QUALITY_ASSESS permission."""
+    if crop_quality_grader is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    try:
+        await rbac_manager.raise_if_unauthorized(request, [Permission.QUALITY_ASSESS], require_all=False)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=403, detail=str(e))
     try:
         import base64
         image_bytes_list = [base64.b64decode(img) for img in data.images_base64]
@@ -81,8 +95,15 @@ async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
 
 @router.post("/trends")
 async def get_quality_trends(request: Request, data: QualityTrendsRequest):
-    if crop_quality_grader is None:
+    """Get quality trends. Requires QUALITY_READ permission."""
+    if crop_quality_grader is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    try:
+        await rbac_manager.raise_if_unauthorized(request, [Permission.QUALITY_READ], require_all=False)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=403, detail=str(e))
     try:
         trends = crop_quality_grader.get_quality_trends(data.crop_type, data.days)
         return {"success": True, "crop_type": data.crop_type, "days": data.days, "trends": trends}
@@ -92,15 +113,29 @@ async def get_quality_trends(request: Request, data: QualityTrendsRequest):
 
 @router.get("/supported-crops")
 async def get_supported_crops(request: Request):
-    if crop_quality_grader is None:
+    """Get supported crop types. Requires QUALITY_READ permission."""
+    if crop_quality_grader is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    try:
+        await rbac_manager.raise_if_unauthorized(request, [Permission.QUALITY_READ], require_all=False)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=403, detail=str(e))
     crops = crop_quality_grader.supported_crops if hasattr(crop_quality_grader, 'supported_crops') else []
     return {"success": True, "supported_crops": crops}
 
 @router.post("/market-price")
 async def calculate_market_price(request: Request, data: CropQualityGradingRequest):
-    if crop_quality_grader is None:
+    """Calculate market price from crop image. Requires QUALITY_ASSESS permission."""
+    if crop_quality_grader is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    try:
+        await rbac_manager.raise_if_unauthorized(request, [Permission.QUALITY_ASSESS], require_all=False)
+    except HTTPException:
+        raise
+    except Exception as e:
+        raise HTTPException(status_code=403, detail=str(e))
     try:
         import base64
         image_bytes = base64.b64decode(data.image_base64)


### PR DESCRIPTION
All five quality endpoints accepted a Request parameter but never called rbac_manager or Permission, even though both were initialized via init_quality(). Any unauthenticated caller could submit up to 100 images (50 MB total) to the AI grading pipeline, enabling:
  - Resource exhaustion / DoS by flooding the image processing pipeline
  - Free use of the AI grading service without authentication
  - Potential Gemini API quota abuse if the grader uses it internally

Fix: call rbac_manager.raise_if_unauthorized() at the top of each handler using the Permission values already passed in via init_quality():

  assess-single  -> QUALITY_ASSESS
  assess-batch   -> QUALITY_ASSESS
  market-price   -> QUALITY_ASSESS
  trends         -> QUALITY_READ
  supported-crops -> QUALITY_READ

The rbac_manager and Permission globals were already wired correctly by init_quality() — the auth check was simply never invoked.

Closes #873 