### PR TITLE
fix: remove duplicate owner_uid field and kwargs in farm_finance_ai.py

### DIFF
--- a/farm_finance_ai.py
+++ b/farm_finance_ai.py
@@ -34,7 +34,6 @@ class FinanceApplication:
     created_at: str
     assessment_score: float
     risk_level: str
-    owner_uid: str = ""
     required_documents: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
     # owner_uid ties the application to the Firebase UID of the farmer who
@@ -234,7 +233,6 @@ class FarmFinanceAI:
             created_at=datetime.now().isoformat(),
             assessment_score=analysis["financial_health_score"],
             risk_level=analysis["risk_level"],
-            owner_uid=owner_uid,
             required_documents=analysis["required_documents"],
             notes=analysis["action_plan"],
             owner_uid=owner_uid,
@@ -257,7 +255,6 @@ class FarmFinanceAI:
                     "owner_uid": application.owner_uid,
                     "required_documents": application.required_documents,
                     "notes": application.notes,
-                    "owner_uid": application.owner_uid,
                 }
                 self.repository.create(app_dict)
                 logger.info("Application %s persisted to repository.", application_id)


### PR DESCRIPTION
Fixes #1059 — three separate duplicate-definition bugs in farm_finance_ai.py:

1. FinanceApplication dataclass declared owner_uid twice:
     owner_uid: str = ''                        (first, line ~37)
     owner_uid: Optional[str] = field(default=None)  (second, line ~44)
   Python dataclasses silently replace the first field with the second,
   so the effective type is Optional[str] with default None. The first
   declaration also violated dataclass field ordering rules (a field with
   a default before fields without defaults), which raises TypeError at
   class definition time on some Python versions, crashing the entire
   module import.
   Fix: remove the first owner_uid: str = '' declaration entirely, keeping
   only the correct Optional[str] = field(default=None) after required_documents
   and notes.

2. FinanceApplication(...) constructor call in create_application() passed
   owner_uid=owner_uid twice as a keyword argument:
     owner_uid=owner_uid,   (before required_documents)
     owner_uid=owner_uid,   (after notes)
   Python raises TypeError: __init__() got multiple values for keyword
   argument 'owner_uid' at runtime, crashing every loan application
   creation request.
   Fix: remove the first occurrence, keeping only the single owner_uid=owner_uid
   kwarg at the end of the constructor call.

3. app_dict in the repository persistence block also had a duplicate key:
     'owner_uid': application.owner_uid,   (first occurrence)
     'owner_uid': application.owner_uid,   (second occurrence)
   Python dicts silently keep the last value for duplicate keys, so this
   was functionally harmless but misleading and a sign of the same
   copy-paste error.
   Fix: remove the duplicate key.