### PR TITLE
fix(data): validate profit and area in BankReports to prevent fabricated signed reports

### DIFF
--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -1,11 +1,41 @@
 """Reports & Logging Router"""
+import re
 from fastapi import APIRouter, Request, HTTPException
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, validator
 from typing import Optional
 import logging
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Validation bounds — intentionally generous to accommodate large commercial
+# farms while still rejecting obviously fabricated figures.
+# ---------------------------------------------------------------------------
+_PROFIT_MAX_INR = 50_000_000   # ₹5 crore per season
+_AREA_MAX_ACRES = 10_000       # 10,000 acres
+
+# Regex that matches a valid Indian-locale number string produced by the
+# frontend (e.g. "50,000" or "1,00,000") or a plain integer string.
+_NUMERIC_RE = re.compile(r"^[\d,]+(\.\d+)?$")
+
+
+def _parse_inr(value: str) -> float:
+    """Strip commas and parse as float. Raises ValueError on invalid input."""
+    cleaned = value.replace(",", "").strip()
+    if not cleaned:
+        raise ValueError("Value is empty")
+    return float(cleaned)
+
+
+def _parse_acres(value: str) -> float:
+    """Extract the numeric part from strings like '5 Acres' or '5.5'."""
+    cleaned = value.lower().replace("acres", "").replace("acre", "").strip()
+    cleaned = cleaned.replace(",", "")
+    if not cleaned:
+        raise ValueError("Value is empty")
+    return float(cleaned)
+
 
 class ClientErrorReport(BaseModel):
     message: str = Field(..., min_length=1, max_length=500)
@@ -19,6 +49,36 @@ class ReportRequest(BaseModel):
     area: str = Field(..., max_length=50)
     profit: str = Field(..., max_length=50)
     season: str = Field(..., max_length=50)
+
+    @validator("profit")
+    def validate_profit(cls, v):
+        try:
+            amount = _parse_inr(v)
+        except (ValueError, TypeError):
+            raise ValueError("Profit must be a valid number (e.g. 50000 or 50,000).")
+        if amount < 0:
+            raise ValueError("Profit cannot be negative.")
+        if amount > _PROFIT_MAX_INR:
+            raise ValueError(
+                f"Profit cannot exceed ₹{_PROFIT_MAX_INR:,} per season. "
+                "If your farm genuinely exceeds this, contact support."
+            )
+        return v
+
+    @validator("area")
+    def validate_area(cls, v):
+        try:
+            acres = _parse_acres(v)
+        except (ValueError, TypeError):
+            raise ValueError("Farm area must be a valid number of acres (e.g. '5 Acres' or '5.5').")
+        if acres <= 0:
+            raise ValueError("Farm area must be greater than zero.")
+        if acres > _AREA_MAX_ACRES:
+            raise ValueError(
+                f"Farm area cannot exceed {_AREA_MAX_ACRES:,} acres. "
+                "If your farm genuinely exceeds this, contact support."
+            )
+        return v
 
 verify_role_fn = None
 get_signing_keys_fn = None

--- a/frontend/BankReports.jsx
+++ b/frontend/BankReports.jsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import { FaFileInvoiceDollar, FaDownload, FaShieldAlt, FaCheckCircle, FaSpinner, FaHistory } from "react-icons/fa";
+import { FaFileInvoiceDollar, FaDownload, FaShieldAlt, FaCheckCircle, FaSpinner, FaHistory, FaExclamationTriangle } from "react-icons/fa";
 import "./BankReports.css";
 import apiClient from "./lib/apiClient";
 import { loadVersionedArray, saveVersionedArray } from "./utils/versionedStorage";
@@ -8,9 +8,17 @@ const REPORTS_STORAGE_KEY = "farm_reports";
 const REPORTS_STORAGE_VERSION = 1;
 const MAX_REPORTS = 50;
 
+// Validation bounds — these are intentionally generous to accommodate
+// large commercial farms while still preventing obviously fabricated figures.
+const PROFIT_MIN_INR = 0;
+const PROFIT_MAX_INR = 50_000_000;   // ₹5 crore — upper bound for a single season
+const AREA_MIN_ACRES = 0.1;
+const AREA_MAX_ACRES = 10_000;       // 10,000 acres — large but plausible
+
 const BankReports = ({ userData }) => {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
+  const [fieldErrors, setFieldErrors] = useState({});
   const [reports, setReports] = useState(() => loadVersionedArray(REPORTS_STORAGE_KEY, {
     version: REPORTS_STORAGE_VERSION,
     fallback: [],
@@ -20,26 +28,68 @@ const BankReports = ({ userData }) => {
   const [formData, setFormData] = useState({
     name: userData?.displayName || "",
     crop: userData?.cropType || "Wheat",
-    area: userData?.area || "5 Acres",
-    profit: "50,000",
+    areaAcres: "",          // numeric acres — replaces free-text "area"
+    profitInr: "",          // numeric INR — replaces free-text "profit"
     season: "Kharif 2026"
   });
 
+  // Validate all fields and return true only if everything is within bounds.
+  const validateForm = () => {
+    const errors = {};
+
+    if (!formData.name.trim()) {
+      errors.name = "Farmer name is required.";
+    }
+
+    const profit = parseFloat(formData.profitInr);
+    if (formData.profitInr === "" || isNaN(profit)) {
+      errors.profitInr = "Please enter a numeric profit amount.";
+    } else if (profit < PROFIT_MIN_INR) {
+      errors.profitInr = "Profit cannot be negative.";
+    } else if (profit > PROFIT_MAX_INR) {
+      errors.profitInr = `Profit cannot exceed ₹${PROFIT_MAX_INR.toLocaleString("en-IN")} per season.`;
+    }
+
+    const area = parseFloat(formData.areaAcres);
+    if (formData.areaAcres === "" || isNaN(area)) {
+      errors.areaAcres = "Please enter a numeric farm area.";
+    } else if (area < AREA_MIN_ACRES) {
+      errors.areaAcres = `Farm area must be at least ${AREA_MIN_ACRES} acres.`;
+    } else if (area > AREA_MAX_ACRES) {
+      errors.areaAcres = `Farm area cannot exceed ${AREA_MAX_ACRES.toLocaleString()} acres.`;
+    }
+
+    if (!formData.season.trim()) {
+      errors.season = "Season is required.";
+    }
+
+    setFieldErrors(errors);
+    return Object.keys(errors).length === 0;
+  };
+
   const handleGenerate = async () => {
-    setLoading(true);
     setError("");
+    if (!validateForm()) return;
+
+    setLoading(true);
     try {
-      // Use apiClient instead of raw fetch() so the Firebase auth token is
-      // automatically injected via the Axios request interceptor in
-      // services/api.js.  The raw fetch() call had no Authorization header,
-      // so every request was rejected with HTTP 401 by verify_role() on the
-      // backend — the feature was silently broken for all users.
-      //
-      // responseType: 'blob' tells Axios to treat the response body as binary
-      // data (the PDF file) rather than trying to parse it as JSON.
+      // Send validated, typed values to the backend.
+      // profit and area are sent as formatted strings matching the backend
+      // ReportRequest schema, but derived from validated numeric inputs.
+      const profit = parseFloat(formData.profitInr);
+      const area = parseFloat(formData.areaAcres);
+
+      const payload = {
+        name: formData.name.trim(),
+        crop: formData.crop,
+        area: `${area.toLocaleString("en-IN")} Acres`,
+        profit: profit.toLocaleString("en-IN"),
+        season: formData.season.trim(),
+      };
+
       const response = await apiClient.post(
         "/api/reports/generate",
-        formData,
+        payload,
         { responseType: "blob" }
       );
 
@@ -53,12 +103,11 @@ const BankReports = ({ userData }) => {
       document.body.removeChild(a);
       window.URL.revokeObjectURL(url);
 
-      // Save to history
       const newReport = {
         id: Math.random().toString(36).substr(2, 9),
         date: new Date().toLocaleDateString(),
         crop: formData.crop,
-        profit: formData.profit,
+        profit: profit.toLocaleString("en-IN"),
         sigId: "CERT-" + Math.random().toString(36).substr(2, 5).toUpperCase()
       };
       const updatedReports = [newReport, ...reports];
@@ -78,6 +127,8 @@ const BankReports = ({ userData }) => {
         setError("You must be logged in to generate a report. Please sign in and try again.");
       } else if (status === 403) {
         setError("Report generation requires Expert or Admin role. Contact your administrator.");
+      } else if (status === 422) {
+        setError("The submitted values were rejected by the server. Please check your inputs.");
       } else if (status === 429) {
         setError("Too many requests. Please wait a moment before trying again.");
       } else {
@@ -87,6 +138,14 @@ const BankReports = ({ userData }) => {
       setLoading(false);
     }
   };
+
+  const field = (key, value, onChange) => ({
+    value,
+    onChange: (e) => {
+      onChange(e);
+      if (fieldErrors[key]) setFieldErrors(prev => ({ ...prev, [key]: undefined }));
+    },
+  });
 
   return (
     <div className="reports-container">
@@ -102,15 +161,31 @@ const BankReports = ({ userData }) => {
             <FaShieldAlt />
             <h2>Certified Report Details</h2>
           </div>
-          
+
+          {/* Disclaimer — shown before the form so users understand the limitation */}
+          <div className="report-disclaimer" style={{
+            padding: "10px 14px", marginBottom: "16px",
+            background: "#fffbeb", border: "1px solid #fde68a",
+            borderRadius: "8px", fontSize: "0.82rem", color: "#92400e",
+            display: "flex", gap: "8px", alignItems: "flex-start"
+          }}>
+            <FaExclamationTriangle style={{ marginTop: "2px", flexShrink: 0 }} />
+            <span>
+              <strong>Important:</strong> The cryptographic signature on this report confirms
+              the document has not been altered after generation. It does <strong>not</strong> independently
+              verify the accuracy of the figures you enter. Enter only accurate, verifiable data.
+            </span>
+          </div>
+
           <div className="form-group">
             <label>Farmer Name (As per Bank A/C)</label>
-            <input 
-              type="text" 
-              value={formData.name} 
-              onChange={(e) => setFormData({...formData, name: e.target.value})}
+            <input
+              type="text"
+              {...field("name", formData.name, (e) => setFormData({...formData, name: e.target.value}))}
               placeholder="e.g. Rajesh Kumar"
+              maxLength={100}
             />
+            {fieldErrors.name && <p className="field-error">{fieldErrors.name}</p>}
           </div>
 
           <div className="form-row">
@@ -124,46 +199,55 @@ const BankReports = ({ userData }) => {
               </select>
             </div>
             <div className="form-group">
-              <label>Farm Area</label>
-              <input 
-                type="text" 
-                value={formData.area} 
-                onChange={(e) => setFormData({...formData, area: e.target.value})}
-                placeholder="e.g. 5 Acres"
+              <label>Farm Area (Acres)</label>
+              <input
+                type="number"
+                {...field("areaAcres", formData.areaAcres, (e) => setFormData({...formData, areaAcres: e.target.value}))}
+                placeholder={`e.g. 5  (max ${AREA_MAX_ACRES.toLocaleString()})`}
+                min={AREA_MIN_ACRES}
+                max={AREA_MAX_ACRES}
+                step="0.1"
               />
+              {fieldErrors.areaAcres && <p className="field-error">{fieldErrors.areaAcres}</p>}
             </div>
           </div>
 
           <div className="form-row">
             <div className="form-group">
               <label>Estimated Season Profit (₹)</label>
-              <input 
-                type="text" 
-                value={formData.profit} 
-                onChange={(e) => setFormData({...formData, profit: e.target.value})}
+              <input
+                type="number"
+                {...field("profitInr", formData.profitInr, (e) => setFormData({...formData, profitInr: e.target.value}))}
+                placeholder={`e.g. 50000  (max ₹${PROFIT_MAX_INR.toLocaleString("en-IN")})`}
+                min={PROFIT_MIN_INR}
+                max={PROFIT_MAX_INR}
+                step="1"
               />
+              {fieldErrors.profitInr && <p className="field-error">{fieldErrors.profitInr}</p>}
             </div>
             <div className="form-group">
               <label>Current Season</label>
-              <input 
-                type="text" 
-                value={formData.season} 
-                onChange={(e) => setFormData({...formData, season: e.target.value})}
+              <input
+                type="text"
+                {...field("season", formData.season, (e) => setFormData({...formData, season: e.target.value}))}
+                placeholder="e.g. Kharif 2026"
+                maxLength={50}
               />
+              {fieldErrors.season && <p className="field-error">{fieldErrors.season}</p>}
             </div>
           </div>
 
           {error && <div className="error-msg">{error}</div>}
 
-          <button 
-            className={`generate-btn ${loading ? 'loading' : ''}`} 
+          <button
+            className={`generate-btn ${loading ? 'loading' : ''}`}
             onClick={handleGenerate}
             disabled={loading}
           >
             {loading ? <FaSpinner className="spin" /> : <FaDownload />}
             {loading ? "Generating Signature..." : "Download Certified Report"}
           </button>
-          
+
           <p className="security-note">
             <FaCheckCircle /> This report will be cryptographically signed and cannot be edited after generation.
           </p>


### PR DESCRIPTION
The profit field was a free-text input with no validation. A farmer could type any value (e.g. '999999999') which was embedded directly into a cryptographically signed PDF described as 'bank-ready'. The signature proves the document was not altered after generation, but it does not verify the accuracy of the figures — so a signed report with a fabricated profit figure could be presented to a bank as a certified financial document.

The area field had the same issue: it defaulted to userData.area which is a free-text profile field.

Two-layer fix:

frontend/BankReports.jsx:
- profit: changed from type='text' to type='number' with min=0 and max=50,000,000 (₹5 crore — generous upper bound for a single season)
- area: changed from free-text 'e.g. 5 Acres' to type='number' in acres with min=0.1 and max=10,000
- validateForm() runs before submission and shows inline field errors for out-of-range or non-numeric values
- Added a disclaimer banner explaining that the signature confirms document integrity, not the accuracy of the entered figures
- Added HTTP 422 error handling for server-side validation rejections

backend/routers/reports.py:
- Added @validator('profit') to ReportRequest: strips commas, parses as float, rejects negative values and values above ₹5 crore
- Added @validator('area') to ReportRequest: strips 'Acres' suffix, parses as float, rejects zero/negative and values above 10,000 acres
- Both validators return HTTP 422 Unprocessable Entity on failure, which the frontend now handles with a specific error message

Closes #904 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added input validation for farm area (acres) and season profit with configurable limits
  * Numeric input fields with bounds enforcement for improved data accuracy
  * Server-side validation with user-friendly error messages for invalid formats or out-of-range values
  * Enhanced error handling for validation failures with per-field feedback

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/937?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->