### PR TITLE
Fix/community fetch authors by doc

### DIFF
--- a/frontend/Community.jsx
+++ b/frontend/Community.jsx
@@ -124,9 +124,9 @@ const Community = () => {
       for (const id of authorIds) {
         if (!newAuthorsData[id]) {
           try {
-            const userDoc = await getDocs(query(collection(db, "users"), where("uid", "==", id)));
-            if (!userDoc.empty) {
-              newAuthorsData[id] = userDoc.docs[0].data();
+            const userDoc = await getDoc(doc(db, "users", id));
+            if (userDoc.exists()) {
+              newAuthorsData[id] = userDoc.data();
               changed = true;
             }
           } catch (err) {


### PR DESCRIPTION

Community.jsx
 — lines 128–130

// Before (broken)
const userDoc = await getDocs(query(collection(db, "users"), where("uid", "==", id)));
if (!userDoc.empty) {
  newAuthorsData[id] = userDoc.docs[0].data();

// After (fixed)
const userDoc = await getDoc(doc(db, "users", id));
if (userDoc.exists()) {
  newAuthorsData[id] = userDoc.data();
The collection query with where("uid", "==", id) never matched anything because Firestore user documents use the Firebase UID as the document ID, not as a field. Switching to a direct getDoc by document ID resolves the lookup correctly. getDoc was already imported, so no import changes were needed.

closes #1082 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized author profile data retrieval for improved performance.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1110?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->