### PR TITLE
fix: remove duplicate insecure whatsapp_webhook and deduplicate alerts.py

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -5,15 +5,18 @@ import hmac
 import os
 import re
 import urllib.parse
-from fastapi import APIRouter, Request, HTTPException, Query, Form
-from pydantic import BaseModel, Field
 from datetime import datetime
 
+from fastapi import APIRouter, Form, HTTPException, Query, Request
+from pydantic import BaseModel, Field
+
 router = APIRouter()
+
 
 class AlertTriggerRequest(BaseModel):
     alert_type: str = Field(..., pattern=r'^(weather|pest|advisory)$')
     message: str = Field(..., min_length=1, max_length=500)
+
 
 notification_store = None
 subscriber_store = None
@@ -22,75 +25,10 @@ send_whatsapp_fn = None
 format_alert_fn = None
 verify_role_fn = None
 
-def init_alerts(ns, ss, ga_fn, sw_fn, fa_fn, vr_fn):
-    global notification_store, subscriber_store, generate_alerts_fn, send_whatsapp_fn, format_alert_fn, verify_role_fn
-    notification_store = ns
-    subscriber_store = ss
-    generate_alerts_fn = ga_fn
-    send_whatsapp_fn = sw_fn
-    format_alert_fn = fa_fn
-    verify_role_fn = vr_fn
-
-
-def _verify_twilio_signature(request: Request, body: bytes) -> None:
-    """Validate the X-Twilio-Signature header using HMAC-SHA1.
-
-    Twilio signs every webhook request with:
-        HMAC-SHA1(auth_token, url + sorted_params)
-
-    If the signature is absent or does not match we raise HTTP 403 so
-    forged requests are rejected before any processing occurs.
-
-    Reference: https://www.twilio.com/docs/usage/webhooks/webhooks-security
-    """
-    auth_token = os.getenv("TWILIO_AUTH_TOKEN", "")
-    if not auth_token:
-        # If the token is not configured we cannot verify — fail closed.
-        raise HTTPException(
-            status_code=500,
-            detail="Webhook signature verification is not configured",
-        )
-
-    twilio_signature = request.headers.get("X-Twilio-Signature", "")
-    if not twilio_signature:
-        raise HTTPException(status_code=403, detail="Missing Twilio signature")
-
-    # Reconstruct the full URL exactly as Twilio sees it.
-    url = str(request.url)
-
-    # Parse the form-encoded body and sort parameters alphabetically.
-    try:
-        params = urllib.parse.parse_qsl(body.decode("utf-8"), keep_blank_values=True)
-    except Exception:
-        params = []
-    sorted_params = sorted(params, key=lambda kv: kv[0])
-
-    # Build the string Twilio signs: URL + key1value1key2"""Alerts & Notifications Router"""
-import base64
-import hashlib
-import hmac
-import os
-import re
-import urllib.parse
-from fastapi import APIRouter, Request, HTTPException, Query, Form
-from pydantic import BaseModel, Field
-from datetime import datetime
-
-router = APIRouter()
-
-class AlertTriggerRequest(BaseModel):
-    alert_type: str = Field(..., pattern=r'^(weather|pest|advisory)$')
-    message: str = Field(..., min_length=1, max_length=500)
-
-notification_store = None
-subscriber_store = None
-generate_alerts_fn = None
-send_whatsapp_fn = None
-format_alert_fn = None
-verify_role_fn = None
 
 def init_alerts(ns, ss, ga_fn, sw_fn, fa_fn, vr_fn):
-    global notification_store, subscriber_store, generate_alerts_fn, send_whatsapp_fn, format_alert_fn, verify_role_fn
+    global notification_store, subscriber_store, generate_alerts_fn
+    global send_whatsapp_fn, format_alert_fn, verify_role_fn
     notification_store = ns
     subscriber_store = ss
     generate_alerts_fn = ga_fn
@@ -155,54 +93,55 @@ def _validate_whatsapp_number(raw: str) -> str:
     """
     number = raw.replace("whatsapp:", "").strip()
     # E.164: optional leading +, then 7–15 digits
-    if not re.fullmatch(r"\+?\d{7,15}", number):value2...
-    signing_string = url + "".join(k + v for k, v in sorted_params)
-
-    expected = hmac.new(
-        auth_token.encode("utf-8"),
-        signing_string.encode("utf-8"),
-        hashlib.sha1,
-    ).digest()
-
-    expected_b64 = base64.b64encode(expected).decode("utf-8")
-
-    if not hmac.compare_digest(expected_b64, twilio_signature):
-        raise HTTPException(status_code=403, detail="Invalid Twilio signature")
-
-
-def _validate_whatsapp_number(raw: str) -> str:
-    """Strip the 'whatsapp:' prefix and do basic E.164 sanity check.
-
-    Raises HTTP 400 for values that don't look like a phone number so
-    the raw From field cannot be used to inject arbitrary strings.
-    """
-    number = raw.replace("whatsapp:", "").strip()
-    # E.164: optional leading +, then 7–15 digits
     if not re.fullmatch(r"\+?\d{7,15}", number):
         raise HTTPException(status_code=400, detail="Invalid sender number")
     return number
 
+
 @router.get("/notifications")
-async def get_notifications(request: Request, crop: str = Query(None), irrigation_count: int = Query(None, ge=0), water_coverage: int = Query(None, ge=0, le=100), season: str = Query(None)):
+async def get_notifications(
+    request: Request,
+    crop: str = Query(None),
+    irrigation_count: int = Query(None, ge=0),
+    water_coverage: int = Query(None, ge=0, le=100),
+    season: str = Query(None),
+):
     if notification_store is None or generate_alerts_fn is None:
         raise HTTPException(status_code=500, detail="Not initialized")
-    dynamic_alerts = generate_alerts_fn(crop=crop, irrigation_count=irrigation_count, water_coverage=water_coverage, season=season)
+    dynamic_alerts = generate_alerts_fn(
+        crop=crop,
+        irrigation_count=irrigation_count,
+        water_coverage=water_coverage,
+        season=season,
+    )
     return {"success": True, "data": notification_store.get_recent() + dynamic_alerts}
 
+
 @router.post("/whatsapp/subscribe")
-async def subscribe_whatsapp(request: Request, phone_number: str = Form(...), name: str = Form(...)):
+async def subscribe_whatsapp(
+    request: Request,
+    phone_number: str = Form(...),
+    name: str = Form(...),
+):
     if not all([subscriber_store, send_whatsapp_fn, verify_role_fn]):
         raise HTTPException(status_code=500, detail="Not initialized")
     try:
         token_data = await verify_role_fn(request)
         uid = token_data["uid"]
-        subscriber = {"phone_number": phone_number, "name": name, "subscribed_at": datetime.now().isoformat()}
+        subscriber = {
+            "phone_number": phone_number,
+            "name": name,
+            "subscribed_at": datetime.now().isoformat(),
+        }
         subscriber_store.upsert(uid, subscriber)
         welcome_msg = f"Namaste {name}! 🙏\nWelcome to *Fasal Saathi WhatsApp Alerts*."
         send_whatsapp_fn(phone_number, welcome_msg)
         return {"success": True, "message": "Successfully subscribed"}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
+
 
 @router.post("/whatsapp/trigger-alert")
 async def trigger_whatsapp_alert(request: Request, data: AlertTriggerRequest):
@@ -215,31 +154,26 @@ async def trigger_whatsapp_alert(request: Request, data: AlertTriggerRequest):
         formatted_msg = format_alert_fn(data.alert_type, data.message)
         for user_id, info in subscribers.items():
             res = send_whatsapp_fn(info["phone_number"], formatted_msg)
-            results.append({"user_id": user_id, "success": res.get("success", False), "status": res.get("status", "error")})
+            results.append({
+                "user_id": user_id,
+                "success": res.get("success", False),
+                "status": res.get("status", "error"),
+            })
         notification_store.append(alert_type=data.alert_type, message=data.message)
         delivered = sum(1 for r in results if r["success"])
         return {"success": True, "results": results, "delivered": delivered, "total": len(results)}
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e))
 
+
 @router.post("/whatsapp/webhook")
-async def whatsapp_webhook(Body: str = Form(...), From: str = Form(...)):
-    """
-    Handle incoming WhatsApp messages from Twilio.
-    
-    Processing is offloaded to a background Celery task to immediately
-    acknowledge the webhook (preventing Twilio timeout/penalties under burst traffic)
-    and process the message asynchronously.
-    """
-    if send_whatsapp_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
-    sender_number = From.replace("whatsapp:", "")
-    
-    # Offload message processing to reliable background task queue
-    from celery_worker import process_whatsapp_webhook_task
-    process_whatsapp_webhook_task.delay(Body, sender_number)
-    
-async def whatsapp_webhook(request: Request, Body: str = Form(...), From: str = Form(...)):
+async def whatsapp_webhook(
+    request: Request,
+    Body: str = Form(...),
+    From: str = Form(...),
+):
     """Receive inbound WhatsApp messages from Twilio.
 
     Security controls applied:

--- a/farm_finance_ai.py
+++ b/farm_finance_ai.py
@@ -34,7 +34,6 @@ class FinanceApplication:
     created_at: str
     assessment_score: float
     risk_level: str
-    owner_uid: str = ""
     required_documents: List[str] = field(default_factory=list)
     notes: List[str] = field(default_factory=list)
     # owner_uid ties the application to the Firebase UID of the farmer who
@@ -234,7 +233,6 @@ class FarmFinanceAI:
             created_at=datetime.now().isoformat(),
             assessment_score=analysis["financial_health_score"],
             risk_level=analysis["risk_level"],
-            owner_uid=owner_uid,
             required_documents=analysis["required_documents"],
             notes=analysis["action_plan"],
             owner_uid=owner_uid,
@@ -257,7 +255,6 @@ class FarmFinanceAI:
                     "owner_uid": application.owner_uid,
                     "required_documents": application.required_documents,
                     "notes": application.notes,
-                    "owner_uid": application.owner_uid,
                 }
                 self.repository.create(app_dict)
                 logger.info("Application %s persisted to repository.", application_id)


### PR DESCRIPTION
Fixes #1061 — alerts.py was self-concatenated: the entire file content
appeared twice, resulting in two async def whatsapp_webhook definitions
at module scope. Python silently replaces the first with the second, so
the insecure version (no request parameter, no Twilio HMAC-SHA1 signature
verification, no sender number validation, no return statement) was the
one registered with FastAPI.

Consequences of the insecure version winning:
1. Any attacker could POST arbitrary Body and From values to the webhook
   endpoint and trigger bot responses to any phone number — the Twilio
   signature check was completely bypassed.
2. The function had no return statement, so FastAPI returned None and
   every legitimate Twilio webhook delivery received a 500 response,
   causing Twilio to retry and eventually disable the webhook.

Fix: rewrite alerts.py as a single canonical file containing exactly one
whatsapp_webhook definition — the secure version that:
- Accepts request: Request as the first parameter.
- Reads the raw body with await request.body() before FastAPI consumes
  the Form parameters.
- Calls _verify_twilio_signature(request, raw_body) to validate the
  HMAC-SHA1 signature against TWILIO_AUTH_TOKEN.
- Calls _validate_whatsapp_number(From) to enforce E.164 format.
- Returns {'status': 'success'} so Twilio receives HTTP 200.

Also add HTTPException re-raises in subscribe_whatsapp and
trigger_whatsapp_alert so auth errors (401/403) propagate correctly
instead of being swallowed by the bare except Exception handler.