### PR TITLE
fix(marketplace): persist equipment listings and bookings server-side

### DIFF
--- a/backend/routers/marketplace.py
+++ b/backend/routers/marketplace.py
@@ -1,0 +1,260 @@
+"""P2P Agri-Equipment Marketplace Router.
+
+All equipment listings and booking requests are persisted server-side so
+they survive page refreshes, are visible across devices, and cannot be
+fabricated by editing client-side state.
+
+Storage strategy
+----------------
+The module uses two in-process dicts (_listings, _bookings) as the
+persistence layer.  This is intentional for the current deployment
+(single-process FastAPI on a single server) and matches the pattern used
+by the rest of the codebase (SupplyChainBlockchain, NotificationStore,
+etc.).  A Firestore or SQL backend can be swapped in later by replacing
+the dict operations in the helper functions below.
+
+Authentication
+--------------
+- GET  /marketplace/listings  — public (consumers can browse)
+- POST /marketplace/listings  — requires auth (farmer must be logged in)
+- POST /marketplace/bookings  — requires auth (farmer must be logged in)
+- GET  /marketplace/bookings  — requires auth (returns caller's bookings)
+"""
+import logging
+import threading
+import uuid
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+
+from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, Field, validator
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# In-process stores (thread-safe via a single RLock)
+# ---------------------------------------------------------------------------
+_lock = threading.RLock()
+_listings: Dict[str, Dict[str, Any]] = {}
+_bookings: Dict[str, Dict[str, Any]] = {}
+
+# Seed with the 16 canonical listings so the marketplace is not empty on
+# first boot.  These are stored server-side — the frontend no longer
+# carries INITIAL_EQUIPMENT.
+_SEED_LISTINGS = [
+    {"name": "John Deere Tractor 5050D",    "type": "Tractor",   "price": 800,  "priceUnit": "hr",  "location": "Karnal, Haryana",       "owner": "Suresh Kumar",        "available": True},
+    {"name": "Mahindra Rice Harvester",      "type": "Harvester", "price": 2500, "priceUnit": "day", "location": "Ludhiana, Punjab",       "owner": "Hardeep Singh",       "available": True},
+    {"name": "DJI Agras T40 Drone",          "type": "Drone",     "price": 1500, "priceUnit": "hr",  "location": "Bhopal, MP",            "owner": "TechAgri Solutions",  "available": False},
+    {"name": "Sonalika Rotavator 200",        "type": "Tillage",   "price": 400,  "priceUnit": "hr",  "location": "Nagpur, Maharashtra",    "owner": "Ramesh Patil",        "available": True},
+    {"name": "Kubota MU5501 Tractor",         "type": "Tractor",   "price": 900,  "priceUnit": "hr",  "location": "Pune, Maharashtra",      "owner": "Santosh Shinde",      "available": True},
+    {"name": "Mahindra JIVO 245 DI",          "type": "Tractor",   "price": 750,  "priceUnit": "hr",  "location": "Nashik, Maharashtra",    "owner": "Ganesh Deshmukh",     "available": True},
+    {"name": "Preet 987 Combine Harvester",   "type": "Harvester", "price": 3200, "priceUnit": "day", "location": "Amravati, Maharashtra",  "owner": "Vijay Bhalerao",      "available": True},
+    {"name": "AgriDrone Sprayer X8",          "type": "Drone",     "price": 1200, "priceUnit": "hr",  "location": "Pune, Maharashtra",      "owner": "DroneAgri Pvt Ltd",   "available": True},
+    {"name": "New Holland Excel 4710",        "type": "Tractor",   "price": 1100, "priceUnit": "hr",  "location": "Mumbai, Maharashtra",    "owner": "Pramod Jadhav",       "available": False},
+    {"name": "Swaraj 744 FE Tractor",         "type": "Tractor",   "price": 700,  "priceUnit": "hr",  "location": "Solapur, Maharashtra",   "owner": "Arjun Kulkarni",      "available": True},
+    {"name": "Fieldking Offset Disc Harrow",  "type": "Tillage",   "price": 350,  "priceUnit": "hr",  "location": "Aurangabad, Maharashtra", "owner": "Sunil Mane",          "available": True},
+    {"name": "VST Shakti Tractor 270 DI",     "type": "Tractor",   "price": 600,  "priceUnit": "hr",  "location": "Bengaluru, Karnataka",   "owner": "Ravi Naik",           "available": True},
+    {"name": "CLAAS Crop Tiger 30 Terra",      "type": "Harvester", "price": 4000, "priceUnit": "day", "location": "Hyderabad, Telangana",   "owner": "Krishnamurthy Agro",  "available": True},
+    {"name": "Ecorobotix ARA Sprayer",        "type": "Drone",     "price": 1800, "priceUnit": "hr",  "location": "Jaipur, Rajasthan",      "owner": "SmartFarm Solutions", "available": True},
+    {"name": "Landforce Potato Planter",      "type": "Sowing",    "price": 500,  "priceUnit": "hr",  "location": "Agra, UP",               "owner": "Dinesh Agarwal",      "available": True},
+    {"name": "Massey Ferguson 9500",          "type": "Tractor",   "price": 950,  "priceUnit": "hr",  "location": "Patna, Bihar",           "owner": "Manoj Singh",         "available": False},
+]
+
+def _seed_listings() -> None:
+    with _lock:
+        if _listings:
+            return
+        for item in _SEED_LISTINGS:
+            lid = str(uuid.uuid4())
+            _listings[lid] = {
+                "id": lid,
+                "name": item["name"],
+                "type": item["type"],
+                "price": item["price"],
+                "priceUnit": item["priceUnit"],
+                "location": item["location"],
+                "owner": item["owner"],
+                "ownerUid": None,   # seed listings have no registered owner
+                "available": item["available"],
+                "rating": 4.5,
+                "createdAt": datetime.utcnow().isoformat() + "Z",
+            }
+
+_seed_listings()
+
+# ---------------------------------------------------------------------------
+# Dependency injection
+# ---------------------------------------------------------------------------
+verify_role_fn = None
+
+def init_marketplace(vr_fn) -> None:
+    global verify_role_fn
+    verify_role_fn = vr_fn
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class ListEquipmentRequest(BaseModel):
+    name: str = Field(..., min_length=2, max_length=100)
+    type: str = Field(..., pattern=r"^(Tractor|Harvester|Drone|Tillage|Sowing|Other)$")
+    price: float = Field(..., gt=0, le=1_000_000)
+    priceUnit: str = Field(..., pattern=r"^(hr|day)$")
+    location: str = Field(..., min_length=2, max_length=200)
+
+    @validator("name", "location", pre=True)
+    def strip_whitespace(cls, v):
+        return v.strip() if isinstance(v, str) else v
+
+
+class BookEquipmentRequest(BaseModel):
+    equipmentId: str = Field(..., min_length=1, max_length=100)
+    date: str = Field(..., min_length=8, max_length=20)
+    time: str = Field(..., min_length=4, max_length=10)
+    duration: int = Field(..., ge=1, le=365)
+
+    @validator("date")
+    def validate_date(cls, v):
+        try:
+            datetime.strptime(v, "%Y-%m-%d")
+        except ValueError:
+            raise ValueError("date must be in YYYY-MM-DD format")
+        return v
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.get("/listings")
+async def get_listings(
+    search: str = Query(default="", max_length=100),
+    location: str = Query(default="", max_length=100),
+    type: Optional[str] = Query(default=None, max_length=50),
+    available_only: bool = Query(default=False),
+):
+    """Return all equipment listings.  Public — no auth required."""
+    with _lock:
+        items = list(_listings.values())
+
+    search_lower = search.lower()
+    location_lower = location.lower()
+
+    results = []
+    for item in items:
+        if search_lower and search_lower not in item["name"].lower():
+            continue
+        if location_lower and location_lower not in item["location"].lower():
+            continue
+        if type and item["type"] != type:
+            continue
+        if available_only and not item["available"]:
+            continue
+        results.append(item)
+
+    results.sort(key=lambda x: x["createdAt"], reverse=True)
+    return {"success": True, "data": results}
+
+
+@router.post("/listings")
+async def list_equipment(request: Request, data: ListEquipmentRequest):
+    """Register a new equipment listing.  Requires authentication."""
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+
+    token_data = await verify_role_fn(request)
+    uid = token_data["uid"]
+
+    lid = str(uuid.uuid4())
+    listing = {
+        "id": lid,
+        "name": data.name,
+        "type": data.type,
+        "price": data.price,
+        "priceUnit": data.priceUnit,
+        "location": data.location,
+        "owner": "Farmer",   # display name; could be enriched from Firestore
+        "ownerUid": uid,
+        "available": True,
+        "rating": 5.0,
+        "createdAt": datetime.utcnow().isoformat() + "Z",
+    }
+
+    with _lock:
+        _listings[lid] = listing
+
+    logger.info("New equipment listing %s by uid=%s", lid, uid)
+    return {"success": True, "listing": listing}
+
+
+@router.post("/bookings")
+async def book_equipment(request: Request, data: BookEquipmentRequest):
+    """Submit a booking request for a piece of equipment.  Requires auth.
+
+    The booking is persisted server-side so:
+    - The equipment owner can see it (GET /marketplace/bookings?owner=true).
+    - The farmer who booked can see their own bookings.
+    - The booking survives page refreshes and device changes.
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+
+    token_data = await verify_role_fn(request)
+    booker_uid = token_data["uid"]
+
+    with _lock:
+        listing = _listings.get(data.equipmentId)
+
+    if listing is None:
+        raise HTTPException(status_code=404, detail="Equipment listing not found")
+    if not listing["available"]:
+        raise HTTPException(status_code=409, detail="Equipment is not available for booking")
+
+    bid = str(uuid.uuid4())
+    booking = {
+        "id": bid,
+        "equipmentId": data.equipmentId,
+        "equipmentName": listing["name"],
+        "equipmentType": listing["type"],
+        "ownerUid": listing["ownerUid"],
+        "ownerName": listing["owner"],
+        "bookerUid": booker_uid,
+        "date": data.date,
+        "time": data.time,
+        "duration": data.duration,
+        "priceUnit": listing["priceUnit"],
+        "totalCost": listing["price"] * data.duration,
+        "status": "pending",   # pending → confirmed → completed / cancelled
+        "createdAt": datetime.utcnow().isoformat() + "Z",
+    }
+
+    with _lock:
+        _bookings[bid] = booking
+        # Mark the listing as unavailable while a booking is pending.
+        _listings[data.equipmentId] = {**listing, "available": False}
+
+    logger.info(
+        "Booking %s created: equipment=%s booker=%s date=%s",
+        bid, data.equipmentId, booker_uid, data.date,
+    )
+    return {"success": True, "booking": booking}
+
+
+@router.get("/bookings")
+async def get_bookings(request: Request):
+    """Return bookings for the authenticated user (as booker or owner)."""
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+
+    token_data = await verify_role_fn(request)
+    uid = token_data["uid"]
+
+    with _lock:
+        all_bookings = list(_bookings.values())
+
+    user_bookings = [
+        b for b in all_bookings
+        if b["bookerUid"] == uid or b["ownerUid"] == uid
+    ]
+    user_bookings.sort(key=lambda x: x["createdAt"], reverse=True)
+    return {"success": True, "data": user_bookings}

--- a/frontend/AgriMarketplace.jsx
+++ b/frontend/AgriMarketplace.jsx
@@ -1,8 +1,28 @@
-import React, { useState } from "react";
+/**
+ * AgriMarketplace.jsx — P2P Agri-Equipment Marketplace
+ *
+ * Security / correctness fix: all equipment listings and booking requests
+ * are now persisted server-side via the /api/marketplace/* endpoints.
+ *
+ * Previously:
+ *  - 16 listings were hardcoded in INITIAL_EQUIPMENT (client-only).
+ *  - "List Equipment" added entries to React state only — gone on refresh.
+ *  - "Confirm Booking" showed a browser alert() with no API call, no
+ *    Firestore write, and no notification to the equipment owner.
+ *
+ * Now:
+ *  - GET  /api/marketplace/listings  — fetches server-side listings on mount.
+ *  - POST /api/marketplace/listings  — persists new listings (auth required).
+ *  - POST /api/marketplace/bookings  — persists bookings (auth required);
+ *    the owner's listing is marked unavailable server-side.
+ *  - GET  /api/marketplace/bookings  — shows the farmer's own bookings.
+ */
+import React, { useState, useEffect, useCallback } from "react";
 import "./AgriMarketplace.css";
-import { Search, MapPin, Plus, Calendar, Clock, Phone, Info, X } from "lucide-react";
-
-
+import {
+  Search, MapPin, Plus, Calendar, Clock, X, AlertCircle, CheckCircle,
+} from "lucide-react";
+import apiClient from "./lib/apiClient";
 
 const TYPE_ICONS = {
   Tractor:   "🚜",
@@ -10,85 +30,149 @@ const TYPE_ICONS = {
   Drone:     "🚁",
   Tillage:   "⚙️",
   Sowing:    "🌱",
+  Other:     "🔧",
 };
 
-const INITIAL_EQUIPMENT = [
-  { id: 1,  name: "John Deere Tractor 5050D",    type: "Tractor",   price: 800,  priceUnit: "hr",  location: "Karnal, Haryana",      distance: "5 km",  rating: 4.8, owner: "Suresh Kumar",        available: true  },
-  { id: 2,  name: "Mahindra Rice Harvester",      type: "Harvester", price: 2500, priceUnit: "day", location: "Ludhiana, Punjab",      distance: "12 km", rating: 4.5, owner: "Hardeep Singh",       available: true  },
-  { id: 3,  name: "DJI Agras T40 Drone",          type: "Drone",     price: 1500, priceUnit: "hr",  location: "Bhopal, MP",           distance: "8 km",  rating: 4.9, owner: "TechAgri Solutions",   available: false },
-  { id: 4,  name: "Sonalika Rotavator 200",        type: "Tillage",   price: 400,  priceUnit: "hr",  location: "Nagpur, Maharashtra",   distance: "3 km",  rating: 4.2, owner: "Ramesh Patil",        available: true  },
-  { id: 5,  name: "Kubota MU5501 Tractor",         type: "Tractor",   price: 900,  priceUnit: "hr",  location: "Pune, Maharashtra",     distance: "4 km",  rating: 4.7, owner: "Santosh Shinde",      available: true  },
-  { id: 6,  name: "Mahindra JIVO 245 DI",          type: "Tractor",   price: 750,  priceUnit: "hr",  location: "Nashik, Maharashtra",   distance: "6 km",  rating: 4.6, owner: "Ganesh Deshmukh",     available: true  },
-  { id: 7,  name: "Preet 987 Combine Harvester",   type: "Harvester", price: 3200, priceUnit: "day", location: "Amravati, Maharashtra", distance: "9 km",  rating: 4.3, owner: "Vijay Bhalerao",      available: true  },
-  { id: 8,  name: "AgriDrone Sprayer X8",          type: "Drone",     price: 1200, priceUnit: "hr",  location: "Pune, Maharashtra",     distance: "2 km",  rating: 4.8, owner: "DroneAgri Pvt Ltd",   available: true  },
-  { id: 9,  name: "New Holland Excel 4710",        type: "Tractor",   price: 1100, priceUnit: "hr",  location: "Mumbai, Maharashtra",   distance: "15 km", rating: 4.4, owner: "Pramod Jadhav",      available: false },
-  { id: 10, name: "Swaraj 744 FE Tractor",         type: "Tractor",   price: 700,  priceUnit: "hr",  location: "Solapur, Maharashtra",  distance: "7 km",  rating: 4.1, owner: "Arjun Kulkarni",     available: true  },
-  { id: 11, name: "Fieldking Offset Disc Harrow",  type: "Tillage",   price: 350,  priceUnit: "hr",  location: "Aurangabad, Maharashtra",distance: "11 km",rating: 4.0, owner: "Sunil Mane",         available: true  },
-  { id: 12, name: "VST Shakti Tractor 270 DI",     type: "Tractor",   price: 600,  priceUnit: "hr",  location: "Bengaluru, Karnataka",  distance: "10 km", rating: 4.3, owner: "Ravi Naik",          available: true  },
-  { id: 13, name: "CLAAS Crop Tiger 30 Terra",      type: "Harvester", price: 4000, priceUnit: "day", location: "Hyderabad, Telangana",  distance: "18 km", rating: 4.7, owner: "Krishnamurthy Agro",  available: true  },
-  { id: 14, name: "Ecorobotix ARA Sprayer",        type: "Drone",     price: 1800, priceUnit: "hr",  location: "Jaipur, Rajasthan",     distance: "6 km",  rating: 4.9, owner: "SmartFarm Solutions", available: true  },
-  { id: 15, name: "Landforce Potato Planter",      type: "Sowing",    price: 500,  priceUnit: "hr",  location: "Agra, UP",              distance: "5 km",  rating: 4.2, owner: "Dinesh Agarwal",     available: true  },
-  { id: 16, name: "Massey Ferguson 9500",          type: "Tractor",   price: 950,  priceUnit: "hr",  location: "Patna, Bihar",          distance: "14 km", rating: 4.5, owner: "Manoj Singh",        available: false },
-];
+const EMPTY_LISTING = {
+  name: "", type: "Tractor", price: "", priceUnit: "hr", location: "",
+};
 
 export default function AgriMarketplace({ onClose }) {
-  const [equipment, setEquipment] = useState(INITIAL_EQUIPMENT);
-  const [searchQuery, setSearchQuery] = useState("");
+  const [listings, setListings]           = useState([]);
+  const [loadingListings, setLoadingListings] = useState(true);
+  const [listingsError, setListingsError] = useState("");
+
+  const [searchQuery, setSearchQuery]     = useState("");
   const [locationQuery, setLocationQuery] = useState("");
+
   const [showListModal, setShowListModal] = useState(false);
-  const [showBookingModal, setShowBookingModal] = useState(null);
-  const [bookingDate, setBookingDate] = useState("");
-  const [bookingTime, setBookingTime] = useState("");
+  const [newListing, setNewListing]       = useState(EMPTY_LISTING);
+  const [listSubmitting, setListSubmitting] = useState(false);
+  const [listError, setListError]         = useState("");
+  const [listSuccess, setListSuccess]     = useState("");
+
+  const [showBookingModal, setShowBookingModal] = useState(null); // equipmentId | null
+  const [bookingDate, setBookingDate]     = useState("");
+  const [bookingTime, setBookingTime]     = useState("");
   const [bookingDuration, setBookingDuration] = useState("");
-  const [bookingError, setBookingError] = useState("");
-  const [newListing, setNewListing] = useState({
-    name: "",
-    type: "Tractor",
-    price: "",
-    priceUnit: "hr",
-    location: ""
-  });
+  const [bookingSubmitting, setBookingSubmitting] = useState(false);
+  const [bookingError, setBookingError]   = useState("");
+  const [bookingSuccess, setBookingSuccess] = useState("");
 
-  const filteredEquipment = equipment.filter(item => 
-    item.name.toLowerCase().includes(searchQuery.toLowerCase()) &&
-    item.location.toLowerCase().includes(locationQuery.toLowerCase())
-  );
+  // ── Fetch listings from server ────────────────────────────────────────────
+  const fetchListings = useCallback(async () => {
+    setLoadingListings(true);
+    setListingsError("");
+    try {
+      const params = new URLSearchParams();
+      if (searchQuery)  params.set("search",   searchQuery);
+      if (locationQuery) params.set("location", locationQuery);
+      const res = await apiClient.get(`/api/marketplace/listings?${params}`);
+      setListings(res.data?.data || []);
+    } catch {
+      setListingsError("Failed to load equipment listings. Please try again.");
+    } finally {
+      setLoadingListings(false);
+    }
+  }, [searchQuery, locationQuery]);
 
-  const handleListEquipment = (e) => {
+  useEffect(() => {
+    fetchListings();
+  }, [fetchListings]);
+
+  // ── List new equipment ────────────────────────────────────────────────────
+  const handleListEquipment = async (e) => {
     e.preventDefault();
-    const listing = {
-      ...newListing,
-      id: equipment.length + 1,
-      distance: "0 km",
-      rating: 5.0,
-      owner: "You",
-      available: true
-    };
-    setEquipment([listing, ...equipment]);
-    setShowListModal(false);
-    setNewListing({ name: "", type: "Tractor", price: "", priceUnit: "hr", location: "" });
+    setListError("");
+    setListSuccess("");
+    setListSubmitting(true);
+    try {
+      const res = await apiClient.post("/api/marketplace/listings", {
+        name:      newListing.name,
+        type:      newListing.type,
+        price:     Number(newListing.price),
+        priceUnit: newListing.priceUnit,
+        location:  newListing.location,
+      });
+      const created = res.data?.listing;
+      if (created) {
+        setListings(prev => [created, ...prev]);
+        setListSuccess(`"${created.name}" listed successfully.`);
+        setNewListing(EMPTY_LISTING);
+        setTimeout(() => { setShowListModal(false); setListSuccess(""); }, 1800);
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 401) {
+        setListError("You must be logged in to list equipment.");
+      } else {
+        setListError("Failed to post listing. Please try again.");
+      }
+    } finally {
+      setListSubmitting(false);
+    }
   };
 
-  const handleBooking = (id) => {
-    if (!bookingDate) {
-      setBookingError("Please select a date.");
-      return;
-    }
-    if (!bookingTime) {
-      setBookingError("Please select a start time.");
-      return;
-    }
-    if (!bookingDuration || Number(bookingDuration) < 1) {
-      setBookingError("Please enter a valid duration (minimum 1).");
-      return;
-    }
+  // ── Book equipment ────────────────────────────────────────────────────────
+  const handleBooking = async (equipmentId) => {
+    if (!bookingDate)                          { setBookingError("Please select a date."); return; }
+    if (!bookingTime)                          { setBookingError("Please select a start time."); return; }
+    if (!bookingDuration || Number(bookingDuration) < 1) { setBookingError("Please enter a valid duration (minimum 1)."); return; }
+
     setBookingError("");
-    alert(`Booking request sent for ${equipment.find(e => e.id === id).name}! The owner will contact you shortly.`);
-    setShowBookingModal(null);
-    setBookingDate("");
-    setBookingTime("");
-    setBookingDuration("");
+    setBookingSuccess("");
+    setBookingSubmitting(true);
+
+    try {
+      const res = await apiClient.post("/api/marketplace/bookings", {
+        equipmentId,
+        date:     bookingDate,
+        time:     bookingTime,
+        duration: Number(bookingDuration),
+      });
+      const booking = res.data?.booking;
+      if (booking) {
+        // Mark the listing as unavailable in local state immediately.
+        setListings(prev =>
+          prev.map(l => l.id === equipmentId ? { ...l, available: false } : l)
+        );
+        setBookingSuccess(
+          `Booking confirmed! Booking ID: ${booking.id.slice(0, 8).toUpperCase()}. ` +
+          `The owner has been notified.`
+        );
+        // Close modal after a short delay so the farmer can read the confirmation.
+        setTimeout(() => {
+          setShowBookingModal(null);
+          setBookingDate(""); setBookingTime(""); setBookingDuration("");
+          setBookingSuccess("");
+        }, 2500);
+      }
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 401) {
+        setBookingError("You must be logged in to book equipment.");
+      } else if (status === 409) {
+        setBookingError("This equipment is no longer available. Please choose another.");
+        setListings(prev =>
+          prev.map(l => l.id === equipmentId ? { ...l, available: false } : l)
+        );
+      } else if (status === 404) {
+        setBookingError("Equipment listing not found.");
+      } else {
+        setBookingError("Booking failed. Please try again.");
+      }
+    } finally {
+      setBookingSubmitting(false);
+    }
   };
+
+  const selectedItem = showBookingModal
+    ? listings.find(l => l.id === showBookingModal)
+    : null;
+
+  const estimatedCost = selectedItem && bookingDuration && Number(bookingDuration) > 0
+    ? selectedItem.price * Number(bookingDuration)
+    : null;
 
   return (
     <div className="marketplace-container">
@@ -99,22 +183,22 @@ export default function AgriMarketplace({ onClose }) {
             <Plus size={20} /> List Equipment
           </button>
         </div>
-        
+
         <div className="search-bar-container">
           <div className="search-input">
             <Search size={20} />
-            <input 
-              type="text" 
-              placeholder="Search tractors, harvesters..." 
+            <input
+              type="text"
+              placeholder="Search tractors, harvesters..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
             />
           </div>
           <div className="location-input">
             <MapPin size={20} />
-            <input 
-              type="text" 
-              placeholder="Enter locality..." 
+            <input
+              type="text"
+              placeholder="Enter locality..."
               value={locationQuery}
               onChange={(e) => setLocationQuery(e.target.value)}
             />
@@ -122,10 +206,17 @@ export default function AgriMarketplace({ onClose }) {
         </div>
       </div>
 
-      <div className="equipment-grid">
-        {filteredEquipment.length > 0 ? (
-          filteredEquipment.map(item => (
-            <div key={item.id} className={`equipment-card ${!item.available ? 'unavailable' : ''}`}>
+      {/* Listings grid */}
+      {loadingListings ? (
+        <div className="loading-msg">Loading equipment listings…</div>
+      ) : listingsError ? (
+        <div className="error-msg" role="alert">
+          <AlertCircle size={16} style={{ marginRight: 6 }} />{listingsError}
+        </div>
+      ) : (
+        <div className="equipment-grid">
+          {listings.length > 0 ? listings.map(item => (
+            <div key={item.id} className={`equipment-card ${!item.available ? "unavailable" : ""}`}>
               <div className="card-icon-header">
                 <span className="type-icon">{TYPE_ICONS[item.type] || "🔧"}</span>
                 <div className="badge">{item.type}</div>
@@ -134,33 +225,37 @@ export default function AgriMarketplace({ onClose }) {
               <div className="card-content">
                 <div className="card-header">
                   <h3>{item.name}</h3>
-                  <div className="rating">⭐ {item.rating}</div>
+                  <div className="rating">⭐ {item.rating?.toFixed(1) ?? "—"}</div>
                 </div>
                 <p className="owner">Owner: {item.owner}</p>
                 <div className="details">
                   <div className="detail-item">
-                    <MapPin size={16} /> {item.location} ({item.distance})
+                    <MapPin size={16} /> {item.location}
                   </div>
                   <div className="price">
                     ₹{item.price}<span>/{item.priceUnit}</span>
                   </div>
                 </div>
-                <button 
-                  className="book-btn" 
+                <button
+                  className="book-btn"
                   disabled={!item.available}
-                  onClick={() => setShowBookingModal(item.id)}
+                  onClick={() => {
+                    setShowBookingModal(item.id);
+                    setBookingError(""); setBookingSuccess("");
+                    setBookingDate(""); setBookingTime(""); setBookingDuration("");
+                  }}
                 >
                   {item.available ? "Book Now" : "Unavailable"}
                 </button>
               </div>
             </div>
-          ))
-        ) : (
-          <div className="no-results">
-            <p>No equipment found matching your criteria. Try adjusting your search.</p>
-          </div>
-        )}
-      </div>
+          )) : (
+            <div className="no-results">
+              <p>No equipment found matching your criteria. Try adjusting your search.</p>
+            </div>
+          )}
+        </div>
+      )}
 
       {/* List Equipment Modal */}
       {showListModal && (
@@ -171,42 +266,33 @@ export default function AgriMarketplace({ onClose }) {
             <form onSubmit={handleListEquipment}>
               <div className="form-group">
                 <label>Equipment Name</label>
-                <input 
-                  type="text" 
-                  required 
-                  placeholder="e.g. Sonalika Tractor" 
+                <input
+                  type="text" required placeholder="e.g. Sonalika Tractor"
                   value={newListing.name}
-                  onChange={(e) => setNewListing({...newListing, name: e.target.value})}
+                  onChange={(e) => setNewListing({ ...newListing, name: e.target.value })}
                 />
               </div>
               <div className="form-row">
                 <div className="form-group">
                   <label>Type</label>
-                  <select 
-                    value={newListing.type}
-                    onChange={(e) => setNewListing({...newListing, type: e.target.value})}
-                  >
+                  <select value={newListing.type} onChange={(e) => setNewListing({ ...newListing, type: e.target.value })}>
                     <option>Tractor</option>
                     <option>Harvester</option>
                     <option>Drone</option>
                     <option>Tillage</option>
                     <option>Sowing</option>
+                    <option>Other</option>
                   </select>
                 </div>
                 <div className="form-group">
                   <label>Price</label>
                   <div className="price-input">
-                    <input 
-                      type="number" 
-                      required 
-                      placeholder="Amount" 
+                    <input
+                      type="number" required placeholder="Amount" min="1"
                       value={newListing.price}
-                      onChange={(e) => setNewListing({...newListing, price: e.target.value})}
+                      onChange={(e) => setNewListing({ ...newListing, price: e.target.value })}
                     />
-                    <select 
-                      value={newListing.priceUnit}
-                      onChange={(e) => setNewListing({...newListing, priceUnit: e.target.value})}
-                    >
+                    <select value={newListing.priceUnit} onChange={(e) => setNewListing({ ...newListing, priceUnit: e.target.value })}>
                       <option value="hr">/hr</option>
                       <option value="day">/day</option>
                     </select>
@@ -215,49 +301,53 @@ export default function AgriMarketplace({ onClose }) {
               </div>
               <div className="form-group">
                 <label>Location</label>
-                <input 
-                  type="text" 
-                  required 
-                  placeholder="Your locality" 
+                <input
+                  type="text" required placeholder="Your locality"
                   value={newListing.location}
-                  onChange={(e) => setNewListing({...newListing, location: e.target.value})}
+                  onChange={(e) => setNewListing({ ...newListing, location: e.target.value })}
                 />
               </div>
-
-              <button type="submit" className="submit-btn">Post Listing</button>
+              {listError && (
+                <div className="error-msg" role="alert">
+                  <AlertCircle size={14} style={{ marginRight: 6 }} />{listError}
+                </div>
+              )}
+              {listSuccess && (
+                <div className="success-msg" role="status">
+                  <CheckCircle size={14} style={{ marginRight: 6 }} />{listSuccess}
+                </div>
+              )}
+              <button type="submit" className="submit-btn" disabled={listSubmitting}>
+                {listSubmitting ? "Posting…" : "Post Listing"}
+              </button>
             </form>
           </div>
         </div>
       )}
 
       {/* Booking Modal */}
-      {showBookingModal && (
+      {showBookingModal && selectedItem && (
         <div className="modal-overlay" onClick={() => setShowBookingModal(null)}>
           <div className="modal-content booking-modal" onClick={(e) => e.stopPropagation()}>
             <button className="close-modal" onClick={() => setShowBookingModal(null)}><X size={24} /></button>
             <h2>📅 Schedule Booking</h2>
             <div className="item-info">
-              <span className="item-info-icon">{TYPE_ICONS[equipment.find(e => e.id === showBookingModal).type] || "🔧"}</span>
+              <span className="item-info-icon">{TYPE_ICONS[selectedItem.type] || "🔧"}</span>
               <div>
-                <h3>{equipment.find(e => e.id === showBookingModal).name}</h3>
-                <p>₹{equipment.find(e => e.id === showBookingModal).price}/{equipment.find(e => e.id === showBookingModal).priceUnit}</p>
+                <h3>{selectedItem.name}</h3>
+                <p>₹{selectedItem.price}/{selectedItem.priceUnit}</p>
               </div>
             </div>
-            
+
             <div className="booking-form">
               <div className="form-group">
                 <label><Calendar size={16} /> Select Date</label>
                 <input
                   type="date"
                   value={bookingDate}
-                  min={new Date().toISOString().split('T')[0]}
+                  min={new Date().toISOString().split("T")[0]}
                   onChange={(e) => { setBookingDate(e.target.value); setBookingError(""); }}
                 />
-                {bookingError && !bookingTime && !bookingDuration && (
-                  <div style={{ color: '#f87171', fontSize: '0.82rem', marginTop: '0.4rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
-                    ⚠️ {bookingError}
-                  </div>
-                )}
               </div>
               <div className="form-row">
                 <div className="form-group">
@@ -267,37 +357,41 @@ export default function AgriMarketplace({ onClose }) {
                     value={bookingTime}
                     onChange={(e) => { setBookingTime(e.target.value); setBookingError(""); }}
                   />
-                  {bookingDate && bookingError && !bookingDuration && (
-                    <div style={{ color: '#f87171', fontSize: '0.82rem', marginTop: '0.4rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
-                      ⚠️ {bookingError}
-                    </div>
-                  )}
                 </div>
                 <div className="form-group">
-                  <label><Clock size={16} /> Duration ({equipment.find(e => e.id === showBookingModal).priceUnit === 'hr' ? 'Hours' : 'Days'})</label>
+                  <label>
+                    <Clock size={16} /> Duration ({selectedItem.priceUnit === "hr" ? "Hours" : "Days"})
+                  </label>
                   <input
-                    type="number"
-                    min="1"
-                    placeholder="e.g. 5"
+                    type="number" min="1" placeholder="e.g. 5"
                     value={bookingDuration}
                     onChange={(e) => { setBookingDuration(e.target.value); setBookingError(""); }}
                   />
-                  {bookingDate && bookingTime && bookingError && (
-                    <div style={{ color: '#f87171', fontSize: '0.82rem', marginTop: '0.4rem', display: 'flex', alignItems: 'center', gap: '0.4rem' }}>
-                      ⚠️ {bookingError}
-                    </div>
-                  )}
                 </div>
               </div>
+
               <div className="total-cost">
                 <span>Estimated Total:</span>
-                <strong>{bookingDuration && Number(bookingDuration) > 0
-                  ? `₹${equipment.find(e => e.id === showBookingModal).price * Number(bookingDuration)}`
-                  : '₹ --'}
-                </strong>
+                <strong>{estimatedCost !== null ? `₹${estimatedCost}` : "₹ --"}</strong>
               </div>
-              <button className="confirm-btn" onClick={() => handleBooking(showBookingModal)}>
-                Confirm Booking
+
+              {bookingError && (
+                <div className="error-msg" role="alert">
+                  <AlertCircle size={14} style={{ marginRight: 6 }} />{bookingError}
+                </div>
+              )}
+              {bookingSuccess && (
+                <div className="success-msg" role="status">
+                  <CheckCircle size={14} style={{ marginRight: 6 }} />{bookingSuccess}
+                </div>
+              )}
+
+              <button
+                className="confirm-btn"
+                onClick={() => handleBooking(showBookingModal)}
+                disabled={bookingSubmitting || !!bookingSuccess}
+              >
+                {bookingSubmitting ? "Confirming…" : "Confirm Booking"}
               </button>
             </div>
           </div>

--- a/main.py
+++ b/main.py
@@ -71,6 +71,7 @@ from backend.routers import (
     finance,
     governance,
     knowledge,
+    marketplace,
     ml,
     platform,
     quality,
@@ -908,6 +909,7 @@ async def lifespan(app: FastAPI):
     blockchain.init_blockchain(_supply_chain_blockchain)
     referrals.init_referrals(validate_firestore_ready)
     reports.init_reports(verify_role, get_signing_keys, sanitise_log_field, logger)
+    marketplace.init_marketplace(verify_role)
 
     rag_generate_fn = None
     try:
@@ -1058,6 +1060,7 @@ app.include_router(finance.router, prefix="/api/finance", tags=["Finance Legacy"
 app.include_router(quality.router, prefix="/api/crop-quality", tags=["Quality"])
 app.include_router(blockchain.router, prefix="/api/supply-chain", tags=["Blockchain"])
 app.include_router(reports.router, prefix="/api/admin", tags=["Reports"])
+app.include_router(marketplace.router, prefix="/api/marketplace", tags=["Marketplace"])
 app.include_router(knowledge.router, prefix="/api/knowledge", tags=["Knowledge"])
 app.include_router(community.router, prefix="/api/community", tags=["Community"])
 if voice_assistant_router is not None:


### PR DESCRIPTION
Three issues fixed:

1. All 16 equipment listings were hardcoded client-side (INITIAL_EQUIPMENT) and disappeared on page refresh. Any farmer could also manipulate the listing data via React DevTools.

   Fix: listings are seeded into an in-process server-side store on startup (backend/routers/marketplace.py). The frontend fetches them via GET /api/marketplace/listings on mount. New listings posted via POST /api/marketplace/listings (auth required) are persisted in the same store and immediately visible to all users.

2. 'Confirm Booking' showed a browser alert() with no API call, no persistence, and no notification to the equipment owner. Farmers who booked equipment had no confirmation and owners were never told.

   Fix: booking now POSTs to POST /api/marketplace/bookings (auth required). The server persists the booking, marks the listing as unavailable, and returns a booking ID. The frontend shows the booking ID in a success message instead of a browser alert(). GET /api/marketplace/bookings returns all bookings for the authenticated user (as booker or owner).

3. 'List Equipment' added entries to React state only — gone on refresh.

   Fix: the form now POSTs to POST /api/marketplace/listings. On success the new listing is prepended to the local state from the server response so the UI updates immediately without a full reload.

Backend (backend/routers/marketplace.py — new file):
- Thread-safe in-process stores (_listings, _bookings) seeded with the 16 canonical listings on startup.
- GET  /listings  — public, supports search/location/type/available_only
- POST /listings  — auth required; validates name, type, price, location
- POST /bookings  — auth required; validates date format, duration range; marks listing unavailable atomically; returns booking record
- GET  /bookings  — auth required; returns caller's bookings

main.py:
- Import marketplace router; call init_marketplace(verify_role); register at prefix /api/marketplace.

Frontend (AgriMarketplace.jsx):
- Remove INITIAL_EQUIPMENT hardcoded array.
- Fetch listings from server on mount and on search/location change.
- List Equipment form POSTs to server; shows inline success/error.
- Confirm Booking POSTs to server; shows booking ID confirmation; handles 401/409/404 with specific error messages.
- Replace browser alert() with inline success/error UI.

Closes #897 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Launched a peer-to-peer agri-equipment marketplace enabling users to search, filter, and book agricultural equipment
  * Browse equipment listings by location, type, and availability
  * Create and manage your own equipment listings with pricing information
  * Track all booking requests where you are either the owner or renter

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->