### PR TITLE
fix: correct sliding window in predict_yield_trend_task (#1080)

### DIFF
--- a/celery_worker.py
+++ b/celery_worker.py
@@ -113,7 +113,7 @@ def predict_yield_trend_task(self, data: list):
             pred = model.predict([features])[0]
             pred_value = round(float(pred), 2)
             trend.append(pred_value)
-            temp = [pred_value] + temp
+            temp = temp[1:] + [pred_value]
 
         return {
             "trend": trend,


### PR DESCRIPTION
Replace temp = [pred_value] + temp with temp = temp[1:] + [pred_value] so the window advances forward in time rather than growing unboundedly.

Previously, prepending each prediction caused the window to grow from 5 to 6, 7, 8... elements. features = temp[:5] then always sliced the 5 most-recently-prepended values, meaning by step 3 the original input data was fully displaced and the model was predicting solely from its own prior outputs, compounding any initial bias.

With the corrected append-and-drop approach the window stays exactly 5 elements, always representing the most recent chronological values, so each step uses a proper rolling window of real + predicted data.

Closes #1080



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Updates**
  * Modified yield trend forecasting logic to correctly sequence prediction calculations during multi-step forecasts.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1102?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->