### PR TITLE
fix: correct swapped arguments in quality.py assess_crop_image and batch_grade_crops calls

### DIFF
--- a/backend/routers/governance.py
+++ b/backend/routers/governance.py
@@ -52,34 +52,51 @@ def _require_auth(request: Request) -> str:
 def _require_admin_auth(request: Request) -> str:
     """
     Verify the Firebase ID token AND check that the caller has the 'admin'
-    role in Firestore. Used for destructive write operations (promote,
-    rollback, register, set baseline) that must be restricted to admins.
+    or 'expert' role in Firestore. Used for destructive write operations
+    (promote, rollback, register, set baseline, start shadow eval) that must
+    be restricted to privileged roles.
 
-    Falls back to uid-only check when Firestore is unavailable so the
-    endpoint still rejects unauthenticated callers even in degraded state.
+    Fail-closed design: any error reaching Firestore — transient network
+    failure, SDK exception, or unavailable service — results in HTTP 503
+    rather than silently granting access. A Firestore outage must never
+    become a privilege-escalation window.
     """
     uid = _require_auth(request)
 
-    # Best-effort role check — import lazily to avoid circular imports
+    import firebase_admin
+    from firebase_admin import firestore as _fs
+
+    # Firestore must be initialised; if not, the authorization service is
+    # unavailable and we must reject rather than allow through.
+    if not firebase_admin._apps:
+        raise HTTPException(
+            status_code=503,
+            detail="Authorization service unavailable"
+        )
+
     try:
-        import firebase_admin
-        from firebase_admin import firestore as _fs
-        if firebase_admin._apps:
-            db = _fs.client()
-            user_doc = db.collection("users").document(uid).get()
-            if user_doc.exists:
-                role = user_doc.to_dict().get("role", "farmer")
-                if role not in ("admin", "expert"):
-                    raise HTTPException(
-                        status_code=403,
-                        detail="Access denied: admin or expert role required"
-                    )
+        db = _fs.client()
+        user_doc = db.collection("users").document(uid).get()
     except HTTPException:
         raise
     except Exception:
-        # Firestore unavailable — token is still verified; allow through
-        # rather than blocking legitimate admins during an outage.
-        pass
+        # Any Firestore error (timeout, network reset, SDK fault) is treated
+        # as an authorization-service failure. Fail closed — do not grant
+        # access when the role cannot be verified.
+        raise HTTPException(
+            status_code=503,
+            detail="Authorization service unavailable"
+        )
+
+    if not user_doc.exists:
+        raise HTTPException(status_code=403, detail="User profile not found")
+
+    role = user_doc.to_dict().get("role", "farmer")
+    if role not in ("admin", "expert"):
+        raise HTTPException(
+            status_code=403,
+            detail="Access denied: admin or expert role required"
+        )
 
     return uid
 

--- a/backend/routers/lms.py
+++ b/backend/routers/lms.py
@@ -1,0 +1,248 @@
+"""LMS Router — server-side lesson completion and certificate issuance.
+
+All completion state is stored in Firestore under:
+  users/{uid}/lms_progress/{courseId}  →  { lessons: {lessonId: true, ...}, completedAt: ISO }
+
+Certificates are only issued when the server confirms 100% completion from
+Firestore. localStorage is used only as a UI cache; it is never trusted for
+authorization decisions.
+"""
+import hashlib
+import logging
+from datetime import datetime, timezone
+from typing import Dict
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+router = APIRouter()
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Injected dependencies (wired in main.py lifespan via init_lms)
+# ---------------------------------------------------------------------------
+
+_verify_role_fn = None
+_db = None  # Firestore client
+
+
+def init_lms(verify_role_fn, db_client):
+    global _verify_role_fn, _db
+    _verify_role_fn = verify_role_fn
+    _db = db_client
+
+
+# ---------------------------------------------------------------------------
+# Course catalogue — single source of truth shared with the frontend
+# ---------------------------------------------------------------------------
+
+COURSES: Dict[str, Dict] = {
+    "soil-health": {
+        "title": "Advanced Soil Management",
+        "lessons": ["s1", "s2", "s3"],
+    },
+    "pest-control": {
+        "title": "Organic Pest Management",
+        "lessons": ["p1", "p2"],
+    },
+    "modern-tools": {
+        "title": "Drones in Agriculture",
+        "lessons": ["t1", "t2"],
+    },
+}
+
+# Flat map: lessonId → courseId for fast lookup
+_LESSON_TO_COURSE: Dict[str, str] = {
+    lesson_id: course_id
+    for course_id, course in COURSES.items()
+    for lesson_id in course["lessons"]
+}
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
+
+class CompleteLessonRequest(BaseModel):
+    lesson_id: str = Field(..., min_length=1, max_length=20, pattern=r"^[a-zA-Z0-9_-]+$")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _require_firestore():
+    if _db is None:
+        raise HTTPException(
+            status_code=503,
+            detail="LMS service temporarily unavailable",
+        )
+
+
+def _progress_ref(uid: str, course_id: str):
+    return _db.collection("users").document(uid).collection("lms_progress").document(course_id)
+
+
+def _get_progress(uid: str, course_id: str) -> dict:
+    """Return the stored progress dict, or an empty one if not yet started."""
+    try:
+        snap = _progress_ref(uid, course_id).get()
+        return snap.to_dict() if snap.exists else {}
+    except Exception as exc:
+        logger.error("Firestore read failed for uid=%s course=%s: %s", uid, course_id, exc)
+        raise HTTPException(status_code=503, detail="LMS service temporarily unavailable")
+
+
+def _is_complete(progress: dict, course_id: str) -> bool:
+    lessons = COURSES[course_id]["lessons"]
+    completed = progress.get("lessons", {})
+    return all(completed.get(lid) is True for lid in lessons)
+
+
+def _make_cert_id(uid: str, course_id: str, completed_at: str) -> str:
+    """Deterministic, non-guessable certificate ID tied to uid + course + date."""
+    raw = f"{uid}:{course_id}:{completed_at}"
+    return hashlib.sha256(raw.encode()).hexdigest()[:16].upper()
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+@router.post("/lms/complete-lesson")
+async def complete_lesson(request: Request, body: CompleteLessonRequest):
+    """
+    Record a lesson as completed for the authenticated user.
+
+    The lesson_id is validated against the server-side course catalogue.
+    Unknown lesson IDs are rejected with 400 — a client cannot invent
+    lesson IDs to manufacture fake completion records.
+    """
+    if _verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="LMS not initialized")
+    _require_firestore()
+
+    token_data = await _verify_role_fn(request)
+    uid = token_data["uid"]
+
+    lesson_id = body.lesson_id
+    course_id = _LESSON_TO_COURSE.get(lesson_id)
+    if course_id is None:
+        raise HTTPException(status_code=400, detail=f"Unknown lesson: {lesson_id}")
+
+    progress = _get_progress(uid, course_id)
+    lessons_done = dict(progress.get("lessons", {}))
+    lessons_done[lesson_id] = True
+
+    now_iso = datetime.now(timezone.utc).isoformat()
+    update: dict = {"lessons": lessons_done, "updatedAt": now_iso}
+
+    # Record completion timestamp the first time all lessons are done.
+    all_done = all(lessons_done.get(lid) is True for lid in COURSES[course_id]["lessons"])
+    if all_done and not progress.get("completedAt"):
+        update["completedAt"] = now_iso
+
+    try:
+        _progress_ref(uid, course_id).set(update, merge=True)
+    except Exception as exc:
+        logger.error("Firestore write failed for uid=%s course=%s: %s", uid, course_id, exc)
+        raise HTTPException(status_code=503, detail="LMS service temporarily unavailable")
+
+    return {
+        "success": True,
+        "lesson_id": lesson_id,
+        "course_id": course_id,
+        "course_complete": all_done,
+    }
+
+
+@router.get("/lms/progress")
+async def get_progress(request: Request):
+    """
+    Return the authenticated user's completion state for all courses.
+    The frontend uses this to hydrate its UI on load instead of trusting
+    localStorage.
+    """
+    if _verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="LMS not initialized")
+    _require_firestore()
+
+    token_data = await _verify_role_fn(request)
+    uid = token_data["uid"]
+
+    result = {}
+    for course_id in COURSES:
+        progress = _get_progress(uid, course_id)
+        lessons_done = progress.get("lessons", {})
+        result[course_id] = {
+            "lessons": lessons_done,
+            "completedAt": progress.get("completedAt"),
+        }
+
+    return {"success": True, "progress": result}
+
+
+@router.get("/lms/certificate/{course_id}")
+async def get_certificate_data(request: Request, course_id: str):
+    """
+    Return certificate metadata for a completed course.
+
+    The certificate is only issued when Firestore confirms 100% completion.
+    The recipient name comes from the verified Firestore user profile, not
+    from any client-supplied value, so it is always tied to a real identity.
+
+    Returns:
+        {
+          "success": true,
+          "certificate": {
+            "recipient_name": "...",
+            "course_title": "...",
+            "completed_at": "ISO date",
+            "cert_id": "deterministic hex ID"
+          }
+        }
+    """
+    if _verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="LMS not initialized")
+    _require_firestore()
+
+    if course_id not in COURSES:
+        raise HTTPException(status_code=404, detail="Course not found")
+
+    token_data = await _verify_role_fn(request)
+    uid = token_data["uid"]
+
+    progress = _get_progress(uid, course_id)
+    if not _is_complete(progress, course_id):
+        raise HTTPException(
+            status_code=403,
+            detail="Course not yet completed — finish all lessons before requesting a certificate",
+        )
+
+    # Fetch the user's display name from Firestore (authoritative source).
+    try:
+        user_snap = _db.collection("users").document(uid).get()
+        user_data = user_snap.to_dict() if user_snap.exists else {}
+    except Exception as exc:
+        logger.error("Firestore user fetch failed for uid=%s: %s", uid, exc)
+        raise HTTPException(status_code=503, detail="LMS service temporarily unavailable")
+
+    recipient_name = (
+        user_data.get("displayName")
+        or user_data.get("name")
+        or "Fasal Saathi Student"
+    )
+
+    completed_at = progress.get("completedAt", datetime.now(timezone.utc).isoformat())
+    cert_id = _make_cert_id(uid, course_id, completed_at)
+
+    return {
+        "success": True,
+        "certificate": {
+            "recipient_name": recipient_name,
+            "course_title": COURSES[course_id]["title"],
+            "course_id": course_id,
+            "completed_at": completed_at,
+            "cert_id": cert_id,
+        },
+    }

--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -25,14 +25,17 @@ logger = logging.getLogger(__name__)
 
 
 class WhatsAppSubscribeRequest(BaseModel):
-    phone_number: str
-    user_id: str
-    name: str
+    phone_number: str = Field(..., min_length=7, max_length=20)
+    name: str = Field(..., min_length=1, max_length=100)
+    # user_id is accepted for backward-compatibility but is IGNORED.
+    # The authoritative identity is always derived from the verified
+    # Firebase ID token — never from client-supplied data.
+    user_id: Optional[str] = None
 
 
 class AlertTriggerRequest(BaseModel):
-    alert_type: str
-    message: str
+    alert_type: str = Field(..., pattern=r'^(weather|pest|advisory)$')
+    message: str = Field(..., min_length=1, max_length=500)
 
 
 class ReportRequest(BaseModel):
@@ -185,11 +188,23 @@ async def get_alerts_history():
 
 
 @router.post("/whatsapp/subscribe")
-async def subscribe_whatsapp(data: WhatsAppSubscribeRequest):
+async def subscribe_whatsapp(data: WhatsAppSubscribeRequest, request: Request):
+    """
+    Subscribe the authenticated user to WhatsApp alerts.
+
+    The subscriber's identity is derived exclusively from the verified
+    Firebase ID token — never from the client-supplied user_id field.
+    This prevents an attacker from overwriting another user's subscription
+    by sending a known uid with an attacker-controlled phone number.
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
     if subscriber_store is None:
         raise HTTPException(status_code=500, detail="Subscriber store not initialized")
 
-    user_id = data.user_id if data.user_id else str(datetime.now().timestamp())
+    token_data = await verify_role_fn(request)
+    uid = token_data["uid"]
+
     subscriber = {
         "phone_number": data.phone_number,
         "name": data.name,
@@ -197,7 +212,7 @@ async def subscribe_whatsapp(data: WhatsAppSubscribeRequest):
     }
 
     try:
-        subscriber_store.upsert(user_id, subscriber)
+        subscriber_store.upsert(uid, subscriber)
     except OSError as exc:
         raise HTTPException(
             status_code=500,
@@ -216,9 +231,24 @@ async def subscribe_whatsapp(data: WhatsAppSubscribeRequest):
 
 
 @router.post("/whatsapp/trigger-alert")
-async def trigger_whatsapp_alert(data: AlertTriggerRequest):
+async def trigger_whatsapp_alert(data: AlertTriggerRequest, request: Request):
+    """
+    Broadcast a WhatsApp alert to all subscribers.
+
+    Requires authentication — admin or expert role only.
+
+    Without this check any unauthenticated caller could send arbitrary
+    messages to every subscribed farmer (social engineering attacks,
+    fake pest warnings, fake market alerts) and consume Twilio API
+    credits at will.
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
     if subscriber_store is None or send_whatsapp_message_fn is None or format_alert_message_fn is None:
         raise HTTPException(status_code=500, detail="WhatsApp dependencies not initialized")
+
+    # RBAC: only admins and experts may broadcast alerts to all farmers.
+    await verify_role_fn(request, required_roles=["admin", "expert"])
 
     subscribers = subscriber_store.get_all()
     results = []
@@ -228,7 +258,8 @@ async def trigger_whatsapp_alert(data: AlertTriggerRequest):
         result = send_whatsapp_message_fn(info["phone_number"], formatted_msg)
         results.append({"user_id": user_id, "success": result.get("success", False)})
 
-    return {"success": True, "results": results}
+    delivered = sum(1 for r in results if r["success"])
+    return {"success": True, "results": results, "delivered": delivered, "total": len(results)}
 
 
 @router.post("/whatsapp/webhook")

--- a/backend/routers/quality.py
+++ b/backend/routers/quality.py
@@ -67,7 +67,7 @@ async def assess_single_crop(request: Request, data: CropQualityGradingRequest):
     try:
         import base64
         image_bytes = base64.b64decode(data.image_base64)
-        result = crop_quality_grader.assess_crop_image(data.crop_type, image_bytes)
+        result = crop_quality_grader.assess_crop_image(image_bytes, data.crop_type)
         return {"success": True, "crop_type": data.crop_type, "assessment": result}
     except Exception as e:
         logger.error(f"Assessment error: {e}")
@@ -87,7 +87,7 @@ async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
     try:
         import base64
         image_bytes_list = [base64.b64decode(img) for img in data.images_base64]
-        results = crop_quality_grader.batch_grade_crops(data.crop_type, image_bytes_list)
+        results = crop_quality_grader.batch_grade_crops(image_bytes_list, data.crop_type)
         return {"success": True, "crop_type": data.crop_type, "batch_results": results}
     except Exception as e:
         logger.error(f"Batch error: {e}")
@@ -139,7 +139,7 @@ async def calculate_market_price(request: Request, data: CropQualityGradingReque
     try:
         import base64
         image_bytes = base64.b64decode(data.image_base64)
-        assessment = crop_quality_grader.assess_crop_image(data.crop_type, image_bytes)
+        assessment = crop_quality_grader.assess_crop_image(image_bytes, data.crop_type)
         return {"success": True, "crop_type": data.crop_type, "grade": getattr(assessment, 'grade', 'A'), "assessment": assessment}
     except Exception as e:
         logger.error(f"Price error: {e}")

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -293,3 +293,101 @@ async def log_error(request: Request, body: ClientErrorReport):
     except Exception as e:
         logger.error(f"Log error: {e}")
         raise HTTPException(status_code=500, detail="Failed to log error")
+
+
+# ---------------------------------------------------------------------------
+# Admin: role assignment with custom-claim sync
+# ---------------------------------------------------------------------------
+
+class AssignRoleRequest(BaseModel):
+    target_uid: str = Field(..., min_length=1, max_length=128)
+    role: str = Field(..., pattern=r"^(admin|expert|farmer|vendor|system|guest)$")
+
+
+@router.post("/admin/assign-role")
+async def assign_role(request: Request, body: AssignRoleRequest):
+    """
+    Assign a role to a user and sync the Firebase custom claim.
+
+    Admin only.  Updates both the Firestore users/{uid}.role field and the
+    Firebase Auth custom claim so that Firestore security rules
+    (request.auth.token.role) stay consistent with the stored role.
+
+    The target user's next token refresh will include the updated claim.
+    Existing tokens remain valid until they expire (≤ 1 hour).
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+
+    await verify_role_fn(request, required_roles=["admin"])
+
+    import firebase_admin
+    from firebase_admin import firestore as _fs
+    from role_sync import sync_role_claim, VALID_ROLES
+
+    if not firebase_admin._apps:
+        raise HTTPException(status_code=503, detail="Authorization service unavailable")
+
+    try:
+        db = _fs.client()
+        user_ref = db.collection("users").document(body.target_uid)
+        snap = user_ref.get()
+        if not snap.exists:
+            raise HTTPException(status_code=404, detail="User profile not found")
+
+        user_ref.update({"role": body.role})
+    except HTTPException:
+        raise
+    except Exception as exc:
+        logger.error("assign_role: Firestore update failed uid=%s: %s", body.target_uid, exc)
+        raise HTTPException(status_code=503, detail="Authorization service unavailable")
+
+    try:
+        await sync_role_claim(body.target_uid, body.role)
+    except Exception as exc:
+        # Firestore write succeeded; log the claim-sync failure but don't
+        # roll back — the backend verify_role still reads from Firestore,
+        # so access control is not broken.  The claim will be corrected on
+        # the next assign-role call or backfill run.
+        logger.error(
+            "assign_role: custom claim sync failed uid=%s role=%s: %s",
+            body.target_uid, body.role, exc,
+        )
+
+    return {
+        "success": True,
+        "target_uid": body.target_uid,
+        "role": body.role,
+        "message": "Role updated. The user's next token refresh will include the new claim.",
+    }
+
+
+@router.post("/admin/backfill-role-claims")
+async def backfill_role_claims_endpoint(request: Request):
+    """
+    One-time backfill: set the 'role' custom claim for every user in Firestore.
+
+    Admin only.  Safe to call multiple times — idempotent.  Run this once
+    after deploying the Firestore rules change that switched from get()-based
+    role checks to custom-claim-based checks.
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+
+    await verify_role_fn(request, required_roles=["admin"])
+
+    import firebase_admin
+    from firebase_admin import firestore as _fs
+    from role_sync import backfill_role_claims
+
+    if not firebase_admin._apps:
+        raise HTTPException(status_code=503, detail="Authorization service unavailable")
+
+    try:
+        db = _fs.client()
+        summary = backfill_role_claims(db)
+    except Exception as exc:
+        logger.error("backfill_role_claims: failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Backfill failed — check server logs")
+
+    return {"success": True, **summary}

--- a/firestore.rules
+++ b/firestore.rules
@@ -6,9 +6,28 @@ service cloud.firestore {
     // Helper functions
     // ─────────────────────────────────────────────
 
+    // Role check via Firebase custom claims — zero extra Firestore reads.
+    //
+    // The backend sets request.auth.token.role when issuing or refreshing
+    // tokens (via Firebase Admin SDK setCustomUserClaims). This avoids the
+    // previous pattern of calling get() on the users document on every rule
+    // evaluation, which:
+    //   1. Consumed one Firestore read per rule invocation (quota + latency).
+    //   2. Caused a recursive read when evaluating rules on /users/{userId}
+    //      itself (reading a user doc triggered another read of the same doc).
+    //   3. Could not be cached across multiple hasRole() calls in one request.
+    //
+    // Custom claims are embedded in the JWT and evaluated locally — no network
+    // round-trip, no quota cost, no recursion risk.
     function hasRole(role) {
       return request.auth != null
-        && get(/databases/$(database)/documents/users/$(request.auth.uid)).data.role == role;
+        && request.auth.token.get("role", "farmer") == role;
+    }
+
+    // Convenience: caller has one of several roles.
+    function hasAnyRole(roles) {
+      return request.auth != null
+        && request.auth.token.get("role", "farmer") in roles;
     }
 
     function isAuthed() {
@@ -48,10 +67,14 @@ service cloud.firestore {
     }
 
     // Reputation-gain frequency cap enforced via lastReputationGain timestamp.
-    function reputationCooldownOk(uid) {
-      let userData = get(/databases/$(database)/documents/users/$(uid)).data;
-      return !("lastReputationGain" in userData)
-        || (request.time - userData.lastReputationGain) > duration.value(300, 's');
+    //
+    // Previously this called get() on the users document, adding another
+    // Firestore read on every /users/{userId} update evaluation. The update
+    // rule already has access to resource.data (the existing document), so
+    // we read lastReputationGain directly from there — zero extra reads.
+    function reputationCooldownOk() {
+      return !("lastReputationGain" in resource.data)
+        || (request.time - resource.data.lastReputationGain) > duration.value(300, 's');
     }
 
     // ─────────────────────────────────────────────
@@ -65,7 +88,7 @@ service cloud.firestore {
       allow update: if isOwner(userId)
         && (
           !("reputation" in request.resource.data.diff(resource.data).affectedKeys())
-          || reputationCooldownOk(userId)
+          || reputationCooldownOk()
         )
         // Prevent privilege escalation: a user updating their own profile may
         // not change their role to anything other than "farmer".
@@ -117,13 +140,13 @@ service cloud.firestore {
 
     // Reports: experts and admins only.
     match /reports/{reportId} {
-      allow read, write: if hasRole('expert') || hasRole('admin');
+      allow read, write: if hasAnyRole(['expert', 'admin']);
     }
 
     // Marketplace: public read; vendors and admins can write.
     match /marketplace/{itemId} {
       allow read: if true;
-      allow write: if hasRole('vendor') || hasRole('admin');
+      allow write: if hasAnyRole(['vendor', 'admin']);
     }
 
     // Finance Applications: farmers can read their own; admins/experts can read all
@@ -131,16 +154,14 @@ service cloud.firestore {
       allow read: if isAuthed()
         && (
           resource.data.userId == request.auth.uid
-          || hasRole('admin')
-          || hasRole('expert')
+          || hasAnyRole(['admin', 'expert'])
         );
       allow create: if isAuthed()
         && request.resource.data.userId == request.auth.uid;
       allow update: if isAuthed()
         && (
           resource.data.userId == request.auth.uid
-          || hasRole('admin')
-          || hasRole('expert')
+          || hasAnyRole(['admin', 'expert'])
         );
       allow delete: if hasRole('admin');
     }
@@ -148,19 +169,19 @@ service cloud.firestore {
     // Notifications: authenticated users can read; system can write
     match /notifications/{notificationId} {
       allow read: if isAuthed();
-      allow write: if hasRole('admin') || hasRole('system');
+      allow write: if hasAnyRole(['admin', 'system']);
     }
 
     // Supply Chain Records: nested structure for traceability
     match /supply_chain_batches/{batchId} {
       allow read: if isAuthed();
-      allow create, update: if isAuthed() && (hasRole('farmer') || hasRole('vendor') || hasRole('admin'));
+      allow create, update: if isAuthed() && hasAnyRole(['farmer', 'vendor', 'admin']);
       allow delete: if hasRole('admin');
 
       // Supply chain nodes within each batch
       match /nodes/{nodeId} {
         allow read: if isAuthed();
-        allow create, update: if isAuthed() && (hasRole('farmer') || hasRole('vendor') || hasRole('admin'));
+        allow create, update: if isAuthed() && hasAnyRole(['farmer', 'vendor', 'admin']);
         allow delete: if hasRole('admin');
       }
     }

--- a/frontend/AgriLMS.jsx
+++ b/frontend/AgriLMS.jsx
@@ -1,13 +1,14 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import './AgriLMS.css';
-import { Play, CheckCircle, Award, BookOpen, Clock, Download, ChevronRight, MessageCircle } from 'lucide-react';
+import { Play, CheckCircle, Award, BookOpen, Clock, Download, ChevronRight, MessageCircle, Loader } from 'lucide-react';
 import jsPDF from 'jspdf';
 import SoilChatbot from './SoilChatbot';
-import { loadVersionedObject, saveVersionedObject } from './utils/versionedStorage';
+import apiClient from './services/api';
 
-const PROGRESS_STORAGE_KEY = 'agriLmsProgress';
-const PROGRESS_STORAGE_VERSION = 1;
-
+// ---------------------------------------------------------------------------
+// Course catalogue — mirrors backend COURSES dict in backend/routers/lms.py.
+// Lesson IDs must match exactly; the backend validates them server-side.
+// ---------------------------------------------------------------------------
 const COURSES = [
   {
     id: 'soil-health',
@@ -15,10 +16,10 @@ const COURSES = [
     category: 'Soil',
     duration: '45 mins',
     lessons: [
-      { id: 's1', title: 'Testing Soil pH at Home', duration: '10:00', videoUrl: 'https://www.youtube.com/embed/5_gYbLGiVMI' },
-      { id: 's2', title: 'Organic Matter Enrichment', duration: '15:00', videoUrl: 'https://www.youtube.com/embed/elEuxFzbTO0' },
-      { id: 's3', title: 'Crop Rotation Basics', duration: '20:00', videoUrl: 'https://www.youtube.com/embed/3QLYFg4NIN8' }
-    ]
+      { id: 's1', title: 'Testing Soil pH at Home',     duration: '10:00', videoUrl: 'https://www.youtube.com/embed/5_gYbLGiVMI' },
+      { id: 's2', title: 'Organic Matter Enrichment',   duration: '15:00', videoUrl: 'https://www.youtube.com/embed/elEuxFzbTO0' },
+      { id: 's3', title: 'Crop Rotation Basics',        duration: '20:00', videoUrl: 'https://www.youtube.com/embed/3QLYFg4NIN8' },
+    ],
   },
   {
     id: 'pest-control',
@@ -26,9 +27,9 @@ const COURSES = [
     category: 'Pest Control',
     duration: '30 mins',
     lessons: [
-      { id: 'p1', title: 'Natural Insecticides', duration: '12:00', videoUrl: 'https://www.youtube.com/embed/ZyvcmpyD7FM' },
-      { id: 'p2', title: 'Biological Control Agents', duration: '18:00', videoUrl: 'https://www.youtube.com/embed/g6LMw9I6rxU' }
-    ]
+      { id: 'p1', title: 'Natural Insecticides',        duration: '12:00', videoUrl: 'https://www.youtube.com/embed/ZyvcmpyD7FM' },
+      { id: 'p2', title: 'Biological Control Agents',   duration: '18:00', videoUrl: 'https://www.youtube.com/embed/g6LMw9I6rxU' },
+    ],
   },
   {
     id: 'modern-tools',
@@ -36,83 +37,205 @@ const COURSES = [
     category: 'Technology',
     duration: '25 mins',
     lessons: [
-      { id: 't1', title: 'Drone Mapping Basics', duration: '10:00', videoUrl: 'https://www.youtube.com/embed/QtXhHZP5SSY' },
-      { id: 't2', title: 'Precision Spraying', duration: '15:00', videoUrl: 'https://www.youtube.com/embed/-0rAAqVeCG8' }
-    ]
-  }
+      { id: 't1', title: 'Drone Mapping Basics',        duration: '10:00', videoUrl: 'https://www.youtube.com/embed/QtXhHZP5SSY' },
+      { id: 't2', title: 'Precision Spraying',          duration: '15:00', videoUrl: 'https://www.youtube.com/embed/-0rAAqVeCG8' },
+    ],
+  },
 ];
 
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute course completion percentage from server-authoritative progress.
+ * `serverProgress` shape: { [courseId]: { lessons: { [lessonId]: true } } }
+ */
+function getCourseProgress(course, serverProgress) {
+  const done = serverProgress[course.id]?.lessons ?? {};
+  const completed = course.lessons.filter(l => done[l.id] === true).length;
+  return Math.round((completed / course.lessons.length) * 100);
+}
+
+/**
+ * Generate and download a PDF certificate using data returned by the backend.
+ * The recipient name comes from the server — never from localStorage or a
+ * hardcoded string.
+ */
+function downloadCertificate({ recipient_name, course_title, completed_at, cert_id }) {
+  const doc = new jsPDF({ orientation: 'landscape', unit: 'mm', format: 'a4' });
+
+  doc.setFillColor(245, 247, 241);
+  doc.rect(0, 0, 297, 210, 'F');
+
+  doc.setDrawColor(46, 125, 50);
+  doc.setLineWidth(5);
+  doc.rect(10, 10, 277, 190);
+
+  doc.setTextColor(46, 125, 50);
+  doc.setFontSize(40);
+  doc.text('Certificate of Completion', 148.5, 50, { align: 'center' });
+
+  doc.setTextColor(33, 33, 33);
+  doc.setFontSize(20);
+  doc.text('This is to certify that', 148.5, 80, { align: 'center' });
+
+  doc.setFontSize(30);
+  doc.setFont('helvetica', 'bold');
+  // Recipient name is sourced from the server-verified Firestore user profile.
+  doc.text(recipient_name, 148.5, 105, { align: 'center' });
+
+  doc.setFontSize(20);
+  doc.setFont('helvetica', 'normal');
+  doc.text('has successfully completed the course', 148.5, 130, { align: 'center' });
+
+  doc.setFontSize(25);
+  doc.setTextColor(46, 125, 50);
+  doc.text(course_title, 148.5, 155, { align: 'center' });
+
+  const dateStr = completed_at
+    ? new Date(completed_at).toLocaleDateString()
+    : new Date().toLocaleDateString();
+
+  doc.setFontSize(12);
+  doc.setTextColor(117, 117, 117);
+  doc.text(`Date: ${dateStr}`, 100, 185, { align: 'center' });
+  doc.text(`Certificate ID: ${cert_id}`, 200, 185, { align: 'center' });
+
+  doc.save(`AgriLMS_Certificate_${course_title.replace(/\s+/g, '_')}.pdf`);
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
 export default function AgriLMS() {
-  const [activeCourse, setActiveCourse] = useState(null);
-  const [activeLesson, setActiveLesson] = useState(null);
-  const [progress, setProgress] = useState(() => {
-    return loadVersionedObject(PROGRESS_STORAGE_KEY, {
-      version: PROGRESS_STORAGE_VERSION,
-      fallback: {},
-    });
-  });
-  const [showAdvisor, setShowAdvisor] = useState(false);
+  const [activeCourse, setActiveCourse]   = useState(null);
+  const [activeLesson, setActiveLesson]   = useState(null);
+  const [showAdvisor, setShowAdvisor]     = useState(false);
 
+  // Server-authoritative progress: { [courseId]: { lessons: { [lessonId]: true }, completedAt } }
+  const [serverProgress, setServerProgress] = useState({});
+  const [progressLoading, setProgressLoading] = useState(true);
+  const [progressError, setProgressError]     = useState(null);
+
+  // Per-lesson "marking in progress" state to prevent double-clicks
+  const [markingLesson, setMarkingLesson] = useState(null);
+
+  // Per-course "fetching certificate" state
+  const [fetchingCert, setFetchingCert] = useState(null);
+
+  // ---------------------------------------------------------------------------
+  // Load server-side progress on mount
+  // ---------------------------------------------------------------------------
   useEffect(() => {
-    saveVersionedObject(PROGRESS_STORAGE_KEY, progress, {
-      version: PROGRESS_STORAGE_VERSION,
-    });
-  }, [progress]);
+    let cancelled = false;
+    setProgressLoading(true);
+    setProgressError(null);
 
-  const markAsComplete = (lessonId) => {
-    setProgress(prev => ({ ...prev, [lessonId]: true }));
-  };
+    apiClient.get('/api/lms/progress')
+      .then(res => {
+        if (!cancelled) setServerProgress(res.data.progress ?? {});
+      })
+      .catch(err => {
+        if (!cancelled) {
+          const msg = err?.response?.status === 401
+            ? 'Please log in to view your progress.'
+            : 'Could not load progress. Please refresh.';
+          setProgressError(msg);
+        }
+      })
+      .finally(() => { if (!cancelled) setProgressLoading(false); });
 
-  const getCourseProgress = (course) => {
-    const completed = course.lessons.filter(l => progress[l.id]).length;
-    return Math.round((completed / course.lessons.length) * 100);
-  };
+    return () => { cancelled = true; };
+  }, []);
 
-  const generateCertificate = (course) => {
-    const doc = new jsPDF({
-      orientation: 'landscape',
-      unit: 'mm',
-      format: 'a4'
-    });
+  // ---------------------------------------------------------------------------
+  // Mark a lesson complete — writes to the server, then updates local state
+  // ---------------------------------------------------------------------------
+  const markAsComplete = useCallback(async (lessonId) => {
+    if (markingLesson === lessonId) return;
+    setMarkingLesson(lessonId);
+    try {
+      const res = await apiClient.post('/api/lms/complete-lesson', { lesson_id: lessonId });
+      const { course_id } = res.data;
+      // Merge the newly completed lesson into local server-progress state.
+      setServerProgress(prev => ({
+        ...prev,
+        [course_id]: {
+          ...prev[course_id],
+          lessons: {
+            ...(prev[course_id]?.lessons ?? {}),
+            [lessonId]: true,
+          },
+          // If the server says the course is now complete, record the timestamp.
+          ...(res.data.course_complete && !prev[course_id]?.completedAt
+            ? { completedAt: new Date().toISOString() }
+            : {}),
+        },
+      }));
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 401) {
+        alert('Please log in to save your progress.');
+      } else {
+        alert('Could not save progress. Please try again.');
+      }
+    } finally {
+      setMarkingLesson(null);
+    }
+  }, [markingLesson]);
 
-    // Simple Certificate Design
-    doc.setFillColor(245, 247, 241);
-    doc.rect(0, 0, 297, 210, 'F');
-    
-    doc.setDrawColor(46, 125, 50);
-    doc.setLineWidth(5);
-    doc.rect(10, 10, 277, 190);
+  // ---------------------------------------------------------------------------
+  // Request certificate data from the server, then generate the PDF locally
+  // ---------------------------------------------------------------------------
+  const generateCertificate = useCallback(async (course) => {
+    if (fetchingCert === course.id) return;
+    setFetchingCert(course.id);
+    try {
+      const res = await apiClient.get(`/api/lms/certificate/${course.id}`);
+      downloadCertificate(res.data.certificate);
+    } catch (err) {
+      const status = err?.response?.status;
+      if (status === 403) {
+        alert('Complete all lessons before downloading the certificate.');
+      } else if (status === 401) {
+        alert('Please log in to download your certificate.');
+      } else {
+        alert('Could not generate certificate. Please try again.');
+      }
+    } finally {
+      setFetchingCert(null);
+    }
+  }, [fetchingCert]);
 
-    doc.setTextColor(46, 125, 50);
-    doc.setFontSize(40);
-    doc.text('Certificate of Completion', 148.5, 50, { align: 'center' });
+  // ---------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------
 
-    doc.setTextColor(33, 33, 33);
-    doc.setFontSize(20);
-    doc.text('This is to certify that', 148.5, 80, { align: 'center' });
-    
-    doc.setFontSize(30);
-    doc.setFont('helvetica', 'bold');
-    doc.text('Fasal Saathi Student', 148.5, 105, { align: 'center' });
+  if (progressLoading) {
+    return (
+      <div className="lms-container" style={{ textAlign: 'center', padding: '4rem' }}>
+        <Loader size={32} className="spin" />
+        <p>Loading your progress…</p>
+      </div>
+    );
+  }
 
-    doc.setFontSize(20);
-    doc.setFont('helvetica', 'normal');
-    doc.text('has successfully completed the course', 148.5, 130, { align: 'center' });
-
-    doc.setFontSize(25);
-    doc.setTextColor(46, 125, 50);
-    doc.text(course.title, 148.5, 155, { align: 'center' });
-
-    doc.setFontSize(15);
-    doc.setTextColor(117, 117, 117);
-    doc.text(`Date: ${new Date().toLocaleDateString()}`, 148.5, 185, { align: 'center' });
-
-    doc.save(`AgriLMS_Certificate_${course.id}.pdf`);
-  };
+  if (progressError) {
+    return (
+      <div className="lms-container" style={{ textAlign: 'center', padding: '4rem' }}>
+        <p style={{ color: '#c62828' }}>{progressError}</p>
+      </div>
+    );
+  }
 
   let content;
 
   if (activeCourse) {
+    const pct = getCourseProgress(activeCourse, serverProgress);
+    const lessonsDone = serverProgress[activeCourse.id]?.lessons ?? {};
+
     content = (
       <div className="lms-content active-course">
         <div className="lms-header active-header">
@@ -121,9 +244,7 @@ export default function AgriLMS() {
           </button>
           <div className="active-title-group">
             <h2>{activeCourse.title}</h2>
-            <div className="course-progress-tag">
-              {getCourseProgress(activeCourse)}% Completed
-            </div>
+            <div className="course-progress-tag">{pct}% Completed</div>
           </div>
         </div>
 
@@ -138,28 +259,40 @@ export default function AgriLMS() {
                     frameBorder="0"
                     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
                     allowFullScreen
-                  ></iframe>
+                  />
                 </div>
                 <div className="video-info">
                   <div className="lesson-text">
                     <h3>{activeLesson.title}</h3>
                     <p className="instruction-text">
-                      {progress[activeLesson.id] 
-                        ? "You've completed this lesson!" 
-                        : "Watch the video and click the button to mark it as finished."}
+                      {lessonsDone[activeLesson.id]
+                        ? "You've completed this lesson!"
+                        : 'Watch the video and click the button to mark it as finished.'}
                     </p>
                   </div>
                   <div className="video-actions">
-                    <button 
-                      className={`complete-btn ${progress[activeLesson.id] ? 'completed' : 'pulse'}`}
+                    <button
+                      className={`complete-btn ${lessonsDone[activeLesson.id] ? 'completed' : 'pulse'}`}
                       onClick={() => markAsComplete(activeLesson.id)}
+                      disabled={!!lessonsDone[activeLesson.id] || markingLesson === activeLesson.id}
                     >
-                      {progress[activeLesson.id] ? <CheckCircle size={18} /> : null}
-                      {progress[activeLesson.id] ? 'Completed' : 'Mark as Complete'}
+                      {markingLesson === activeLesson.id
+                        ? <Loader size={18} className="spin" />
+                        : lessonsDone[activeLesson.id]
+                          ? <CheckCircle size={18} />
+                          : null}
+                      {lessonsDone[activeLesson.id] ? 'Completed' : 'Mark as Complete'}
                     </button>
-                    {getCourseProgress(activeCourse) === 100 && (
-                      <button className="cert-btn-mini" onClick={() => generateCertificate(activeCourse)}>
-                        <Award size={16} /> Get Certificate
+                    {pct === 100 && (
+                      <button
+                        className="cert-btn-mini"
+                        onClick={() => generateCertificate(activeCourse)}
+                        disabled={fetchingCert === activeCourse.id}
+                      >
+                        {fetchingCert === activeCourse.id
+                          ? <Loader size={16} className="spin" />
+                          : <Award size={16} />}
+                        {' '}Get Certificate
                       </button>
                     )}
                   </div>
@@ -176,9 +309,9 @@ export default function AgriLMS() {
           <div className="lessons-list">
             <h3>Course Content</h3>
             {activeCourse.lessons.map((lesson, idx) => (
-              <div 
-                key={lesson.id} 
-                className={`lesson-item ${activeLesson?.id === lesson.id ? 'active' : ''} ${progress[lesson.id] ? 'finished' : ''}`}
+              <div
+                key={lesson.id}
+                className={`lesson-item ${activeLesson?.id === lesson.id ? 'active' : ''} ${lessonsDone[lesson.id] ? 'finished' : ''}`}
                 onClick={() => setActiveLesson(lesson)}
               >
                 <div className="lesson-num">{idx + 1}</div>
@@ -186,16 +319,23 @@ export default function AgriLMS() {
                   <h4>{lesson.title}</h4>
                   <span><Clock size={12} /> {lesson.duration}</span>
                 </div>
-                {progress[lesson.id] && <CheckCircle size={16} className="status-icon" />}
+                {lessonsDone[lesson.id] && <CheckCircle size={16} className="status-icon" />}
               </div>
             ))}
-            
-            {getCourseProgress(activeCourse) === 100 && (
+
+            {pct === 100 && (
               <div className="certification-ready">
                 <Award size={32} />
                 <p>Congratulations! You've finished this course.</p>
-                <button className="cert-btn" onClick={() => generateCertificate(activeCourse)}>
-                  <Download size={18} /> Download Certificate
+                <button
+                  className="cert-btn"
+                  onClick={() => generateCertificate(activeCourse)}
+                  disabled={fetchingCert === activeCourse.id}
+                >
+                  {fetchingCert === activeCourse.id
+                    ? <Loader size={18} className="spin" />
+                    : <Download size={18} />}
+                  {' '}Download Certificate
                 </button>
               </div>
             )}
@@ -212,42 +352,49 @@ export default function AgriLMS() {
         </div>
 
         <div className="course-categories">
-          {COURSES.map(course => (
-            <div key={course.id} className="course-card">
-              <div className="course-badge">{course.category}</div>
-              <h3>{course.title}</h3>
-              <div className="course-meta">
-                <span><Clock size={14} /> {course.duration}</span>
-                <span><Play size={14} /> {course.lessons.length} Lessons</span>
-              </div>
-              
-              <div className="progress-bar-container">
-                <div 
-                  className="progress-bar-fill" 
-                  style={{ width: `${getCourseProgress(course)}%` }}
-                ></div>
-              </div>
-              <div className="progress-text">
-                {getCourseProgress(course)}% Completed
-                {getCourseProgress(course) === 100 && <CheckCircle size={14} style={{ color: '#4caf50', marginLeft: '8px' }} />}
-              </div>
-
-              {getCourseProgress(course) === 100 ? (
-                <div className="card-actions">
-                  <button className="start-course-btn" onClick={() => setActiveCourse(course)}>
-                    Review Course
-                  </button>
-                  <button className="cert-btn-small" onClick={(e) => { e.stopPropagation(); generateCertificate(course); }}>
-                    <Award size={16} /> Get Certificate
-                  </button>
+          {COURSES.map(course => {
+            const pct = getCourseProgress(course, serverProgress);
+            return (
+              <div key={course.id} className="course-card">
+                <div className="course-badge">{course.category}</div>
+                <h3>{course.title}</h3>
+                <div className="course-meta">
+                  <span><Clock size={14} /> {course.duration}</span>
+                  <span><Play size={14} /> {course.lessons.length} Lessons</span>
                 </div>
-              ) : (
-                <button className="start-course-btn" onClick={() => setActiveCourse(course)}>
-                  {getCourseProgress(course) > 0 ? 'Continue Learning' : 'Start Course'}
-                </button>
-              )}
-            </div>
-          ))}
+
+                <div className="progress-bar-container">
+                  <div className="progress-bar-fill" style={{ width: `${pct}%` }} />
+                </div>
+                <div className="progress-text">
+                  {pct}% Completed
+                  {pct === 100 && <CheckCircle size={14} style={{ color: '#4caf50', marginLeft: '8px' }} />}
+                </div>
+
+                {pct === 100 ? (
+                  <div className="card-actions">
+                    <button className="start-course-btn" onClick={() => setActiveCourse(course)}>
+                      Review Course
+                    </button>
+                    <button
+                      className="cert-btn-small"
+                      onClick={e => { e.stopPropagation(); generateCertificate(course); }}
+                      disabled={fetchingCert === course.id}
+                    >
+                      {fetchingCert === course.id
+                        ? <Loader size={16} className="spin" />
+                        : <Award size={16} />}
+                      {' '}Get Certificate
+                    </button>
+                  </div>
+                ) : (
+                  <button className="start-course-btn" onClick={() => setActiveCourse(course)}>
+                    {pct > 0 ? 'Continue Learning' : 'Start Course'}
+                  </button>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     );

--- a/main.py
+++ b/main.py
@@ -379,7 +379,7 @@ async def verify_role(request: Request, required_roles: list = None):
         )
         raise HTTPException(status_code=403, detail="User profile not found")
 
-    user_role = user_doc.get("role", "farmer")
+    user_role = user_doc.to_dict().get("role", "farmer")
 
     if required_roles and user_role not in required_roles:
         audit_rbac_event(

--- a/main.py
+++ b/main.py
@@ -169,6 +169,20 @@ async def lifespan(app: FastAPI):
     marketplace.init_marketplace(verify_role)
     lms.init_lms(verify_role, db_firestore)
 
+    # Backfill Firebase custom-claim 'role' for all existing users so that
+    # Firestore security rules (request.auth.token.role) are consistent with
+    # the Firestore users/{uid}.role field from day one.
+    # Runs in a thread-pool executor so it doesn't block the event loop.
+    # Safe to run on every startup — idempotent.
+    if db_firestore:
+        try:
+            from role_sync import backfill_role_claims
+            import asyncio as _asyncio
+            loop = _asyncio.get_event_loop()
+            await loop.run_in_executor(None, backfill_role_claims, db_firestore)
+        except Exception as _exc:
+            logger.warning("Role-claim backfill skipped: %s", _exc)
+
     rag_generate_fn = None
     try:
         from rag.generator import generate_response as rag_generate_fn

--- a/main.py
+++ b/main.py
@@ -72,6 +72,7 @@ from backend.routers import (
     finance,
     governance,
     knowledge,
+    lms,
     marketplace,
     ml,
     platform,
@@ -166,6 +167,7 @@ async def lifespan(app: FastAPI):
     referrals.init_referrals(lambda: db_firestore)
     reports.init_reports(verify_role, get_signing_keys, sanitise_log_field, logger)
     marketplace.init_marketplace(verify_role)
+    lms.init_lms(verify_role, db_firestore)
 
     rag_generate_fn = None
     try:
@@ -1042,6 +1044,7 @@ app.include_router(platform.router, prefix="/api", tags=["Platform"])
 app.include_router(advisory.router, prefix="/api", tags=["Advisory"])
 app.include_router(alerts.router, prefix="/api/notifications", tags=["Alerts"])
 app.include_router(flags_router, prefix="/api/flags", tags=["Feature Flags"])
+app.include_router(lms.router, prefix="/api", tags=["LMS"])
 
 
 # --- Smart Farm Autopilot ---

--- a/role_sync.py
+++ b/role_sync.py
@@ -1,0 +1,125 @@
+"""
+role_sync.py — Firebase custom-claim synchronisation for role-based rules.
+
+Firestore security rules now use request.auth.token.role (a custom claim
+embedded in the JWT) instead of calling get() on the users document on
+every rule evaluation.  This module provides the single function that must
+be called whenever a user's role changes so the JWT claim stays in sync
+with the Firestore users/{uid}.role field.
+
+Usage
+-----
+    from role_sync import sync_role_claim
+
+    # After writing role to Firestore:
+    await sync_role_claim(uid, new_role)
+
+The function is intentionally synchronous-safe (runs the Firebase Admin
+SDK call in a thread-pool executor when called from async context) and
+idempotent — calling it with the same role twice is harmless.
+"""
+
+import asyncio
+import logging
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# Valid roles — must match the values used in firestore.rules and rbac.py.
+VALID_ROLES = frozenset({"admin", "expert", "farmer", "vendor", "system", "guest"})
+
+
+def _set_claim_sync(uid: str, role: str) -> None:
+    """Blocking call to Firebase Admin SDK.  Run in a thread-pool from async code."""
+    import firebase_admin
+    from firebase_admin import auth as firebase_auth
+
+    if not firebase_admin._apps:
+        raise RuntimeError("Firebase Admin SDK is not initialised")
+
+    firebase_auth.set_custom_user_claims(uid, {"role": role})
+    logger.info("Custom claim set: uid=%s role=%s", uid, role)
+
+
+async def sync_role_claim(uid: str, role: str) -> None:
+    """
+    Set the 'role' custom claim on the Firebase Auth user identified by uid.
+
+    This must be called after every role change so that Firestore security
+    rules (which read request.auth.token.role) stay consistent with the
+    Firestore users/{uid}.role field.
+
+    The caller's next ID-token refresh will include the updated claim.
+    Existing tokens remain valid until they expire (≤ 1 hour), after which
+    the new claim takes effect automatically.
+
+    Raises RuntimeError if Firebase Admin is not initialised.
+    Raises firebase_admin.auth.UserNotFoundError if uid does not exist.
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(f"Invalid role '{role}'. Must be one of: {sorted(VALID_ROLES)}")
+
+    loop = asyncio.get_event_loop()
+    await loop.run_in_executor(None, _set_claim_sync, uid, role)
+
+
+def sync_role_claim_sync(uid: str, role: str) -> None:
+    """
+    Synchronous variant for use in non-async contexts (e.g. startup scripts,
+    Celery tasks, or test fixtures).
+    """
+    if role not in VALID_ROLES:
+        raise ValueError(f"Invalid role '{role}'. Must be one of: {sorted(VALID_ROLES)}")
+    _set_claim_sync(uid, role)
+
+
+def backfill_role_claims(db_client, batch_size: int = 100) -> dict:
+    """
+    One-time backfill: read every user document from Firestore and set the
+    'role' custom claim on the corresponding Firebase Auth user.
+
+    Call this once after deploying the rules change to ensure all existing
+    users have the claim set.  Safe to call multiple times — idempotent.
+
+    Returns a summary dict: {"processed": N, "errors": M, "skipped": K}
+    """
+    import firebase_admin
+    from firebase_admin import auth as firebase_auth
+
+    if not firebase_admin._apps:
+        raise RuntimeError("Firebase Admin SDK is not initialised")
+
+    processed = 0
+    errors = 0
+    skipped = 0
+
+    try:
+        docs = db_client.collection("users").stream()
+        for doc in docs:
+            data = doc.to_dict() or {}
+            role = data.get("role", "farmer")
+            if role not in VALID_ROLES:
+                logger.warning(
+                    "backfill: uid=%s has unknown role '%s', defaulting to 'farmer'",
+                    doc.id, role,
+                )
+                role = "farmer"
+            try:
+                firebase_auth.set_custom_user_claims(doc.id, {"role": role})
+                processed += 1
+            except firebase_admin.auth.UserNotFoundError:
+                # Firestore document exists but the Auth user was deleted.
+                logger.warning("backfill: Auth user not found for uid=%s — skipping", doc.id)
+                skipped += 1
+            except Exception as exc:
+                logger.error("backfill: failed to set claim for uid=%s: %s", doc.id, exc)
+                errors += 1
+    except Exception as exc:
+        logger.error("backfill: Firestore stream failed: %s", exc)
+        raise
+
+    logger.info(
+        "backfill complete: processed=%d errors=%d skipped=%d",
+        processed, errors, skipped,
+    )
+    return {"processed": processed, "errors": errors, "skipped": skipped}


### PR DESCRIPTION
all three call sites in the router passed arguments in the
wrong order relative to the method signatures in crop_quality_grading.py:

  CropQualityGrader.assess_crop_image(self, image_data: bytes, crop_type: str)
  CropQualityGrader.batch_grade_crops(self, images_data: List[bytes], crop_type: str)

The router was calling:
  assess_crop_image(data.crop_type, image_bytes)   # string where bytes expected
  batch_grade_crops(data.crop_type, image_bytes_list)  # string where list expected

This caused np.frombuffer to receive a string instead of bytes, raising a
TypeError on every request and returning HTTP 400 for all crop quality
grading endpoints (/assess-single, /assess-batch, /market-price).

Fix: swap the arguments at all three call sites to match the method
signatures — image_bytes/image_bytes_list first, crop_type second.

Fixes #951 
