### PR TITLE
fix: verify Twilio signature on all WhatsApp webhooks (#1129)

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -1,13 +1,8 @@
 """Alerts & Notifications Router"""
-import base64
-import hashlib
-import hmac
-import os
-import re
-import urllib.parse
 from datetime import datetime
 
 from fastapi import APIRouter, Form, HTTPException, Query, Request
+from twilio_webhook_security import handle_inbound_whatsapp_webhook
 from pydantic import BaseModel, Field
 
 router = APIRouter()
@@ -35,67 +30,6 @@ def init_alerts(ns, ss, ga_fn, sw_fn, fa_fn, vr_fn):
     send_whatsapp_fn = sw_fn
     format_alert_fn = fa_fn
     verify_role_fn = vr_fn
-
-
-def _verify_twilio_signature(request: Request, body: bytes) -> None:
-    """Validate the X-Twilio-Signature header using HMAC-SHA1.
-
-    Twilio signs every webhook request with:
-        HMAC-SHA1(auth_token, url + sorted_params)
-
-    If the signature is absent or does not match we raise HTTP 403 so
-    forged requests are rejected before any processing occurs.
-
-    Reference: https://www.twilio.com/docs/usage/webhooks/webhooks-security
-    """
-    auth_token = os.getenv("TWILIO_AUTH_TOKEN", "")
-    if not auth_token:
-        # If the token is not configured we cannot verify — fail closed.
-        raise HTTPException(
-            status_code=500,
-            detail="Webhook signature verification is not configured",
-        )
-
-    twilio_signature = request.headers.get("X-Twilio-Signature", "")
-    if not twilio_signature:
-        raise HTTPException(status_code=403, detail="Missing Twilio signature")
-
-    # Reconstruct the full URL exactly as Twilio sees it.
-    url = str(request.url)
-
-    # Parse the form-encoded body and sort parameters alphabetically.
-    try:
-        params = urllib.parse.parse_qsl(body.decode("utf-8"), keep_blank_values=True)
-    except Exception:
-        params = []
-    sorted_params = sorted(params, key=lambda kv: kv[0])
-
-    # Build the string Twilio signs: URL + key1value1key2value2...
-    signing_string = url + "".join(k + v for k, v in sorted_params)
-
-    expected = hmac.new(
-        auth_token.encode("utf-8"),
-        signing_string.encode("utf-8"),
-        hashlib.sha1,
-    ).digest()
-
-    expected_b64 = base64.b64encode(expected).decode("utf-8")
-
-    if not hmac.compare_digest(expected_b64, twilio_signature):
-        raise HTTPException(status_code=403, detail="Invalid Twilio signature")
-
-
-def _validate_whatsapp_number(raw: str) -> str:
-    """Strip the 'whatsapp:' prefix and do basic E.164 sanity check.
-
-    Raises HTTP 400 for values that don't look like a phone number so
-    the raw From field cannot be used to inject arbitrary strings.
-    """
-    number = raw.replace("whatsapp:", "").strip()
-    # E.164: optional leading +, then 7–15 digits
-    if not re.fullmatch(r"\+?\d{7,15}", number):
-        raise HTTPException(status_code=400, detail="Invalid sender number")
-    return number
 
 
 @router.get("/notifications")
@@ -169,42 +103,6 @@ async def trigger_whatsapp_alert(request: Request, data: AlertTriggerRequest):
 
 
 @router.post("/whatsapp/webhook")
-async def whatsapp_webhook(
-    request: Request,
-    Body: str = Form(...),
-    From: str = Form(...),
-):
-    """Receive inbound WhatsApp messages from Twilio.
-
-    Security controls applied:
-    1. Twilio signature verification — every request is validated with
-       HMAC-SHA1 against TWILIO_AUTH_TOKEN before any processing.
-       Requests with a missing or invalid X-Twilio-Signature are
-       rejected with HTTP 403.
-    2. Sender number validation — the From field is checked against a
-       basic E.164 pattern after stripping the 'whatsapp:' prefix so
-       malformed values cannot propagate further.
-    """
-    if send_whatsapp_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
-
-    # Read the raw body for signature verification before FastAPI
-    # consumes it via Form parameters.
-    raw_body = await request.body()
-    _verify_twilio_signature(request, raw_body)
-
-    incoming_msg = Body.lower().strip()
-    sender_number = _validate_whatsapp_number(From)
-
-    responses = {
-        "weather": "🌡️ *Weather Update*\n\n28°C, Clear skies.",
-        "pest": "🐛 *Pest Assistant*\n\nPlease use the tool in-app.",
-        "hi": "🙏 *Namaste!*\n\nI am your AI Assistant.",
-        "hello": "🙏 *Namaste!*\n\nI am your AI Assistant.",
-    }
-    response = next(
-        (v for k, v in responses.items() if k in incoming_msg),
-        "Try 'Weather' or 'Pest' 🌱",
-    )
-    send_whatsapp_fn(sender_number, response)
-    return {"status": "success"}
+async def whatsapp_webhook(request: Request):
+    """Receive inbound WhatsApp messages from Twilio (delegates to shared handler)."""
+    return await handle_inbound_whatsapp_webhook(request)

--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -262,27 +262,6 @@ async def trigger_whatsapp_alert(data: AlertTriggerRequest, request: Request):
     return {"success": True, "results": results, "delivered": delivered, "total": len(results)}
 
 
-@router.post("/whatsapp/webhook")
-async def whatsapp_webhook(Body: str = Form(...), From: str = Form(...)):
-    """
-    Handle incoming WhatsApp messages from Twilio.
-    
-    Processing is offloaded to a background Celery task to immediately
-    acknowledge the webhook (preventing Twilio timeout/penalties under burst traffic)
-    and process the message asynchronously.
-    """
-    if send_whatsapp_message_fn is None:
-        raise HTTPException(status_code=500, detail="WhatsApp sender not initialized")
-
-    sender_number = From.replace("whatsapp:", "")
-
-    # Offload message processing to reliable background task queue
-    from celery_worker import process_whatsapp_webhook_task
-    process_whatsapp_webhook_task.delay(Body, sender_number)
-    
-    return {"status": "success"}
-
-
 @router.post("/reports/generate")
 async def generate_signed_report(request: Request, data: ReportRequest):
     if verify_role_fn is None or get_signing_keys_fn is None:

--- a/main.py
+++ b/main.py
@@ -832,21 +832,11 @@ async def get_rbac_audit(request: Request, limit: int = Query(default=50, ge=1, 
 
 @app.post("/api/whatsapp/webhook")
 @limiter.limit("20/minute")
-async def whatsapp_webhook(request: Request, Body: str = Form(...), From: str = Form(...)):
-    """
-    Handle incoming WhatsApp messages from Twilio.
-    
-    Processing is offloaded to a background Celery task to immediately
-    acknowledge the webhook (preventing Twilio timeout/penalties under burst traffic)
-    and process the message asynchronously.
-    """
-    sender_number = From.replace("whatsapp:", "")
-    
-    # Offload message processing to reliable background task queue
-    from celery_worker import process_whatsapp_webhook_task
-    process_whatsapp_webhook_task.delay(Body, sender_number)
-    
-    return {"status": "success"}
+async def whatsapp_webhook(request: Request):
+    """Handle inbound Twilio WhatsApp webhooks (signature-verified)."""
+    from twilio_webhook_security import handle_inbound_whatsapp_webhook
+
+    return await handle_inbound_whatsapp_webhook(request)
 
 # --- Cryptographic Reports ---
 #

--- a/tests/test_twilio_webhook_security.py
+++ b/tests/test_twilio_webhook_security.py
@@ -1,0 +1,128 @@
+"""
+Tests for Twilio WhatsApp webhook signature verification.
+"""
+
+import base64
+import hashlib
+import hmac
+import urllib.parse
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from twilio_webhook_security import (
+    handle_inbound_whatsapp_webhook,
+    verify_twilio_signature,
+)
+
+
+def _sign(url: str, body: bytes, auth_token: str) -> str:
+    params = sorted(
+        urllib.parse.parse_qsl(body.decode("utf-8"), keep_blank_values=True),
+        key=lambda kv: kv[0],
+    )
+    signing_string = url + "".join(k + v for k, v in params)
+    digest = hmac.new(
+        auth_token.encode("utf-8"),
+        signing_string.encode("utf-8"),
+        hashlib.sha1,
+    ).digest()
+    return base64.b64encode(digest).decode("utf-8")
+
+
+@pytest.fixture()
+def webhook_app(monkeypatch):
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "test-auth-token")
+    queued = []
+
+    class _FakeTask:
+        @staticmethod
+        def delay(body, sender):
+            queued.append((body, sender))
+
+    monkeypatch.setattr(
+        "twilio_webhook_security.enqueue_whatsapp_webhook_processing",
+        lambda body, sender: queued.append((body, sender)),
+    )
+
+    app = FastAPI()
+
+    @app.post("/api/whatsapp/webhook")
+    async def webhook(request: Request):
+        return await handle_inbound_whatsapp_webhook(request)
+
+    client = TestClient(app)
+    return client, queued
+
+
+def test_missing_signature_returns_403(webhook_app):
+    client, _queued = webhook_app
+    body = b"Body=hello&From=whatsapp%3A%2B15551234567"
+    response = client.post(
+        "/api/whatsapp/webhook",
+        content=body,
+        headers={"Content-Type": "application/x-www-form-urlencoded"},
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Missing Twilio signature"
+
+
+def test_invalid_signature_returns_403(webhook_app):
+    client, _queued = webhook_app
+    body = b"Body=hello&From=whatsapp%3A%2B15551234567"
+    response = client.post(
+        "/api/whatsapp/webhook",
+        content=body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Twilio-Signature": "invalid",
+        },
+    )
+    assert response.status_code == 403
+    assert response.json()["detail"] == "Invalid Twilio signature"
+
+
+def test_valid_signature_enqueues_task(webhook_app):
+    client, queued = webhook_app
+    body = b"Body=hello&From=whatsapp%3A%2B15551234567"
+    url = "http://testserver/api/whatsapp/webhook"
+    signature = _sign(url, body, "test-auth-token")
+
+    response = client.post(
+        "/api/whatsapp/webhook",
+        content=body,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "X-Twilio-Signature": signature,
+        },
+    )
+    assert response.status_code == 200
+    assert response.json() == {"status": "success"}
+    assert queued == [("hello", "+15551234567")]
+
+
+def test_verify_twilio_signature_unit(monkeypatch):
+    monkeypatch.setenv("TWILIO_AUTH_TOKEN", "secret")
+    auth_token = "secret"
+    body = b"Body=Hi&From=whatsapp%3A%2B19998887777"
+    url = "https://example.com/api/whatsapp/webhook"
+    signature = _sign(url, body, auth_token)
+
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/whatsapp/webhook",
+        "headers": [
+            (b"x-twilio-signature", signature.encode()),
+            (b"host", b"example.com"),
+        ],
+        "scheme": "https",
+        "server": ("example.com", 443),
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": body, "more_body": False}
+
+    request = Request(scope, receive)
+    verify_twilio_signature(request, body)

--- a/twilio_webhook_security.py
+++ b/twilio_webhook_security.py
@@ -1,0 +1,94 @@
+"""
+Twilio WhatsApp webhook signature verification and inbound request handling.
+
+All WhatsApp webhook routes must call :func:`handle_inbound_whatsapp_webhook` so
+X-Twilio-Signature validation stays consistent across the application.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+import hmac
+import os
+import re
+import urllib.parse
+from typing import Tuple
+
+from fastapi import HTTPException, Request
+
+
+def verify_twilio_signature(request: Request, body: bytes) -> None:
+    """Validate the X-Twilio-Signature header using HMAC-SHA1.
+
+    Twilio signs every webhook request with:
+        HMAC-SHA1(auth_token, url + sorted_params)
+
+    Reference: https://www.twilio.com/docs/usage/webhooks/webhooks-security
+    """
+    auth_token = os.getenv("TWILIO_AUTH_TOKEN", "")
+    if not auth_token:
+        raise HTTPException(
+            status_code=500,
+            detail="Webhook signature verification is not configured",
+        )
+
+    twilio_signature = request.headers.get("X-Twilio-Signature", "")
+    if not twilio_signature:
+        raise HTTPException(status_code=403, detail="Missing Twilio signature")
+
+    url = str(request.url)
+
+    try:
+        params = urllib.parse.parse_qsl(body.decode("utf-8"), keep_blank_values=True)
+    except Exception:
+        params = []
+    sorted_params = sorted(params, key=lambda kv: kv[0])
+    signing_string = url + "".join(k + v for k, v in sorted_params)
+
+    expected = hmac.new(
+        auth_token.encode("utf-8"),
+        signing_string.encode("utf-8"),
+        hashlib.sha1,
+    ).digest()
+    expected_b64 = base64.b64encode(expected).decode("utf-8")
+
+    if not hmac.compare_digest(expected_b64, twilio_signature):
+        raise HTTPException(status_code=403, detail="Invalid Twilio signature")
+
+
+def validate_whatsapp_number(raw: str) -> str:
+    """Strip the whatsapp: prefix and validate E.164-ish phone numbers."""
+    number = raw.replace("whatsapp:", "").strip()
+    if not re.fullmatch(r"\+?\d{7,15}", number):
+        raise HTTPException(status_code=400, detail="Invalid sender number")
+    return number
+
+
+def parse_whatsapp_form(body: bytes) -> Tuple[str, str]:
+    """Extract Body and From fields from a Twilio form-encoded webhook payload."""
+    params = dict(urllib.parse.parse_qsl(body.decode("utf-8"), keep_blank_values=True))
+    return params.get("Body", ""), params.get("From", "")
+
+
+def enqueue_whatsapp_webhook_processing(message_body: str, sender_number: str) -> None:
+    """Enqueue inbound WhatsApp webhook work on the Celery worker."""
+    from celery_worker import process_whatsapp_webhook_task
+
+    process_whatsapp_webhook_task.delay(message_body, sender_number)
+
+
+async def handle_inbound_whatsapp_webhook(request: Request) -> dict:
+    """
+    Verify Twilio signature, validate sender, and enqueue async processing.
+
+    Returns immediately so Twilio does not time out under burst traffic.
+    """
+    raw_body = await request.body()
+    verify_twilio_signature(request, raw_body)
+
+    message_body, from_raw = parse_whatsapp_form(raw_body)
+    sender_number = validate_whatsapp_number(from_raw)
+
+    enqueue_whatsapp_webhook_processing(message_body, sender_number)
+    return {"status": "success"}


### PR DESCRIPTION
Centralize X-Twilio-Signature validation in twilio_webhook_security, route main and alerts webhooks through the shared handler, and remove the unsigned duplicate from platform.

Fixes #1129