### PR TITLE
fix: governance _require_admin_auth fails closed on Firestore errors

### DIFF
--- a/backend/routers/governance.py
+++ b/backend/routers/governance.py
@@ -52,34 +52,51 @@ def _require_auth(request: Request) -> str:
 def _require_admin_auth(request: Request) -> str:
     """
     Verify the Firebase ID token AND check that the caller has the 'admin'
-    role in Firestore. Used for destructive write operations (promote,
-    rollback, register, set baseline) that must be restricted to admins.
+    or 'expert' role in Firestore. Used for destructive write operations
+    (promote, rollback, register, set baseline, start shadow eval) that must
+    be restricted to privileged roles.
 
-    Falls back to uid-only check when Firestore is unavailable so the
-    endpoint still rejects unauthenticated callers even in degraded state.
+    Fail-closed design: any error reaching Firestore — transient network
+    failure, SDK exception, or unavailable service — results in HTTP 503
+    rather than silently granting access. A Firestore outage must never
+    become a privilege-escalation window.
     """
     uid = _require_auth(request)
 
-    # Best-effort role check — import lazily to avoid circular imports
+    import firebase_admin
+    from firebase_admin import firestore as _fs
+
+    # Firestore must be initialised; if not, the authorization service is
+    # unavailable and we must reject rather than allow through.
+    if not firebase_admin._apps:
+        raise HTTPException(
+            status_code=503,
+            detail="Authorization service unavailable"
+        )
+
     try:
-        import firebase_admin
-        from firebase_admin import firestore as _fs
-        if firebase_admin._apps:
-            db = _fs.client()
-            user_doc = db.collection("users").document(uid).get()
-            if user_doc.exists:
-                role = user_doc.to_dict().get("role", "farmer")
-                if role not in ("admin", "expert"):
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Access denied: admin or expert role required"
-                    )
+        db = _fs.client()
+        user_doc = db.collection("users").document(uid).get()
     except HTTPException:
         raise
     except Exception:
-        # Firestore unavailable — token is still verified; allow through
-        # rather than blocking legitimate admins during an outage.
-        pass
+        # Any Firestore error (timeout, network reset, SDK fault) is treated
+        # as an authorization-service failure. Fail closed — do not grant
+        # access when the role cannot be verified.
+        raise HTTPException(
+            status_code=503,
+            detail="Authorization service unavailable"
+        )
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=403, detail="User profile not found")
+
+    role = user_doc.to_dict().get("role", "farmer")
+    if role not in ("admin", "expert"):
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: admin or expert role required"
+        )
 
     return uid
 


### PR DESCRIPTION
Previously the role check was wrapped in a bare except Exception: pass block. Any Firestore error (network timeout, SDK exception, service outage) silently skipped the role check and allowed any authenticated user — including a regular farmer — to call destructive admin-only endpoints: promote/rollback model versions, set drift baselines, and start shadow evaluations.

Changes:
- Remove the bare except/pass that caused fail-open behaviour
- Raise HTTP 503 for any Firestore error during role lookup so a transient outage cannot be used as a privilege-escalation window
- Raise HTTP 503 when firebase_admin has no initialised apps (service unavailable) rather than skipping the check entirely
- Raise HTTP 403 when the user document does not exist in Firestore
- Keep the existing HTTPException re-raise so 401/403 from _require_auth propagate correctly
- Update docstring to document the fail-closed contract

Fixes #954

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened authorization checks for privileged operations to prevent unauthorized access during service degradation.
  * System now returns HTTP 503 (Service Unavailable) when backend services are inaccessible, rather than allowing requests to proceed.
  * Authorization now requires a valid user profile to exist before processing role-based permissions.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1018?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->