### PR TITLE
fix(security): block anonymous consultation booking and remove expert phone exposure

### DIFF
--- a/frontend/components/ExpertDirectory.jsx
+++ b/frontend/components/ExpertDirectory.jsx
@@ -208,12 +208,23 @@ function ExpertDirectory({ userData, onClose, onBookConsultation }) {
       return;
     }
 
+    // Require authentication before writing to Firestore.
+    // The Firestore rule enforces userId == request.auth.uid, so writing
+    // userId: "anonymous" would be rejected server-side anyway — but we
+    // catch it here to give the user a clear, actionable error message
+    // instead of a silent failure.
+    const currentUser = auth?.currentUser;
+    if (!currentUser) {
+      toast.error("Please sign in to book a consultation.");
+      return;
+    }
+
     setBookingLoading(true);
 
     try {
       const consultationData = {
-        userId: userData?.uid || "anonymous",
-        userName: userData?.displayName || "Guest Farmer",
+        userId: currentUser.uid,
+        userName: currentUser.displayName || userData?.displayName || "Farmer",
         date: currentDate.toISOString().split("T")[0],
         time: selectedSlot.time,
         notes: bookingNotes,
@@ -434,9 +445,17 @@ function ExpertDirectory({ userData, onClose, onBookConsultation }) {
                   >
                     <Calendar size={16} /> Book Consultation
                   </button>
-                  <a href={`tel:${expert.phone}`} className="call-btn">
-                    <Phone size={16} /> Call
-                  </a>
+                  {/* Phone numbers are not exposed directly — contact is
+                      handled through the consultation booking flow only.
+                      Direct tel: links would bypass the booking system and
+                      expose expert contact details to all authenticated users. */}
+                  <button
+                    className="call-btn"
+                    onClick={() => handleExpertSelect(expert)}
+                    title="Schedule a call via the booking calendar"
+                  >
+                    <Phone size={16} /> Schedule Call
+                  </button>
                 </div>
               </div>
             ))


### PR DESCRIPTION
Two issues fixed in ExpertDirectory.jsx:

1. Anonymous booking (userId: 'anonymous') When userData was null (guest session), the code wrote userId: 'anonymous' to Firestore. The security rule requires userId == request.auth.uid, so the write was rejected server-side, but the component showed no meaningful error — only a console.error and a generic toast. The booking silently failed with no user feedback.

   Fix: check auth.currentUser before attempting the write. If the user is not authenticated, show a clear 'Please sign in to book a consultation' toast and return early. The Firestore write now uses currentUser.uid (the verified Firebase identity) instead of userData?.uid, which could be stale or absent.

2. Expert phone number exposure via tel: links Every expert card rendered <a href='tel:+91...'> exposing the expert's phone number to any authenticated user, bypassing the consultation booking flow and enabling unsolicited direct contact at scale.

   Fix: replace the tel: anchor with a button that opens the booking calendar (same as 'Book Consultation'). Expert contact details are only accessible through the booking flow, not rendered in the DOM.


Closes #879 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Booking requires user authentication before creating a consultation
  * Phone numbers are no longer exposed as direct links; scheduling uses the booking flow

* **New Features**
  * Added "Schedule Call" button to access the booking calendar alongside "Book Consultation"

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/890?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->