### PR TITLE
fix: add authentication to advisory endpoints and remove client-controlled user_id

### DIFF
--- a/backend/routers/advisory.py
+++ b/backend/routers/advisory.py
@@ -1,8 +1,9 @@
 """Rule-based farmer advisory API."""
+import threading
 from collections import defaultdict, deque
 from typing import Any, Optional
 
-from fastapi import APIRouter
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from advisory_rules import generate_advisories
@@ -11,18 +12,55 @@ from advisory_rules import generate_advisories
 router = APIRouter()
 _MAX_STORED_ALERTS = 50
 _stored_alerts: dict[str, deque] = defaultdict(lambda: deque(maxlen=_MAX_STORED_ALERTS))
+_store_lock = threading.Lock()
 
+# ---------------------------------------------------------------------------
+# Dependency injection — wired in main.py lifespan
+# ---------------------------------------------------------------------------
+_verify_role_fn = None
+
+
+def init_advisory(verify_role_fn) -> None:
+    global _verify_role_fn
+    _verify_role_fn = verify_role_fn
+
+
+# ---------------------------------------------------------------------------
+# Pydantic models
+# ---------------------------------------------------------------------------
 
 class AdvisoryRequest(BaseModel):
     weather: dict[str, Any] = Field(default_factory=dict)
     soil: dict[str, Any] = Field(default_factory=dict)
     crop_type: Optional[str] = Field(default=None, max_length=50)
-    user_id: Optional[str] = Field(default=None, max_length=128)
+    # user_id is no longer accepted from the request body.
+    # The authoritative identity is always derived from the verified
+    # Firebase ID token so a caller cannot store alerts under another
+    # user's UID.
     store_alerts: bool = False
 
 
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
 @router.post("/advisory")
-async def create_advisory(payload: AdvisoryRequest):
+async def create_advisory(payload: AdvisoryRequest, request: Request):
+    """
+    Generate rule-based farm advisories for the authenticated user.
+
+    If store_alerts is True the generated alerts are persisted server-side
+    under the caller's verified Firebase UID — never under a client-supplied
+    user_id — so they can be retrieved later via GET /advisory/me.
+
+    Authentication is required when store_alerts is True so that:
+    1. Alerts are always bound to a verified identity.
+    2. An unauthenticated caller cannot pollute another user's alert store
+       by guessing or enumerating Firebase UIDs (IDOR).
+
+    Unauthenticated callers may still generate transient advisories
+    (store_alerts=False) for the climate simulator and public widgets.
+    """
     alerts = generate_advisories(
         weather=payload.weather,
         soil=payload.soil,
@@ -30,8 +68,16 @@ async def create_advisory(payload: AdvisoryRequest):
     )
 
     stored = False
-    if payload.store_alerts and payload.user_id:
-        _stored_alerts[payload.user_id].extend(alerts)
+    if payload.store_alerts:
+        if _verify_role_fn is None:
+            raise HTTPException(status_code=500, detail="Advisory service not initialized")
+
+        # Derive uid from the verified token — never from the request body.
+        token_data = await _verify_role_fn(request)
+        uid = token_data["uid"]
+
+        with _store_lock:
+            _stored_alerts[uid].extend(alerts)
         stored = True
 
     return {
@@ -42,9 +88,26 @@ async def create_advisory(payload: AdvisoryRequest):
     }
 
 
-@router.get("/advisory/{user_id}")
-async def get_stored_advisories(user_id: str):
-    return {
-        "success": True,
-        "data": list(_stored_alerts.get(user_id, [])),
-    }
+@router.get("/advisory/me")
+async def get_my_advisories(request: Request):
+    """
+    Return stored advisories for the authenticated caller.
+
+    Authentication is required — a caller can only read their own stored
+    alerts. The previous GET /advisory/{user_id} endpoint accepted any
+    user_id as a path parameter with no token check, allowing any caller
+    to read another user's alerts (IDOR).
+
+    The endpoint is now /advisory/me so the caller's identity is always
+    derived from the verified Firebase token, not from a URL parameter.
+    """
+    if _verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Advisory service not initialized")
+
+    token_data = await _verify_role_fn(request)
+    uid = token_data["uid"]
+
+    with _store_lock:
+        data = list(_stored_alerts.get(uid, []))
+
+    return {"success": True, "data": data}

--- a/farm_finance_ai.py
+++ b/farm_finance_ai.py
@@ -34,7 +34,6 @@ class FinanceApplication:
     created_at: str
     assessment_score: float
     risk_level: str
-    owner_uid: str = ""
     required_documents: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
     # owner_uid ties the application to the Firebase UID of the farmer who
@@ -234,7 +233,6 @@ class FarmFinanceAI:
             created_at=datetime.now().isoformat(),
             assessment_score=analysis["financial_health_score"],
             risk_level=analysis["risk_level"],
-            owner_uid=owner_uid,
             required_documents=analysis["required_documents"],
             notes=analysis["action_plan"],
             owner_uid=owner_uid,
@@ -257,7 +255,6 @@ class FarmFinanceAI:
                     "owner_uid": application.owner_uid,
                     "required_documents": application.required_documents,
                     "notes": application.notes,
-                    "owner_uid": application.owner_uid,
                 }
                 self.repository.create(app_dict)
                 logger.info("Application %s persisted to repository.", application_id)

--- a/main.py
+++ b/main.py
@@ -168,6 +168,7 @@ async def lifespan(app: FastAPI):
     reports.init_reports(verify_role, get_signing_keys, sanitise_log_field, logger)
     marketplace.init_marketplace(verify_role)
     lms.init_lms(verify_role, db_firestore)
+    advisory.init_advisory(verify_role)
 
     # Backfill Firebase custom-claim 'role' for all existing users so that
     # Firestore security rules (request.auth.token.role) are consistent with


### PR DESCRIPTION
Fixes #1062 — POST /api/advisory and GET /api/advisory/{user_id} had no
authentication checks, enabling two vulnerabilities:

1. Unauthenticated write: any caller could POST with store_alerts=true and
   an arbitrary user_id to store alerts under any user's UID, including
   another farmer's Firebase UID.

2. IDOR on read: GET /api/advisory/{user_id} returned stored alerts for
   any user_id path parameter with no token verification, allowing any
   caller to read another user's advisory history by guessing or
   enumerating UIDs.

Changes to backend/routers/advisory.py:
- Add init_advisory(verify_role_fn) dependency injection function so the
  router receives verify_role from main.py lifespan (same pattern as all
  other routers).
- Remove user_id from AdvisoryRequest — the authoritative identity is
  always derived from the verified Firebase ID token, never from the
  request body.
- POST /api/advisory: require authentication only when store_alerts=True.
  Unauthenticated callers may still generate transient advisories
  (store_alerts=False) for public widgets. When storing, uid comes from
  the verified token exclusively.
- Replace GET /api/advisory/{user_id} with GET /api/advisory/me: the
  caller can only read their own stored alerts, identified by the verified
  token UID. The path parameter is removed entirely so there is no URL
  to enumerate.
- Add threading.Lock around _stored_alerts reads and writes for
  thread-safety (the defaultdict was previously accessed without a lock).

Changes to main.py:
- Call advisory.init_advisory(verify_role) in lifespan startup.