### PR TITLE
fix: correct FinanceApplication dataclass field ordering and remove duplicate owner_uid

### DIFF
--- a/farm_finance_ai.py
+++ b/farm_finance_ai.py
@@ -34,7 +34,6 @@ class FinanceApplication:
     created_at: str
     assessment_score: float
     risk_level: str
-    owner_uid: str = ""
     required_documents: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
     # owner_uid ties the application to the Firebase UID of the farmer who
@@ -234,7 +233,6 @@ class FarmFinanceAI:
             created_at=datetime.now().isoformat(),
             assessment_score=analysis["financial_health_score"],
             risk_level=analysis["risk_level"],
-            owner_uid=owner_uid,
             required_documents=analysis["required_documents"],
             notes=analysis["action_plan"],
             owner_uid=owner_uid,
@@ -257,7 +255,6 @@ class FarmFinanceAI:
                     "owner_uid": application.owner_uid,
                     "required_documents": application.required_documents,
                     "notes": application.notes,
-                    "owner_uid": application.owner_uid,
                 }
                 self.repository.create(app_dict)
                 logger.info("Application %s persisted to repository.", application_id)


### PR DESCRIPTION
Fixes #1064 — the FinanceApplication dataclass had owner_uid: str = '' declared between non-default fields (risk_level: str) and default fields (required_documents, notes). Python dataclasses require all fields with defaults to come after fields without defaults. This ordering violation raises TypeError: non-default argument 'owner_uid' follows default argument at class definition time on affected Python versions, crashing the entire module import and taking down all finance, report, and loan application endpoints.

The dataclass also declared owner_uid twice:
  owner_uid: str = ''                          (line ~37, wrong position)
  owner_uid: Optional[str] = field(default=None)  (line ~44, correct)

Python silently replaces the first with the second, but the first declaration still causes the ordering violation before the replacement takes effect.

Additionally, create_application() passed owner_uid=owner_uid twice as a keyword argument to the FinanceApplication constructor, raising TypeError: __init__() got multiple values for keyword argument 'owner_uid' at runtime on every loan application creation. The app_dict in the repository persistence block also had a duplicate 'owner_uid' key.

Changes:
- Remove owner_uid: str = '' (the misplaced first declaration).
- Keep only owner_uid: Optional[str] = field(default=None) after notes, which is the correct position (all default fields together at the end).
- Remove the first owner_uid=owner_uid kwarg from the FinanceApplication constructor call, keeping only the single trailing one.
- Remove the duplicate 'owner_uid' key from app_dict.

#