### PR TITLE
fix(auth): use apiClient in FarmFinance.jsx to send Firebase auth token

### DIFF
--- a/frontend/FarmFinance.jsx
+++ b/frontend/FarmFinance.jsx
@@ -37,6 +37,7 @@ import {
 } from 'recharts';
 import './FarmFinance.css';
 import { loadVersionedArray, saveVersionedArray } from './utils/versionedStorage';
+import apiClient from './lib/apiClient';
 
 const INCOME_STORAGE_KEY = 'fasalSaathiIncome';
 const EXPENSE_STORAGE_KEY = 'fasalSaathiDiary';
@@ -199,14 +200,13 @@ export default function FarmFinance() {
   });
 
   const postFinanceRequest = async (path, payload) => {
-    const response = await fetch(path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(payload),
-    });
-
-    const responseData = await response.json();
-    if (!response.ok || responseData?.success === false) {
+    // Use apiClient so the Firebase auth token is automatically injected via
+    // the Axios request interceptor. Raw fetch() has no Authorization header,
+    // causing every request to be rejected with 401/403 by the backend's
+    // rbac_manager.raise_if_unauthorized() check.
+    const response = await apiClient.post(path, payload);
+    const responseData = response.data;
+    if (responseData?.success === false) {
       throw new Error(responseData?.detail || responseData?.message || 'Finance request failed');
     }
     return responseData.data;


### PR DESCRIPTION
postFinanceRequest() used raw fetch() with no Authorization header. The backend's /api/farm-finance/analyze and /api/farm-finance/applications endpoints both call rbac_manager.raise_if_unauthorized(), which requires a valid Firebase ID token. Every request was rejected with 401/403, making the entire AI Loan Planner feature silently broken for all users.

Fix: replace fetch() with apiClient.post() from ./lib/apiClient, which automatically injects the Firebase token via its Axios request interceptor — the same pattern used by Dashboard.jsx, BankReports.jsx, ProfileSetup.jsx, and ReferralHub.jsx.


Closes #874 