### PR TITLE
fix: unify authorization across Firestore, JWT claims, and RBAC (#1130)

### DIFF
--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -310,8 +310,8 @@ async def assign_role(request: Request, body: AssignRoleRequest):
     the Firestore users/{uid}.role field.  If the claim sync fails the
     Firestore update is skipped entirely, keeping both stores consistent.
 
-    The target user's next token refresh will include the updated claim.
-    Existing tokens remain valid until they expire (≤ 1 hour).
+    Refresh tokens are revoked so the target user must sign in again with the
+    updated claim (no stale-role window).
     """
     if verify_role_fn is None:
         raise HTTPException(status_code=500, detail="Not initialized")
@@ -348,7 +348,7 @@ async def assign_role(request: Request, body: AssignRoleRequest):
         "success": True,
         "target_uid": body.target_uid,
         "role": body.role,
-        "message": "Role updated. The user's next token refresh will include the new claim.",
+        "message": "Role updated. The user must sign in again to apply the new credentials.",
     }
 
 

--- a/firestore.rules
+++ b/firestore.rules
@@ -8,26 +8,22 @@ service cloud.firestore {
 
     // Role check via Firebase custom claims — zero extra Firestore reads.
     //
-    // The backend sets request.auth.token.role when issuing or refreshing
-    // tokens (via Firebase Admin SDK setCustomUserClaims). This avoids the
-    // previous pattern of calling get() on the users document on every rule
-    // evaluation, which:
-    //   1. Consumed one Firestore read per rule invocation (quota + latency).
-    //   2. Caused a recursive read when evaluating rules on /users/{userId}
-    //      itself (reading a user doc triggered another read of the same doc).
-    //   3. Could not be cached across multiple hasRole() calls in one request.
-    //
-    // Custom claims are embedded in the JWT and evaluated locally — no network
-    // round-trip, no quota cost, no recursion risk.
+    // Firestore users/{uid}.role is authoritative for the API. The backend
+    // mirrors that field into request.auth.token.role via role_sync.sync_role_claim
+    // whenever a role changes. Do NOT default missing claims to "farmer" here —
+    // that would grant farmer-scoped rule access before backfill completes and
+    // widens the stale-JWT window after demotion.
+    function roleClaim() {
+      return request.auth.token.get("role", "");
+    }
+
     function hasRole(role) {
-      return request.auth != null
-        && request.auth.token.get("role", "farmer") == role;
+      return request.auth != null && roleClaim() == role;
     }
 
     // Convenience: caller has one of several roles.
     function hasAnyRole(roles) {
-      return request.auth != null
-        && request.auth.token.get("role", "farmer") in roles;
+      return request.auth != null && roleClaim() in roles;
     }
 
     function isAuthed() {

--- a/main.py
+++ b/main.py
@@ -278,13 +278,11 @@ if not firebase_admin._apps:
 
 async def verify_role(request: Request, required_roles: list = None):
     """
-    Verify the Firebase ID token and check the caller's role against Firestore.
-    Expects 'Authorization: Bearer <ID_TOKEN>' header.
+    Verify the Firebase ID token and check the caller's role.
 
-    Fail-closed design:
-    - If Firestore is unavailable the request is rejected with 503.
-    - If the user document does not exist the request is rejected with 403.
-    - The function never grants a role that was not explicitly stored in Firestore.
+    Delegates identity resolution to :meth:`RBACManager.resolve_auth_context`,
+    which treats Firestore ``users/{uid}.role`` as authoritative and rejects
+    stale JWT custom claims that disagree with Firestore.
     """
     action = f"{request.method} {request.url.path}"
     try:
@@ -299,108 +297,53 @@ async def verify_role(request: Request, required_roles: list = None):
         )
         raise HTTPException(status_code=500, detail="RBAC policy misconfiguration") from exc
 
-    auth_header = request.headers.get("Authorization")
-    if not auth_header or not auth_header.startswith("Bearer "):
-        audit_rbac_event(
-            request=request,
-            action=action,
-            outcome="denied",
-            reason="missing_authentication_token",
-            status_code=401,
-            required_roles=required_roles,
-        )
-        raise HTTPException(status_code=401, detail="Missing or invalid authentication token")
-
-    # Use a slice instead of split()[1] to avoid IndexError when the header
-    # is exactly "Bearer " with no token following it.
-    id_token = auth_header[7:].strip()
-    if not id_token:
-        audit_rbac_event(
-            request=request,
-            action=action,
-            outcome="denied",
-            reason="missing_authentication_token",
-            status_code=401,
-            required_roles=required_roles,
-        )
-        raise HTTPException(status_code=401, detail="Missing or invalid authentication token")
-
     try:
-        decoded_token = auth.verify_id_token(id_token)
-    except Exception:
-        audit_rbac_event(
-            request=request,
-            action=action,
-            outcome="denied",
-            reason="invalid_authentication_token",
-            status_code=401,
-            required_roles=required_roles,
+        ctx = await RBACManager.resolve_auth_context(
+            request,
+            allow_unauthenticated=False,
         )
-        raise HTTPException(status_code=401, detail="Authentication failed")
+    except HTTPException as exc:
+        uid = None
+        reason = "authorization_denied"
+        if exc.status_code == 401:
+            detail = str(exc.detail).lower()
+            reason = (
+                "missing_authentication_token"
+                if "missing" in detail
+                else "invalid_authentication_token"
+            )
+        elif exc.status_code == 403:
+            detail = str(exc.detail).lower()
+            if "profile not found" in detail:
+                reason = "user_profile_not_found"
+            elif "stale" in detail:
+                reason = "stale_authentication_token"
+            elif "invalid role" in detail:
+                reason = "invalid_profile_role"
+            else:
+                reason = "insufficient_permissions"
+        elif exc.status_code == 503:
+            reason = "authorization_service_unavailable"
 
-    uid = decoded_token["uid"]
-
-    # Firestore must be available to resolve the caller's role.
-    # Failing open (granting admin when Firestore is down) is a security bug,
-    # so we reject the request instead.
-    if not db_firestore:
         audit_rbac_event(
             request=request,
             action=action,
-            outcome="error",
+            outcome="denied" if exc.status_code in (401, 403) else "error",
             uid=uid,
-            reason="authorization_service_unavailable",
-            status_code=503,
+            reason=reason,
+            status_code=exc.status_code,
             required_roles=required_roles,
         )
-        raise HTTPException(
-            status_code=503,
-            detail="Authorization service temporarily unavailable"
-        )
+        raise
 
-    # Wrap the Firestore fetch so a transient network error (timeout, reset)
-    # returns the same clean 503 as a missing db_firestore, rather than an
-    # unhandled exception that leaks internal details as a raw 500.
-    try:
-        user_doc = db_firestore.collection("users").document(uid).get()
-    except Exception as e:
-        logger.error(
-            "Firestore fetch failed for uid=%s during role check: %s", uid, e
-        )
-        audit_rbac_event(
-            request=request,
-            action=action,
-            outcome="error",
-            uid=uid,
-            reason="role_lookup_failed",
-            status_code=503,
-            required_roles=required_roles,
-        )
-        raise HTTPException(
-            status_code=503,
-            detail="Authorization service temporarily unavailable"
-        )
-
-    if not user_doc.exists:
-        audit_rbac_event(
-            request=request,
-            action=action,
-            outcome="denied",
-            uid=uid,
-            reason="user_profile_not_found",
-            status_code=403,
-            required_roles=required_roles,
-        )
-        raise HTTPException(status_code=403, detail="User profile not found")
-
-    user_role = user_doc.to_dict().get("role", "farmer")
+    user_role = ctx.role
 
     if required_roles and user_role not in required_roles:
         audit_rbac_event(
             request=request,
             action=action,
             outcome="denied",
-            uid=uid,
+            uid=ctx.uid,
             role=user_role,
             reason="insufficient_permissions",
             status_code=403,
@@ -412,13 +355,13 @@ async def verify_role(request: Request, required_roles: list = None):
         request=request,
         action=action,
         outcome="allowed",
-        uid=uid,
+        uid=ctx.uid,
         role=user_role,
         required_roles=required_roles,
         status_code=200,
     )
 
-    return {"uid": uid, "role": user_role}
+    return {"uid": ctx.uid, "role": user_role}
 
 # --- Models ---
 

--- a/rbac.py
+++ b/rbac.py
@@ -1,18 +1,48 @@
 """
 Role-Based Access Control (RBAC) Enforcement Layer
 Provides fine-grained access control across all API routes.
+
+Authorization model
+-------------------
+* **Authoritative role source (API):** Firestore ``users/{uid}.role``.
+* **JWT custom claim ``role``:** Mirror of Firestore, set via ``role_sync.sync_role_claim``.
+  The API rejects requests when the claim is present but disagrees with Firestore
+  (stale token after demotion or role change).
+* **Firestore security rules:** Read ``request.auth.token.role`` only (no ``get()`` on
+  users). Claims must be kept in sync by the backend; rules do not default missing
+  claims to elevated roles.
+* **Unauthenticated callers:** Treated as ``Role.GUEST`` only when no Bearer token is
+  supplied. Valid tokens without a user profile fail closed (403), never guest.
 """
 
+from __future__ import annotations
+
 import logging
-from typing import List, Dict, Optional, Callable
+from dataclasses import dataclass
 from enum import Enum
 from functools import wraps
+from typing import Callable, Dict, List, Optional
 
-from fastapi import HTTPException, status, Request
 import firebase_admin
+from fastapi import HTTPException, Request, status
 from firebase_admin import auth as firebase_auth, firestore
 
 logger = logging.getLogger(__name__)
+
+# Must match role_sync.VALID_ROLES and firestore.rules role strings.
+KNOWN_ROLES = frozenset({"admin", "expert", "farmer", "vendor", "system", "guest"})
+DEFAULT_PROFILE_ROLE = "farmer"
+STALE_TOKEN_DETAIL = (
+    "Authorization token is stale. Sign out and sign in again to refresh your session."
+)
+
+
+@dataclass(frozen=True, slots=True)
+class AuthContext:
+    """Resolved identity for an authenticated API request."""
+
+    uid: str
+    role: str
 
 
 class Role(Enum):
@@ -208,74 +238,119 @@ class RBACManager:
             return None
 
     @staticmethod
-    async def get_user_role(request: Request) -> Optional[Role]:
+    def _parse_bearer_token(request: Request) -> Optional[str]:
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header or not auth_header.startswith("Bearer "):
+            return None
+        token = auth_header[7:].strip()
+        return token or None
+
+    @staticmethod
+    async def resolve_auth_context(
+        request: Request,
+        *,
+        allow_unauthenticated: bool = False,
+    ) -> Optional[AuthContext]:
         """
-        Extract user role from Firebase token and Firestore.
-        
-        Returns
-        -------
-        Role or None
-            User role, or None if not authenticated
+        Resolve the caller's UID and role from Firestore (authoritative).
+
+        When ``allow_unauthenticated`` is True and no Bearer token is present,
+        returns None. Otherwise fail-closed with 401/403/503 matching ``verify_role``.
         """
-        try:
-            # Get token from Authorization header
-            auth_header = request.headers.get("Authorization", "")
-            if not auth_header:
-                return Role.GUEST
-            if not auth_header.startswith("Bearer "):
-                logger.warning("Missing or invalid Authorization header format")
-                return Role.GUEST
-
-            token = auth_header.split(" ")[1]
-
-            # Verify Firebase token
-            try:
-                decoded_token = firebase_auth.verify_id_token(token)
-                uid = decoded_token.get("uid")
-            except Exception as exc:
-                logger.error("Token verification failed: %s", exc)
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid or expired authorization token"
-                )
-
-            # Get user role from Firestore
-            db = RBACManager.get_db()
-            if db is None:
-                logger.error("Firestore not available; cannot retrieve user role")
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Authentication database service temporarily unavailable"
-                )
-
-            try:
-                user_doc = db.collection("users").document(uid).get()
-            except Exception as exc:
-                logger.error("Firestore query failed for user %s: %s", uid, exc)
-                raise HTTPException(
-                    status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-                    detail="Authentication database lookup failed"
-                )
-
-            if not user_doc.exists:
-                logger.warning("User %s not found in Firestore", uid)
-                return Role.GUEST
-
-            role_str = user_doc.get("role", "guest").lower()
-            try:
-                return Role(role_str)
-            except ValueError:
-                logger.warning("Invalid role for user %s: %s", uid, role_str)
-                return Role.GUEST
-
-        except HTTPException:
-            raise
-        except Exception as exc:
-            logger.error("Unexpected error getting user role: %s", exc)
+        token = RBACManager._parse_bearer_token(request)
+        if token is None:
+            if allow_unauthenticated:
+                return None
             raise HTTPException(
-                status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
-                detail="Internal server error during authorization verification"
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Missing or invalid authentication token",
             )
+
+        try:
+            decoded_token = firebase_auth.verify_id_token(token)
+        except Exception as exc:
+            logger.error("Token verification failed: %s", exc)
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired authorization token",
+            ) from exc
+
+        uid = decoded_token.get("uid")
+        if not uid:
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid or expired authorization token",
+            )
+
+        db = RBACManager.get_db()
+        if db is None:
+            logger.error("Firestore not available; cannot retrieve user role")
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication database service temporarily unavailable",
+            )
+
+        try:
+            user_doc = db.collection("users").document(uid).get()
+        except Exception as exc:
+            logger.error("Firestore query failed for user %s: %s", uid, exc)
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication database lookup failed",
+            ) from exc
+
+        if not user_doc.exists:
+            logger.warning("User %s not found in Firestore", uid)
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User profile not found",
+            )
+
+        role_str = (user_doc.to_dict() or {}).get("role", DEFAULT_PROFILE_ROLE)
+        if not isinstance(role_str, str):
+            role_str = DEFAULT_PROFILE_ROLE
+        role_str = role_str.strip().lower()
+
+        if role_str not in KNOWN_ROLES:
+            logger.warning("Invalid role for user %s: %s", uid, role_str)
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="Invalid role assigned to user profile",
+            )
+
+        claim_role = decoded_token.get("role")
+        if claim_role is not None:
+            claim_normalized = str(claim_role).strip().lower()
+            if claim_normalized != role_str:
+                logger.warning(
+                    "Stale JWT role for uid=%s: claim=%s firestore=%s",
+                    uid,
+                    claim_normalized,
+                    role_str,
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail=STALE_TOKEN_DETAIL,
+                )
+
+        return AuthContext(uid=uid, role=role_str)
+
+    @staticmethod
+    async def get_user_role(request: Request) -> Role:
+        """
+        Return the caller's role.
+
+        Unauthenticated requests (no Bearer token) map to ``Role.GUEST``.
+        Authenticated requests use Firestore and fail closed on missing profiles
+        or stale JWT claims.
+        """
+        ctx = await RBACManager.resolve_auth_context(
+            request,
+            allow_unauthenticated=True,
+        )
+        if ctx is None:
+            return Role.GUEST
+        return Role(ctx.role)
 
     @staticmethod
     async def verify_permission(
@@ -301,12 +376,15 @@ class RBACManager:
         bool
             True if user has required permissions
         """
-        user_role = await RBACManager.get_user_role(request)
+        ctx = await RBACManager.resolve_auth_context(
+            request,
+            allow_unauthenticated=False,
+        )
+        user_role = Role(ctx.role)
 
         if require_all:
             return RBACMatrix.has_all_permissions(user_role, required_permissions)
-        else:
-            return RBACMatrix.has_any_permission(user_role, required_permissions)
+        return RBACMatrix.has_any_permission(user_role, required_permissions)
 
     @staticmethod
     async def raise_if_unauthorized(
@@ -339,10 +417,17 @@ class RBACManager:
         )
 
         if not has_permission:
-            user_role = await RBACManager.get_user_role(request)
+            try:
+                ctx = await RBACManager.resolve_auth_context(
+                    request,
+                    allow_unauthenticated=False,
+                )
+                role_label = ctx.role
+            except HTTPException:
+                role_label = "unknown"
             logger.warning(
                 "Unauthorized access attempt with role: %s, required: %s",
-                user_role.value if user_role else "unknown",
+                role_label,
                 [p.value for p in required_permissions],
             )
             raise HTTPException(
@@ -434,7 +519,10 @@ class RBACMiddleware:
         if any(path.startswith(prefix) for prefix in self.PUBLIC_PATH_PREFIXES):
             user_role = Role.GUEST
         else:
-            user_role = await RBACManager.get_user_role(request)
+            try:
+                user_role = await RBACManager.get_user_role(request)
+            except HTTPException:
+                user_role = Role.GUEST
 
         # Log the access attempt
         logger.info(

--- a/role_sync.py
+++ b/role_sync.py
@@ -41,7 +41,19 @@ def _set_claim_sync(uid: str, role: str) -> None:
     logger.info("Custom claim set: uid=%s role=%s", uid, role)
 
 
-async def sync_role_claim(uid: str, role: str) -> None:
+def _revoke_refresh_tokens_sync(uid: str) -> None:
+    """Invalidate outstanding refresh tokens so ID tokens are re-issued promptly."""
+    import firebase_admin
+    from firebase_admin import auth as firebase_auth
+
+    if not firebase_admin._apps:
+        raise RuntimeError("Firebase Admin SDK is not initialised")
+
+    firebase_auth.revoke_refresh_tokens(uid)
+    logger.info("Refresh tokens revoked: uid=%s", uid)
+
+
+async def sync_role_claim(uid: str, role: str, *, revoke_sessions: bool = True) -> None:
     """
     Set the 'role' custom claim on the Firebase Auth user identified by uid.
 
@@ -49,9 +61,12 @@ async def sync_role_claim(uid: str, role: str) -> None:
     rules (which read request.auth.token.role) stay consistent with the
     Firestore users/{uid}.role field.
 
-    The caller's next ID-token refresh will include the updated claim.
-    Existing tokens remain valid until they expire (≤ 1 hour), after which
-    the new claim takes effect automatically.
+    By default this also revokes refresh tokens so the user must sign in again
+    and cannot keep using a stale JWT with the previous ``role`` claim (closes
+    the demotion / privilege-escalation window documented in issue #1130).
+
+    Authoritative role source for the API is Firestore ``users/{uid}.role``.
+    Custom claims are a mirror for Firestore security rules only.
 
     Raises RuntimeError if Firebase Admin is not initialised.
     Raises firebase_admin.auth.UserNotFoundError if uid does not exist.
@@ -61,9 +76,11 @@ async def sync_role_claim(uid: str, role: str) -> None:
 
     loop = asyncio.get_event_loop()
     await loop.run_in_executor(None, _set_claim_sync, uid, role)
+    if revoke_sessions:
+        await loop.run_in_executor(None, _revoke_refresh_tokens_sync, uid)
 
 
-def sync_role_claim_sync(uid: str, role: str) -> None:
+def sync_role_claim_sync(uid: str, role: str, *, revoke_sessions: bool = True) -> None:
     """
     Synchronous variant for use in non-async contexts (e.g. startup scripts,
     Celery tasks, or test fixtures).
@@ -71,6 +88,8 @@ def sync_role_claim_sync(uid: str, role: str) -> None:
     if role not in VALID_ROLES:
         raise ValueError(f"Invalid role '{role}'. Must be one of: {sorted(VALID_ROLES)}")
     _set_claim_sync(uid, role)
+    if revoke_sessions:
+        _revoke_refresh_tokens_sync(uid)
 
 
 def backfill_role_claims(db_client, batch_size: int = 100) -> dict:

--- a/tests/test_authz_unified.py
+++ b/tests/test_authz_unified.py
@@ -1,0 +1,162 @@
+"""
+Unified authorization tests (issue #1130).
+
+Firestore users/{uid}.role is authoritative; JWT claims must match or the API
+returns 403; missing profiles never map to guest when a Bearer token is present.
+"""
+
+import pytest
+from fastapi import Request
+
+from rbac import AuthContext, RBACManager, Role, STALE_TOKEN_DETAIL
+
+
+def _make_fake_firestore(roles):
+    class _FakeDoc:
+        def __init__(self, role):
+            self.exists = True
+            self._role = role
+
+        def to_dict(self):
+            return {"role": self._role}
+
+    class _FakeUserRef:
+        def __init__(self, uid):
+            self._uid = uid
+
+        def get(self):
+            role = roles.get(self._uid)
+            if role is None:
+                return type("Missing", (), {"exists": False})()
+            return _FakeDoc(role)
+
+    class _FakeCollection:
+        def document(self, uid):
+            return _FakeUserRef(uid)
+
+    class _FakeFirestore:
+        def collection(self, name):
+            return _FakeCollection()
+
+    return _FakeFirestore()
+
+
+def _request_with_token(token: str) -> Request:
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": "/test",
+        "headers": [(b"authorization", f"Bearer {token}".encode())],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+@pytest.fixture()
+def patched_auth(monkeypatch):
+    store = _make_fake_firestore(
+        {
+            "farmer-user": "farmer",
+            "admin-user": "admin",
+        }
+    )
+
+    def verify(token):
+        if token == "stale-admin-token":
+            return {"uid": "farmer-user", "role": "admin"}
+        if token == "farmer-user":
+            return {"uid": "farmer-user", "role": "farmer"}
+        if token == "admin-user":
+            return {"uid": "admin-user", "role": "admin"}
+        if token == "orphan-user":
+            return {"uid": "orphan-user", "role": "farmer"}
+        return {"uid": token, "role": "farmer"}
+
+    monkeypatch.setattr(RBACManager, "get_db", staticmethod(lambda: store))
+    monkeypatch.setattr("rbac.firebase_auth.verify_id_token", verify)
+    return store
+
+
+@pytest.mark.asyncio
+async def test_resolve_auth_context_allows_anonymous(patched_auth):
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)
+    assert await RBACManager.resolve_auth_context(request, allow_unauthenticated=True) is None
+
+
+@pytest.mark.asyncio
+async def test_missing_profile_fails_closed_not_guest(patched_auth):
+    request = _request_with_token("orphan-user")
+    with pytest.raises(Exception) as exc:
+        await RBACManager.resolve_auth_context(request, allow_unauthenticated=False)
+    assert exc.value.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_stale_jwt_claim_rejected(patched_auth):
+    request = _request_with_token("stale-admin-token")
+    with pytest.raises(Exception) as exc:
+        await RBACManager.resolve_auth_context(request, allow_unauthenticated=False)
+    assert exc.value.status_code == 403
+    assert STALE_TOKEN_DETAIL in str(exc.value.detail)
+
+
+@pytest.mark.asyncio
+async def test_matching_claim_and_firestore_succeeds(patched_auth):
+    request = _request_with_token("farmer-user")
+    ctx = await RBACManager.resolve_auth_context(request, allow_unauthenticated=False)
+    assert isinstance(ctx, AuthContext)
+    assert ctx.uid == "farmer-user"
+    assert ctx.role == "farmer"
+
+
+@pytest.mark.asyncio
+async def test_get_user_role_returns_guest_only_without_token(patched_auth):
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)
+    assert await RBACManager.get_user_role(request) == Role.GUEST
+
+
+@pytest.mark.asyncio
+async def test_raise_if_unauthorized_requires_authentication(patched_auth):
+    from rbac import Permission
+
+    scope = {"type": "http", "method": "GET", "path": "/", "headers": []}
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    request = Request(scope, receive)
+    with pytest.raises(Exception) as exc:
+        await RBACManager.raise_if_unauthorized(
+            request,
+            [Permission.FINANCE_CREATE],
+        )
+    assert exc.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_sync_role_claim_revokes_sessions_by_default(monkeypatch):
+    revoked = []
+
+    monkeypatch.setattr("role_sync._set_claim_sync", lambda uid, role: None)
+    monkeypatch.setattr(
+        "role_sync._revoke_refresh_tokens_sync",
+        lambda uid: revoked.append(uid),
+    )
+
+    from role_sync import sync_role_claim
+
+    await sync_role_claim("user-1", "farmer")
+    assert revoked == ["user-1"]


### PR DESCRIPTION
Use RBACManager.resolve_auth_context as the single API resolver with
Firestore as source of truth, reject stale JWT role claims, fail closed
on missing profiles, revoke sessions on role sync, and stop defaulting
missing rule claims to farmer.
closes #1130 