### PR TITLE
fix: require auth for notification REST and WebSocket (#1128)

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -106,15 +106,18 @@ async def get_notifications(
     water_coverage: int = Query(None, ge=0, le=100),
     season: str = Query(None),
 ):
-    if notification_store is None or generate_alerts_fn is None:
+    if notification_store is None or generate_alerts_fn is None or verify_role_fn is None:
         raise HTTPException(status_code=500, detail="Not initialized")
+    token_data = await verify_role_fn(request)
+    uid = token_data["uid"]
     dynamic_alerts = generate_alerts_fn(
         crop=crop,
         irrigation_count=irrigation_count,
         water_coverage=water_coverage,
         season=season,
     )
-    return {"success": True, "data": notification_store.get_recent() + dynamic_alerts}
+    stored = notification_store.get_recent_for_user(uid)
+    return {"success": True, "data": stored + dynamic_alerts}
 
 
 @router.post("/whatsapp/subscribe")

--- a/frontend/Notifications.jsx
+++ b/frontend/Notifications.jsx
@@ -1,6 +1,8 @@
 import { useEffect, useRef } from "react";
 import { toast } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
+import apiClient from "./lib/apiClient";
+import { auth } from "./lib/firebase";
 
 export default function useNotifications() {
   const seenIdsRef = useRef(new Set());
@@ -20,18 +22,29 @@ export default function useNotifications() {
     });
   };
 
-  const buildStreamUrl = () => {
+  const getIdToken = async () => {
+    const user = auth.currentUser;
+    if (!user) {
+      return null;
+    }
+    return user.getIdToken();
+  };
+
+  const buildStreamUrl = async () => {
     const apiBase = import.meta.env.VITE_API_BASE || window.location.origin;
     const url = new URL("/api/notifications/stream", apiBase);
     url.protocol = url.protocol === "https:" ? "wss:" : "ws:";
+    const token = await getIdToken();
+    if (token) {
+      url.searchParams.set("token", token);
+    }
     return url.toString();
   };
 
   const fetchNotifications = async () => {
     try {
-      const apiBase = import.meta.env.VITE_API_BASE || "";
-      const res = await fetch(`${apiBase}/api/notifications`);
-      const data = await res.json();
+      const res = await apiClient.get("/api/notifications");
+      const data = res.data;
 
       if (data.success) {
         data.data.forEach(markAndToast);
@@ -58,11 +71,27 @@ export default function useNotifications() {
       }
     };
 
-    fetchNotifications();
+    const connectWebSocket = async () => {
+      if (!auth.currentUser) {
+        startPollingFallback();
+        return;
+      }
 
-    if (typeof WebSocket !== "undefined") {
+      fetchNotifications();
+
+      if (typeof WebSocket === "undefined") {
+        startPollingFallback();
+        return;
+      }
+
       try {
-        websocket = new WebSocket(buildStreamUrl());
+        const streamUrl = await buildStreamUrl();
+        if (!streamUrl.includes("token=")) {
+          startPollingFallback();
+          return;
+        }
+
+        websocket = new WebSocket(streamUrl);
 
         websocket.onmessage = (event) => {
           try {
@@ -95,9 +124,9 @@ export default function useNotifications() {
         console.log("Notification websocket unavailable:", error);
         startPollingFallback();
       }
-    } else {
-      startPollingFallback();
-    }
+    };
+
+    connectWebSocket();
 
     return () => {
       cancelled = true;

--- a/main.py
+++ b/main.py
@@ -94,6 +94,7 @@ from alert_rules import generate_alerts
 from whatsapp_service import send_whatsapp_message, format_alert_message
 from whatsapp_store import subscriber_store
 from error_recovery_middleware import ErrorRecoveryMiddleware
+from notification_auth import filter_notifications_for_user
 from realtime_notifications import notification_broker
 from rbac_audit import audit_rbac_event, rbac_audit_trail, validate_required_roles
 from rbac import RBACMiddleware, print_rbac_matrix, RBACManager, Permission
@@ -558,12 +559,21 @@ class NotificationStore:
         self._counter = itertools.count(start=1)
         self._ttl = timedelta(hours=ttl_hours)
 
-    def append(self, alert_type: str, message: str) -> dict:
+    def append(
+        self,
+        alert_type: str,
+        message: str,
+        *,
+        recipient_uid: Optional[str] = None,
+    ) -> dict:
         """
         Add a new notification entry and return it.
 
         The ID is assigned from a monotonically increasing counter so
         concurrent calls always produce distinct values.
+
+        When ``recipient_uid`` is None the notification is a broadcast visible
+        to every authenticated user; otherwise only that UID may receive it.
         """
         with self._lock:
             entry = {
@@ -571,6 +581,7 @@ class NotificationStore:
                 "type": alert_type,
                 "message": message,
                 "time": datetime.now().isoformat(),
+                "recipient_uid": recipient_uid,
             }
             self._deque.append(entry)
         return entry
@@ -590,6 +601,10 @@ class NotificationStore:
             if datetime.fromisoformat(e["time"]) >= cutoff
         ]
 
+    def get_recent_for_user(self, uid: str) -> list:
+        """Return TTL-valid entries visible to the given Firebase UID."""
+        return filter_notifications_for_user(self.get_recent(), uid)
+
 
 # Seed the store with the initial weather advisory that was previously
 # hard-coded in the bare list.
@@ -601,11 +616,60 @@ _notification_store.append(
 notification_broker.seed_notifications(_notification_store.get_recent())
 
 
-async def publish_notification(alert_type: str, message: str) -> dict:
-    """Store a notification and broadcast it to websocket subscribers."""
-    entry = _notification_store.append(alert_type=alert_type, message=message)
+async def publish_notification(
+    alert_type: str,
+    message: str,
+    *,
+    recipient_uid: Optional[str] = None,
+) -> dict:
+    """Store a notification and fan it out to authorized websocket subscribers."""
+    entry = _notification_store.append(
+        alert_type=alert_type,
+        message=message,
+        recipient_uid=recipient_uid,
+    )
     await notification_broker.publish(entry)
     return entry
+
+
+async def _authenticate_notification_websocket(websocket: WebSocket) -> Optional[str]:
+    """
+    Verify Firebase ID token from WebSocket query param before accepting.
+
+    Browsers cannot set Authorization headers on WebSocket handshakes, so clients
+    must pass ``?token=<Firebase ID token>``.
+    """
+    token = websocket.query_params.get("token")
+    if not token or not token.strip():
+        await websocket.close(code=1008, reason="Missing authentication token")
+        return None
+
+    try:
+        decoded = auth.verify_id_token(token.strip())
+    except Exception:
+        await websocket.close(code=1008, reason="Invalid authentication token")
+        return None
+
+    uid = decoded.get("uid")
+    if not uid:
+        await websocket.close(code=1008, reason="Invalid authentication token")
+        return None
+
+    if not db_firestore:
+        await websocket.close(code=1011, reason="Authorization service unavailable")
+        return None
+
+    try:
+        user_doc = db_firestore.collection("users").document(uid).get()
+    except Exception:
+        await websocket.close(code=1011, reason="Authorization service unavailable")
+        return None
+
+    if not user_doc.exists:
+        await websocket.close(code=1008, reason="User profile not found")
+        return None
+
+    return uid
 
 
 def _normalize_dynamic_alerts(alerts: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -716,7 +780,7 @@ async def predict_yield_trend(payload: YieldInput, request: Request):
 
 @app.get("/api/notifications")
 @limiter.limit("30/minute")
-def get_notifications(
+async def get_notifications(
     request: Request,
     crop: str = Query(default=None),
     irrigation_count: int = Query(default=None, ge=0),
@@ -727,17 +791,26 @@ def get_notifications(
     Return recent triggered-alert notifications combined with dynamic
     farm advisory alerts generated from the query parameters.
 
+    Requires Firebase authentication. Notifications are scoped to broadcast
+    entries and entries targeted at the caller's UID.
+
     Only notifications newer than the store's TTL window are included,
     so the response payload stays small regardless of how long the
     process has been running.
     """
+    token_data = await verify_role(request)
+    uid = token_data["uid"]
     dynamic_alerts = generate_alerts(
         crop=crop,
         irrigation_count=irrigation_count,
         water_coverage=water_coverage,
         season=season
     )
-    return {"success": True, "data": _notification_store.get_recent() + _normalize_dynamic_alerts(dynamic_alerts)}
+    stored = _notification_store.get_recent_for_user(uid)
+    return {
+        "success": True,
+        "data": stored + _normalize_dynamic_alerts(dynamic_alerts),
+    }
 
 # --- WhatsApp Service Endpoints ---
 #
@@ -820,7 +893,10 @@ async def trigger_whatsapp_alert(data: AlertTriggerRequest, request: Request):
 
 @app.websocket("/api/notifications/stream")
 async def notifications_stream(websocket: WebSocket):
-    await notification_broker.connect(websocket)
+    uid = await _authenticate_notification_websocket(websocket)
+    if uid is None:
+        return
+    await notification_broker.connect(websocket, uid)
 
 
 @app.get("/api/admin/rbac-audit")

--- a/notification_auth.py
+++ b/notification_auth.py
@@ -1,0 +1,32 @@
+"""
+Helpers for authenticated notification access and per-user scoping.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable, List, Optional
+
+
+def notification_visible_to_user(
+    notification: Dict[str, Any],
+    uid: str,
+) -> bool:
+    """
+    Return True when a notification is visible to the given user.
+
+    Broadcast notifications omit ``recipient_uid`` (or set it to None) and are
+    visible to every authenticated user. Targeted notifications include
+    ``recipient_uid`` and are only visible to that user.
+    """
+    recipient = notification.get("recipient_uid")
+    if recipient is None:
+        return True
+    return recipient == uid
+
+
+def filter_notifications_for_user(
+    notifications: Iterable[Dict[str, Any]],
+    uid: str,
+) -> List[Dict[str, Any]]:
+    """Return notifications visible to ``uid``, preserving order."""
+    return [n for n in notifications if notification_visible_to_user(n, uid)]

--- a/realtime_notifications.py
+++ b/realtime_notifications.py
@@ -15,6 +15,8 @@ from typing import Any, Deque, Dict, Iterable, Optional
 
 from fastapi import WebSocket, WebSocketDisconnect
 
+from notification_auth import filter_notifications_for_user, notification_visible_to_user
+
 logger = logging.getLogger(__name__)
 
 
@@ -39,6 +41,10 @@ class NotificationBroadcastHub:
     immediate snapshot. If REDIS_URL is configured and redis.asyncio is
     available, the hub also publishes to a Redis channel so multiple workers can
     fan out the same event across processes.
+
+    Each WebSocket connection is bound to a Firebase UID; snapshots and live
+    events are filtered so clients only receive notifications they are allowed
+    to see (broadcast or targeted to their UID).
     """
 
     def __init__(
@@ -48,7 +54,7 @@ class NotificationBroadcastHub:
         redis_channel: str = "fasal_saathi.notifications",
     ) -> None:
         self._history: Deque[Dict[str, Any]] = collections.deque(maxlen=history_limit)
-        self._connections: set[WebSocket] = set()
+        self._connections: dict[WebSocket, str] = {}
         self._history_lock = asyncio.Lock()
         self._broadcast_lock = asyncio.Lock()
         self._redis_url = redis_url or os.getenv("REDIS_URL")
@@ -66,6 +72,10 @@ class NotificationBroadcastHub:
     def snapshot(self) -> list[Dict[str, Any]]:
         """Return a copy of the current history."""
         return list(self._history)
+
+    def snapshot_for_user(self, uid: str) -> list[Dict[str, Any]]:
+        """Return history entries visible to the given user."""
+        return filter_notifications_for_user(self._history, uid)
 
     async def start(self) -> None:
         """Start optional Redis pub-sub listener."""
@@ -117,7 +127,7 @@ class NotificationBroadcastHub:
         self._started = False
 
     async def publish(self, notification: Dict[str, Any], source: str = "local") -> NotificationEvent:
-        """Persist notification locally and fan it out to connected clients."""
+        """Persist notification locally and fan it out to subscribed clients."""
         event = NotificationEvent(type="notification", data=notification, source=source)
         payload = {
             "type": event.type,
@@ -128,7 +138,11 @@ class NotificationBroadcastHub:
 
         async with self._history_lock:
             self._history.append(notification)
-            clients = list(self._connections)
+            clients = [
+                (websocket, uid)
+                for websocket, uid in self._connections.items()
+                if notification_visible_to_user(notification, uid)
+            ]
 
         await self._broadcast(payload, clients)
 
@@ -140,12 +154,12 @@ class NotificationBroadcastHub:
 
         return event
 
-    async def connect(self, websocket: WebSocket) -> None:
+    async def connect(self, websocket: WebSocket, uid: str) -> None:
         """Accept a websocket client and keep it subscribed until disconnect."""
         await websocket.accept()
         async with self._history_lock:
-            self._connections.add(websocket)
-            snapshot = list(self._history)
+            self._connections[websocket] = uid
+            snapshot = filter_notifications_for_user(self._history, uid)
 
         await websocket.send_json(
             {
@@ -164,15 +178,19 @@ class NotificationBroadcastHub:
             pass
         finally:
             async with self._history_lock:
-                self._connections.discard(websocket)
+                self._connections.pop(websocket, None)
 
-    async def _broadcast(self, payload: Dict[str, Any], clients: list[WebSocket]) -> None:
+    async def _broadcast(
+        self,
+        payload: Dict[str, Any],
+        clients: list[tuple[WebSocket, str]],
+    ) -> None:
         if not clients:
             return
 
         async with self._broadcast_lock:
             stale_clients: list[WebSocket] = []
-            for websocket in clients:
+            for websocket, _uid in clients:
                 try:
                     await websocket.send_json(payload)
                 except Exception:
@@ -181,7 +199,7 @@ class NotificationBroadcastHub:
             if stale_clients:
                 async with self._history_lock:
                     for websocket in stale_clients:
-                        self._connections.discard(websocket)
+                        self._connections.pop(websocket, None)
 
     async def _redis_listener(self) -> None:
         try:
@@ -193,7 +211,11 @@ class NotificationBroadcastHub:
                 if isinstance(notification, dict):
                     async with self._history_lock:
                         self._history.append(notification)
-                        clients = list(self._connections)
+                        clients = [
+                            (websocket, uid)
+                            for websocket, uid in self._connections.items()
+                            if notification_visible_to_user(notification, uid)
+                        ]
                     await self._broadcast(payload, clients)
         except asyncio.CancelledError:
             raise

--- a/test_realtime_notifications.py
+++ b/test_realtime_notifications.py
@@ -14,7 +14,8 @@ def create_test_app():
 
     @app.websocket("/api/notifications/stream")
     async def notifications_stream(websocket: WebSocket):
-        await hub.connect(websocket)
+        uid = websocket.query_params.get("uid", "test-user")
+        await hub.connect(websocket, uid)
 
     @app.post("/api/notifications/test-publish")
     async def publish_notification():
@@ -24,6 +25,7 @@ def create_test_app():
                 "type": "weather",
                 "message": "Heavy rainfall expected in your region today.",
                 "time": "2026-05-20T10:00:00",
+                "recipient_uid": None,
             }
         )
         return {"success": True}
@@ -40,12 +42,13 @@ def test_websocket_receives_snapshot_and_live_notification():
                 "type": "advisory",
                 "message": "Irrigate crops early in the morning.",
                 "time": "2026-05-20T09:00:00",
+                "recipient_uid": None,
             }
         ]
     )
     client = TestClient(app)
 
-    with client.websocket_connect("/api/notifications/stream") as websocket:
+    with client.websocket_connect("/api/notifications/stream?uid=test-user") as websocket:
         snapshot = websocket.receive_json()
         assert snapshot["type"] == "snapshot"
         assert len(snapshot["data"]) == 1
@@ -64,11 +67,11 @@ def test_multiple_clients_receive_same_broadcast():
     app, hub = create_test_app()
     client = TestClient(app)
 
-    with client.websocket_connect("/api/notifications/stream") as ws1:
+    with client.websocket_connect("/api/notifications/stream?uid=user-1") as ws1:
         snapshot1 = ws1.receive_json()
         assert snapshot1["type"] == "snapshot"
 
-        with client.websocket_connect("/api/notifications/stream") as ws2:
+        with client.websocket_connect("/api/notifications/stream?uid=user-2") as ws2:
             snapshot2 = ws2.receive_json()
             assert snapshot2["type"] == "snapshot"
 
@@ -81,3 +84,18 @@ def test_multiple_clients_receive_same_broadcast():
             assert event1["type"] == "notification"
             assert event2["type"] == "notification"
             assert event1["data"]["id"] == event2["data"]["id"] == 101
+
+
+def test_targeted_notification_only_reaches_intended_client():
+    hub = NotificationBroadcastHub(history_limit=10)
+    from notification_auth import notification_visible_to_user
+
+    notification = {
+        "id": 55,
+        "type": "private",
+        "message": "Only for alice",
+        "recipient_uid": "alice",
+    }
+    assert notification_visible_to_user(notification, "alice")
+    assert not notification_visible_to_user(notification, "bob")
+

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -24,11 +24,9 @@ def test_predict_yield_unauthorized(client: TestClient):
     response = client.post("/predict", json={})
     assert response.status_code == 422  # Unprocessable Entity (Validation Error)
 
-def test_notifications(client: TestClient):
+def test_notifications_requires_authentication(client: TestClient):
     """
-    Test the notifications endpoint.
+    Test the notifications endpoint rejects unauthenticated access.
     """
     response = client.get("/api/notifications")
-    assert response.status_code == 200
-    assert response.json()["success"] is True
-    assert isinstance(response.json()["data"], list)
+    assert response.status_code == 401

--- a/tests/test_notification_auth.py
+++ b/tests/test_notification_auth.py
@@ -1,0 +1,118 @@
+"""
+Integration tests for authenticated notification endpoints.
+
+Skipped when optional application dependencies are not installed locally.
+"""
+
+import pytest
+
+pytest.importorskip("qrcode")
+
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+
+import main
+from realtime_notifications import NotificationBroadcastHub
+
+
+def _make_fake_firestore(roles):
+    class _FakeDoc:
+        def __init__(self, role):
+            self.exists = True
+            self._role = role
+
+        def to_dict(self):
+            return {"role": self._role}
+
+    class _FakeUserRef:
+        def __init__(self, uid):
+            self._uid = uid
+
+        def get(self):
+            role = roles.get(self._uid)
+            if role is None:
+                return type("Missing", (), {"exists": False})()
+            return _FakeDoc(role)
+
+    class _FakeCollection:
+        def document(self, uid):
+            return _FakeUserRef(uid)
+
+    class _FakeFirestore:
+        def collection(self, name):
+            return _FakeCollection()
+
+    return _FakeFirestore()
+
+
+@pytest.fixture()
+def notification_client(monkeypatch):
+    monkeypatch.setattr(main.firebase_auth, "verify_id_token", lambda token: {"uid": token})
+    monkeypatch.setattr(main, "db_firestore", _make_fake_firestore({"farmer-user": "farmer"}))
+    return TestClient(main.app)
+
+
+def test_get_notifications_requires_auth(notification_client):
+    response = notification_client.get("/api/notifications")
+    assert response.status_code == 401
+
+
+def test_get_notifications_authenticated(notification_client):
+    response = notification_client.get(
+        "/api/notifications",
+        headers={"Authorization": "Bearer farmer-user"},
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True
+    assert isinstance(response.json()["data"], list)
+
+
+def test_websocket_rejects_missing_token():
+    app = FastAPI()
+    hub = NotificationBroadcastHub(history_limit=10)
+
+    @app.websocket("/api/notifications/stream")
+    async def notifications_stream(websocket: WebSocket):
+        uid = await main._authenticate_notification_websocket(websocket)
+        if uid is None:
+            return
+        await hub.connect(websocket, uid)
+
+    client = TestClient(app)
+    with pytest.raises(Exception):
+        with client.websocket_connect("/api/notifications/stream"):
+            pass
+
+
+def test_websocket_scoped_snapshot(monkeypatch):
+    monkeypatch.setattr(main.firebase_auth, "verify_id_token", lambda token: {"uid": token})
+    monkeypatch.setattr(main, "db_firestore", _make_fake_firestore({"alice": "farmer", "bob": "farmer"}))
+
+    app = FastAPI()
+    hub = NotificationBroadcastHub(history_limit=10)
+    hub.seed_notifications(
+        [
+            {"id": 1, "type": "broadcast", "message": "for all", "recipient_uid": None},
+            {"id": 2, "type": "private", "message": "for alice", "recipient_uid": "alice"},
+        ]
+    )
+
+    @app.websocket("/api/notifications/stream")
+    async def notifications_stream(websocket: WebSocket):
+        uid = await main._authenticate_notification_websocket(websocket)
+        if uid is None:
+            return
+        await hub.connect(websocket, uid)
+
+    client = TestClient(app)
+
+    with client.websocket_connect("/api/notifications/stream?token=alice") as ws:
+        snapshot = ws.receive_json()
+        assert snapshot["type"] == "snapshot"
+        assert len(snapshot["data"]) == 2
+
+    with client.websocket_connect("/api/notifications/stream?token=bob") as ws:
+        snapshot = ws.receive_json()
+        assert snapshot["type"] == "snapshot"
+        assert len(snapshot["data"]) == 1
+        assert snapshot["data"][0]["message"] == "for all"

--- a/tests/test_notification_scoping.py
+++ b/tests/test_notification_scoping.py
@@ -1,0 +1,23 @@
+"""Unit tests for notification visibility helpers (no main.py import)."""
+
+from notification_auth import filter_notifications_for_user, notification_visible_to_user
+
+
+def test_notification_visible_broadcast_and_targeted():
+    broadcast = {"id": 1, "message": "all", "recipient_uid": None}
+    targeted = {"id": 2, "message": "private", "recipient_uid": "user-a"}
+
+    assert notification_visible_to_user(broadcast, "user-a")
+    assert notification_visible_to_user(broadcast, "user-b")
+    assert notification_visible_to_user(targeted, "user-a")
+    assert not notification_visible_to_user(targeted, "user-b")
+
+
+def test_filter_notifications_for_user():
+    items = [
+        {"id": 1, "recipient_uid": None},
+        {"id": 2, "recipient_uid": "alice"},
+        {"id": 3, "recipient_uid": "bob"},
+    ]
+    filtered = filter_notifications_for_user(items, "alice")
+    assert [entry["id"] for entry in filtered] == [1, 2]


### PR DESCRIPTION
Summary
- Require Firebase authentication on `GET /api/notifications` and `/api/notifications/stream`
- Scope in-memory notifications per UID (`recipient_uid` for targeted, `None` for broadcast)
- Pass ID token via WebSocket query param and `apiClient` for REST from `Notifications.jsx`

## Test plan
- [ ] `GET /api/notifications` without token returns 401
- [ ] Authenticated farmer receives broadcast alerts only
- [ ] WebSocket without `?token=` is rejected
- [ ] WebSocket with valid token receives scoped snapshot and live events

fixes #1128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Notifications now require user authentication to access.
  * Added support for targeted notifications sent to specific users.
  * Broadcast notifications remain visible to all authenticated users.
  * Real-time notification streaming now authenticates users via Firebase tokens.

* **Tests**
  * Added comprehensive test coverage for authenticated notification endpoints and WebSocket connections.
  * Added tests validating notification visibility scoping for individual users.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1132?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->