### PR TITLE
fix(auth): replace raw axios with apiClient in SmartFarmAutopilot.jsx

### DIFF
--- a/frontend/SmartFarmAutopilot.jsx
+++ b/frontend/SmartFarmAutopilot.jsx
@@ -5,10 +5,15 @@ import {
   CheckCircle2, ChevronDown, ChevronUp, RefreshCw,
   TrendingUp, CloudRain, Leaf, ArrowRight, Info
 } from "lucide-react";
-import axios from "axios";
 import "./SmartFarmAutopilot.css";
+import apiClient from "./services/api";
 
-const API_BASE = import.meta.env.VITE_API_URL || "http://localhost:8000";
+// apiClient (from services/api.js) automatically injects the Firebase auth
+// token via its Axios request interceptor. Raw axios has no interceptor and
+// would send requests without an Authorization header, causing 401 rejections
+// from the authenticated /api/autopilot/generate-plan endpoint.
+// API_BASE is no longer needed — apiClient uses relative paths so it works
+// correctly in both local development (via Vite proxy) and production.
 
 const STATES = [
   "Andhra Pradesh","Bihar","Gujarat","Haryana","Karnataka",
@@ -79,7 +84,7 @@ export default function SmartFarmAutopilot() {
         area_acres: parseFloat(form.area_acres),
         budget_inr: form.budget_inr ? parseFloat(form.budget_inr) : null,
       };
-      const { data } = await axios.post(`${API_BASE}/api/autopilot/generate-plan`, payload);
+      const { data } = await apiClient.post("/api/autopilot/generate-plan", payload);
       setPlan(data.plan);
       setActiveTab("sowing");
     } catch (err) {


### PR DESCRIPTION
The component imported axios directly and called it with a hardcoded API_BASE (defaulting to http://localhost:8000). Raw axios has no request interceptor, so every plan generation request was sent without an Authorization header — causing 401 rejections from the authenticated /api/autopilot/generate-plan endpoint.

Two problems fixed:
1. Replace axios.post(API_BASE + path) with apiClient.post(path). apiClient (services/api.js) injects the Firebase ID token via its Axios request interceptor, matching the pattern used by Dashboard, BankReports, ProfileSetup, and FarmFinance.
2. Remove the VITE_API_URL / localhost:8000 fallback. apiClient uses relative paths, so it works correctly via the Vite dev proxy in local development and against the real backend in production.

Also removes the now-unused 'import axios from axios' line.

CLoses  #875 