### PR TITLE
fix(data): change seed verifier not_found to unverified with caution warning

### DIFF
--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -456,6 +456,19 @@ async def verify_seed(request: Request, data: SeedVerifyRequest):
 
     await rbac_manager.raise_if_unauthorized(request, [permission_enum.SEEDS_VERIFY], require_all=False)
 
+    # ---------------------------------------------------------------------------
+    # Seed registry — IMPORTANT LIMITATION
+    #
+    # This is a minimal static registry used for demonstration purposes only.
+    # It contains two known codes: one authentic and one blacklisted counterfeit.
+    # Any code NOT in this registry returns status="unverified" with a warning
+    # that the seed could not be verified — NOT a clean "not found" that implies
+    # the seed is safe. Farmers must be told to treat unverified codes with
+    # caution and contact their local agricultural office for confirmation.
+    #
+    # Production deployment should replace this dict with a Firestore/database
+    # lookup against a maintained registry of certified seed batches.
+    # ---------------------------------------------------------------------------
     seed_registry = {
         "FS-RICE-2026-A1": {
             "status": "authentic",
@@ -482,7 +495,22 @@ async def verify_seed(request: Request, data: SeedVerifyRequest):
     entry = seed_registry.get(code)
 
     if entry is None:
-        return {"success": True, "code": code, "status": "not_found"}
+        # Return "unverified" — NOT "not_found".
+        # "Not found" implies the seed is safe but merely unknown.
+        # "Unverified" correctly signals that the code could not be confirmed
+        # as authentic, and the farmer should treat it with caution.
+        return {
+            "success": True,
+            "code": code,
+            "status": "unverified",
+            "warning": (
+                "This seed code was not found in the verified registry. "
+                "This does NOT mean the seed is safe — it may be counterfeit, "
+                "mislabelled, or from an unregistered batch. "
+                "Do not use this seed until you have confirmed its authenticity "
+                "with your local Krishi Vigyan Kendra (KVK) or agricultural office."
+            ),
+        }
 
     if entry["status"] == "invalid":
         return {

--- a/frontend/SeedVerifier.jsx
+++ b/frontend/SeedVerifier.jsx
@@ -71,6 +71,10 @@ const SeedVerifier = ({ onClose }) => {
         if (result.status === "authentic" || result.status === "invalid") {
           setMetadata(result);
         }
+        // "unverified" carries a warning message — store it in metadata too
+        if (result.status === "unverified") {
+          setMetadata(result);
+        }
       } else {
         setError("Verification failed. Please try again.");
         setStatus("idle");
@@ -185,15 +189,30 @@ const SeedVerifier = ({ onClose }) => {
           </div>
         )}
 
-        {status === "not_found" && (
+        {(status === "not_found" || status === "unverified") && (
           <div className="result-card not-found">
             <Search className="result-icon warning" />
-            <h3 className="warning-text">Unregistered</h3>
-            <p>Code not found in our central database.</p>
+            <h3 className="warning-text">⚠️ Cannot Verify — Use With Caution</h3>
+            <p style={{ fontWeight: 600, color: "#b45309" }}>
+              This seed code was <strong>not found</strong> in the verified registry.
+            </p>
+            <p>
+              This does <strong>not</strong> mean the seed is safe. It may be counterfeit,
+              mislabelled, or from an unregistered batch.
+            </p>
+            {metadata?.warning && (
+              <p style={{ fontSize: "0.85rem", color: "#92400e", marginTop: "8px" }}>
+                {metadata.warning}
+              </p>
+            )}
             <div className="data-details">
               <p><span>Batch Code:</span> <strong>{scannedData}</strong></p>
-              <p><span>Status:</span> <strong className="warning-text">NOT FOUND</strong></p>
+              <p><span>Status:</span> <strong className="warning-text">UNVERIFIED</strong></p>
             </div>
+            <p style={{ fontSize: "0.8rem", color: "#6b7280", marginTop: "8px" }}>
+              Contact your local Krishi Vigyan Kendra (KVK) or agricultural office
+              to confirm authenticity before using this seed.
+            </p>
             <button className="action-btn secondary" onClick={handleReset}>Scan Again</button>
           </div>
         )}


### PR DESCRIPTION
The seed registry only contained two entries. Any unrecognised code returned status='not_found' which the frontend displayed as 'Unregistered' — implying the seed was merely unknown rather than potentially dangerous. A farmer scanning a real counterfeit seed bag would see a neutral 'Unregistered' message and might use the seed anyway.

backend/routers/platform.py:
- Change status from 'not_found' to 'unverified' for codes absent from the registry.
- Add a 'warning' field with explicit text: the code could not be verified, it may be counterfeit or mislabelled, and the farmer should not use it until confirmed by their local KVK or agricultural office.
- Add a comment documenting the registry limitation and the requirement to replace the static dict with a real database lookup in production.

frontend/SeedVerifier.jsx:
- Handle both 'not_found' (legacy) and 'unverified' (new) statuses.
- Store metadata for 'unverified' responses so the warning message is available for display.
- Replace the neutral 'Unregistered' heading with a prominent caution warning: 'Cannot Verify — Use With Caution'.
- Display the backend warning message and a KVK contact instruction.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Bug Fixes**
- Enhanced seed verification responses: when a seed code cannot be verified, the system now displays a clear "unverified" status with detailed explanatory text and practical guidance for confirming with local authorities, replacing the previous ambiguous "not found" message
- Improved warning display: unified the verification warning interface to provide consistent, intuitive feedback across all unverifiable seed scenarios with enhanced advisory information shown to users

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/893?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

closes #876