### PR TITLE
fix: require admin auth for feature flag and experiment mutations

### DIFF
--- a/feature_flags/routes.py
+++ b/feature_flags/routes.py
@@ -4,40 +4,60 @@ routes.py
 FastAPI router for the Feature Flag & A/B Testing API.
 
 All routes are prefixed with /api — register via:
-    app.include_router(flags_router)
+    app.include_router(flags_router, prefix="/api/flags")
 
 Endpoints
 ─────────
 Feature Flags
-  GET    /api/flags                  List all flags
-  GET    /api/flags/{flag_id}        Get single flag
-  POST   /api/flags                  Create or update a flag
-  DELETE /api/flags/{flag_id}        Delete a flag
-  POST   /api/flags/{flag_id}/rollback  Disable flag, reset rollout to 0%
+  GET    /api/flags                  List all flags (public read)
+  GET    /api/flags/{flag_id}        Get single flag (public read)
+  POST   /api/flags/{flag_id}        Create or update a flag (admin)
+  DELETE /api/flags/{flag_id}        Delete a flag (admin)
+  POST   /api/flags/{flag_id}/rollback  Rollback flag (admin)
 
 Experiments
-  GET    /api/experiments                     List all experiments
-  POST   /api/experiments                     Create experiment
-  POST   /api/experiments/assign              Assign user to variant
-  PATCH  /api/experiments/{exp_id}/status     Update experiment status
-  GET    /api/experiments/{exp_id}/metrics    Get aggregated metrics
+  GET    /api/experiments                     List all experiments (admin)
+  POST   /api/experiments                     Create experiment (admin)
+  POST   /api/experiments/assign              Assign user to variant (authenticated)
+  PATCH  /api/experiments/{exp_id}/status     Update experiment status (admin)
+  GET    /api/experiments/{exp_id}/metrics    Get aggregated metrics (admin)
 
 Analytics
-  POST   /api/experiments/events              Log single event
-  POST   /api/experiments/events/batch        Batch-log events
+  POST   /api/experiments/events              Log single event (authenticated)
+  POST   /api/experiments/events/batch        Batch-log events (admin)
 """
 
 import logging
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
-from fastapi import APIRouter, HTTPException, Query
+from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, Field
 
-from feature_flags import flag_store, experiment_engine, metrics_collector
+from feature_flags import experiment_engine, flag_store, metrics_collector
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api", tags=["feature-flags"])
+
+verify_role_fn: Optional[Callable] = None
+
+
+def init_feature_flags(verify_role) -> None:
+    """Inject the shared ``verify_role`` dependency from main."""
+    global verify_role_fn
+    verify_role_fn = verify_role
+
+
+async def _require_admin(request: Request) -> None:
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Feature flags API not initialized")
+    await verify_role_fn(request, required_roles=["admin"])
+
+
+async def _require_authenticated(request: Request) -> None:
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Feature flags API not initialized")
+    await verify_role_fn(request)
 
 
 # ── Pydantic schemas ───────────────────────────────────────────────────────────
@@ -95,12 +115,12 @@ class EventBatchRequest(BaseModel):
 
 # ── Feature Flag endpoints ─────────────────────────────────────────────────────
 
-@router.get("/flags", summary="List all feature flags")
+@router.get("/flags", summary="List all feature flags (public read)")
 def list_flags():
     return {"flags": flag_store.list_flags()}
 
 
-@router.get("/flags/{flag_id}", summary="Get a single feature flag")
+@router.get("/flags/{flag_id}", summary="Get a single feature flag (public read)")
 def get_flag(flag_id: str):
     flag = flag_store.get_flag(flag_id)
     if not flag:
@@ -108,22 +128,25 @@ def get_flag(flag_id: str):
     return flag
 
 
-@router.post("/flags/{flag_id}", summary="Create or update a feature flag")
-def upsert_flag(flag_id: str, body: FlagUpsertRequest):
+@router.post("/flags/{flag_id}", summary="Create or update a feature flag (admin)")
+async def upsert_flag(request: Request, flag_id: str, body: FlagUpsertRequest):
+    await _require_admin(request)
     updated = flag_store.upsert_flag(flag_id, body.dict())
     return {"success": True, "flag": updated}
 
 
-@router.delete("/flags/{flag_id}", summary="Delete a feature flag")
-def delete_flag(flag_id: str):
+@router.delete("/flags/{flag_id}", summary="Delete a feature flag (admin)")
+async def delete_flag(request: Request, flag_id: str):
+    await _require_admin(request)
     deleted = flag_store.delete_flag(flag_id)
     if not deleted:
         raise HTTPException(status_code=404, detail=f"Flag '{flag_id}' not found")
     return {"success": True, "deleted": flag_id}
 
 
-@router.post("/flags/{flag_id}/rollback", summary="Rollback — disable flag, reset rollout to 0%")
-def rollback_flag(flag_id: str):
+@router.post("/flags/{flag_id}/rollback", summary="Rollback flag (admin)")
+async def rollback_flag(request: Request, flag_id: str):
+    await _require_admin(request)
     result = flag_store.rollback_flag(flag_id)
     if not result:
         raise HTTPException(status_code=404, detail=f"Flag '{flag_id}' not found")
@@ -132,42 +155,48 @@ def rollback_flag(flag_id: str):
 
 # ── Experiment endpoints ───────────────────────────────────────────────────────
 
-@router.get("/experiments", summary="List all experiments")
-def list_experiments():
+@router.get("/experiments", summary="List all experiments (admin)")
+async def list_experiments(request: Request):
+    await _require_admin(request)
     return {"experiments": experiment_engine.list_experiments()}
 
 
-@router.post("/experiments", summary="Create a new experiment")
-def create_experiment(body: ExperimentCreateRequest):
+@router.post("/experiments", summary="Create a new experiment (admin)")
+async def create_experiment(request: Request, body: ExperimentCreateRequest):
+    await _require_admin(request)
     data = body.dict()
     data["variants"] = [v.dict() for v in body.variants]
     exp = experiment_engine.create_experiment(data)
     return {"success": True, "experiment": exp}
 
 
-@router.post("/experiments/assign", summary="Assign user to experiment variant")
-def assign_user(body: AssignRequest):
+@router.post("/experiments/assign", summary="Assign user to experiment variant (authenticated)")
+async def assign_user(request: Request, body: AssignRequest):
+    await _require_authenticated(request)
     assignment = experiment_engine.assign_user(body.user_id, body.experiment_id)
     return assignment
 
 
-@router.patch("/experiments/{exp_id}/status", summary="Update experiment status")
-def update_status(exp_id: str, body: StatusUpdateRequest):
+@router.patch("/experiments/{exp_id}/status", summary="Update experiment status (admin)")
+async def update_status(request: Request, exp_id: str, body: StatusUpdateRequest):
+    await _require_admin(request)
     result = experiment_engine.update_experiment_status(exp_id, body.status)
     if not result:
         raise HTTPException(status_code=404, detail=f"Experiment '{exp_id}' not found")
     return {"success": True, "experiment": result}
 
 
-@router.get("/experiments/{exp_id}/metrics", summary="Get aggregated experiment metrics")
-def get_metrics(exp_id: str):
+@router.get("/experiments/{exp_id}/metrics", summary="Get experiment metrics (admin)")
+async def get_metrics(request: Request, exp_id: str):
+    await _require_admin(request)
     return metrics_collector.get_experiment_metrics(exp_id)
 
 
 # ── Analytics endpoints ────────────────────────────────────────────────────────
 
-@router.post("/experiments/events", summary="Log a single experiment event")
-def log_event(body: EventRequest):
+@router.post("/experiments/events", summary="Log a single experiment event (authenticated)")
+async def log_event(request: Request, body: EventRequest):
+    await _require_authenticated(request)
     event = metrics_collector.log_event(
         event_type=body.event_type,
         user_id=body.user_id,
@@ -180,8 +209,9 @@ def log_event(body: EventRequest):
     return {"success": True, "event": event}
 
 
-@router.post("/experiments/events/batch", summary="Batch-log experiment events")
-def log_events_batch(body: EventBatchRequest):
+@router.post("/experiments/events/batch", summary="Batch-log experiment events (admin)")
+async def log_events_batch(request: Request, body: EventBatchRequest):
+    await _require_admin(request)
     raw = [e.dict() for e in body.events]
     count = metrics_collector.log_events_batch(raw)
     return {"success": True, "logged": count}

--- a/main.py
+++ b/main.py
@@ -82,7 +82,7 @@ from backend.routers import (
 from blockchain_supply_chain import SupplyChainBlockchain
 from crop_quality_grading import CropQualityGrader
 from farm_finance_ai import FarmFinanceAI
-from feature_flags.routes import router as flags_router
+from feature_flags.routes import init_feature_flags, router as flags_router
 from ml.adapters.xgboost_adapter import XGBoostAdapter
 from ml.governance import DriftDetector, ModelVersionManager, ShadowEvaluator
 from ml.registry import ModelRegistry
@@ -191,6 +191,7 @@ async def lifespan(app: FastAPI):
 
     knowledge.init_knowledge(rag_generate_fn, RBACManager, Permission, {"TEST001": {"verified": True}}, verify_role)
     alerts.init_alerts([], subscriber_store, lambda **kwargs: [], send_whatsapp_message, format_alert_message, verify_role)
+    init_feature_flags(verify_role)
     platform.init_platform(
         verify_role,
         get_signing_keys,
@@ -1204,7 +1205,7 @@ app.include_router(referrals.router, prefix="/api/referrals", tags=["Referrals"]
 app.include_router(platform.router, prefix="/api", tags=["Platform"])
 app.include_router(advisory.router, prefix="/api", tags=["Advisory"])
 app.include_router(alerts.router, prefix="/api/notifications", tags=["Alerts"])
-app.include_router(flags_router, prefix="/api/flags", tags=["Feature Flags"])
+app.include_router(flags_router, tags=["Feature Flags"])
 app.include_router(lms.router, prefix="/api", tags=["LMS"])
 
 

--- a/tests/test_feature_flags_auth.py
+++ b/tests/test_feature_flags_auth.py
@@ -1,0 +1,107 @@
+"""
+Route-level auth tests for the feature flag / experiment API (issue #1127).
+"""
+
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from fastapi.testclient import TestClient
+
+firebase_mock = MagicMock()
+sys.modules.setdefault("firebase_admin", firebase_mock)
+sys.modules.setdefault("firebase_admin.firestore", firebase_mock)
+sys.modules.setdefault("firebase_admin.credentials", firebase_mock)
+sys.modules.setdefault("google", MagicMock())
+sys.modules.setdefault("google.cloud", MagicMock())
+sys.modules.setdefault("google.cloud.firestore_v1", MagicMock())
+sys.modules.setdefault("google.cloud.firestore_v1.base_query", MagicMock())
+
+with pytest.MonkeyPatch.context() as mp:
+    mp.setattr("feature_flags.flag_store._FIRESTORE_AVAILABLE", False, raising=False)
+    mp.setattr("feature_flags.experiment_engine._FIRESTORE_AVAILABLE", False, raising=False)
+    mp.setattr("feature_flags.metrics_collector._FIRESTORE_AVAILABLE", False, raising=False)
+    from feature_flags.routes import init_feature_flags, router as flags_router
+
+
+def _make_app():
+    app = FastAPI()
+    app.include_router(flags_router)
+    return app
+
+
+@pytest.fixture()
+def flags_client():
+    app = _make_app()
+
+    async def verify_role(request, required_roles=None):
+        auth = request.headers.get("Authorization", "")
+        if not auth.startswith("Bearer "):
+            raise HTTPException(status_code=401, detail="Missing or invalid authentication token")
+        token = auth[7:].strip()
+        if token == "admin-token":
+            role = "admin"
+        elif token == "farmer-token":
+            role = "farmer"
+        else:
+            raise HTTPException(status_code=401, detail="Authentication failed")
+        if required_roles and role not in required_roles:
+            raise HTTPException(status_code=403, detail="Access denied: insufficient permissions")
+        return {"uid": token, "role": role}
+
+    init_feature_flags(verify_role)
+    return TestClient(app)
+
+
+def test_public_flag_read_allowed_without_token(flags_client):
+    response = flags_client.get("/api/flags")
+    assert response.status_code == 200
+
+
+@pytest.mark.parametrize(
+    "method,path,payload",
+    [
+        ("post", "/api/flags/test_flag", {"enabled": True, "rollout_pct": 100}),
+        ("delete", "/api/flags/test_flag", None),
+        ("post", "/api/flags/test_flag/rollback", None),
+        ("post", "/api/experiments", {"name": "Test", "status": "draft", "variants": []}),
+        ("patch", "/api/experiments/exp-1/status", {"status": "running"}),
+        (
+            "post",
+            "/api/experiments/events/batch",
+            {
+                "events": [
+                    {
+                        "event_type": "impression",
+                        "user_id": "u1",
+                    }
+                ]
+            },
+        ),
+    ],
+)
+def test_admin_mutations_reject_anonymous(flags_client, method, path, payload):
+    request_fn = getattr(flags_client, method)
+    kwargs = {"json": payload} if payload is not None else {}
+    response = request_fn(path, **kwargs)
+    assert response.status_code == 401
+
+
+def test_admin_mutation_rejects_non_admin(flags_client):
+    response = flags_client.post(
+        "/api/flags/secure_flag",
+        json={"enabled": True, "rollout_pct": 50},
+        headers={"Authorization": "Bearer farmer-token"},
+    )
+    assert response.status_code == 403
+
+
+def test_admin_mutation_allows_admin(flags_client):
+    response = flags_client.post(
+        "/api/flags/secure_flag",
+        json={"enabled": True, "rollout_pct": 25},
+        headers={"Authorization": "Bearer admin-token"},
+    )
+    assert response.status_code == 200
+    assert response.json()["success"] is True


### PR DESCRIPTION
fixes #1127 
Enforce verify_role on mutating control-plane routes, keep public flag reads, require authentication for assign/event endpoints, and fix router mount paths to match /api/flags and /api/experiments.