### PR TITLE
fix(data): scope handleEndCall query to current user to prevent wrong record update

### DIFF
--- a/frontend/components/TeleConsultation.jsx
+++ b/frontend/components/TeleConsultation.jsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import "./ExpertDirectory.css";
-import { db } from "../lib/firebase";
+import { db, auth } from "../lib/firebase";
 import { collection, getDocs, updateDoc, doc, query, where } from "firebase/firestore";
 import { toast } from "react-toastify";
 import {
@@ -50,17 +50,44 @@ function TeleConsultation({ userData, consultation, onEnd }) {
     setIsLoading(true);
     try {
       const consultationsRef = collection(db, "consultations");
-      const q = query(consultationsRef, where("expertId", "==", consultation.expertId));
-      const snapshot = await getDocs(q);
 
-      if (!snapshot.empty) {
-        const docRef = snapshot.docs[0].ref;
+      // If the consultation object already carries its Firestore document ID,
+      // do a direct point-lookup — no query needed, no risk of touching another
+      // user's record.
+      if (consultation.id) {
+        const docRef = doc(db, "consultations", consultation.id);
         await updateDoc(docRef, {
           status: "completed",
           duration: callDuration,
           endTime: new Date().toISOString(),
           notes: notes,
         });
+      } else {
+        // Fallback: scope the query to BOTH the expert AND the current user so
+        // we never accidentally update another farmer's consultation record.
+        // Previously the query only filtered on expertId, meaning snapshot.docs[0]
+        // could be any farmer's record for that expert.
+        const currentUid = auth?.currentUser?.uid || userData?.uid;
+        const constraints = [
+          where("expertId", "==", consultation.expertId),
+          where("status", "==", "scheduled"),
+        ];
+        if (currentUid) {
+          constraints.push(where("userId", "==", currentUid));
+        }
+        const q = query(consultationsRef, ...constraints);
+        const snapshot = await getDocs(q);
+
+        if (!snapshot.empty) {
+          // Update only the first matching record that belongs to this user
+          const docRef = snapshot.docs[0].ref;
+          await updateDoc(docRef, {
+            status: "completed",
+            duration: callDuration,
+            endTime: new Date().toISOString(),
+            notes: notes,
+          });
+        }
       }
 
       toast.success("Consultation completed!");


### PR DESCRIPTION
handleEndCall queried consultations by expertId alone, then blindly updated snapshot.docs[0] — whichever Firestore returned first. If an expert had multiple consultations, this would mark a random farmer's record as 'completed', potentially corrupting a scheduled consultation before it even started. The Firestore security rules would reject the write if the caller didn't own the document, but the actual caller's consultation would also silently fail.

Fix (two-tier):

1. Direct point-lookup (preferred): if consultation.id is present, use doc(db, 'consultations', consultation.id) for a direct update with no query — no ambiguity, no risk of touching another record.

2. Scoped query fallback: when consultation.id is absent, add where('userId', '==', currentUid) and where('status', '==', 'scheduled') to the query so only the current user's active consultation for that expert is matched.

Also imports auth from firebase lib so the current user's uid is available independently of the userData prop.


Closes  #878


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved telemedicine consultation completion handling to ensure the correct user's consultation is updated when ending a call, preventing potential data integrity issues across user accounts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/889?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->