### PR TITLE
fix(middleware): remove three duplicate ErrorRecoveryMiddleware registrations

### DIFF
--- a/main.py
+++ b/main.py
@@ -322,12 +322,6 @@ async def verify_role(request: Request, required_roles: list = None, require_all
 
 app.add_middleware(ErrorRecoveryMiddleware)
 
-app.add_middleware(ErrorRecoveryMiddleware)
-
-app.add_middleware(ErrorRecoveryMiddleware)
-
-app.add_middleware(ErrorRecoveryMiddleware)
-
 # --- Models ---
 
 class PredictRequest(BaseModel):


### PR DESCRIPTION
ErrorRecoveryMiddleware was registered four times in main.py. Every request passed through it four times, causing:
  - Error responses potentially triple/quadruple-wrapped in JSON envelopes, breaking frontend error parsing
  - Side effects (logging, metrics) executing four times per request
  - Unnecessary performance overhead under load

Reduced to a single registration. The duplicate lines were likely introduced by repeated copy-paste during refactoring.

Closes #871 