### PR TITLE
[Bug]: Batch Registration Fails After Vercel Deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,9 +202,8 @@ BACKEND_PORT=5000
 REACT_APP_FIREBASE_API_KEY=xxxxxxxxxxxx
 REACT_APP_FIREBASE_AUTH_DOMAIN=your-app.firebaseapp.com
 REACT_APP_FIREBASE_PROJECT_ID=your-app
-REACT_APP_BACKEND_URL=http://localhost:5000
 VITE_API_BASE_URL=https://your-backend.onrender.com
-```
+# Alternative: VITE_BACKEND_URL is also supported as a fallback
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ REACT_APP_FIREBASE_API_KEY=xxxxxxxxxxxx
 REACT_APP_FIREBASE_AUTH_DOMAIN=your-app.firebaseapp.com
 REACT_APP_FIREBASE_PROJECT_ID=your-app
 REACT_APP_BACKEND_URL=http://localhost:5000
+VITE_API_BASE_URL=https://your-backend.onrender.com
 ```
 
 ---

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,5 +10,7 @@ VITE_FIREBASE_APP_ID=
 # Set GEMINI_API_KEY in the backend .env instead (see root .env.example).
 VITE_OPENWEATHER_API_KEY=
 VITE_API_KEY=
-# Base URL of the backend API (leave empty for same-origin / Vite proxy)
+# Base URL of the backend API.
+# Leave empty only for local development when the Vite proxy is active.
+# Example production value: https://your-backend.onrender.com
 VITE_API_BASE_URL=

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -215,7 +215,13 @@ const resolveApiBaseUrl = () => {
       hostname === '127.0.0.1' ||
       hostname.endsWith('.localhost');
 
-    return isLocalhost ? '' : window.location.origin;
+    if (!isLocalhost) {
+      console.error(
+        '[api.js] VITE_API_BASE_URL is not configured in production. ' +
+        'API requests will fail. Set VITE_API_BASE_URL to your backend origin.'
+      );
+    }
+    return '';
   }
 
   return '';

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -189,6 +189,38 @@ const getRetryDelayMs = (retryCount, retryDelayMs) => {
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const normalizeBaseUrl = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  return String(value).replace(/\/$/, '');
+};
+
+const resolveApiBaseUrl = () => {
+  const configuredBaseUrl = normalizeBaseUrl(
+    import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_BACKEND_URL
+  );
+
+  if (configuredBaseUrl) {
+    return configuredBaseUrl;
+  }
+
+  // Local development relies on the Vite proxy; production deployments need
+  // an explicit backend URL so requests do not stay on the static frontend host.
+  if (typeof window !== 'undefined') {
+    const hostname = window.location.hostname;
+    const isLocalhost =
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.localhost');
+
+    return isLocalhost ? '' : window.location.origin;
+  }
+
+  return '';
+};
+
 /**
  * Retrieve the current Firebase ID token for the signed-in user.
  *
@@ -227,7 +259,7 @@ async function getFirebaseIdToken() {
 }
 
 const axiosClient = axios.create({
-  baseURL: '', // Use relative path to leverage Vite proxy
+  baseURL: resolveApiBaseUrl(),
   timeout: API_TIMEOUT_MS,
   headers: {
     'Content-Type': 'application/json',


### PR DESCRIPTION
I fixed the batch registration client so production deployments can point at the real backend instead of staying on the static Vercel origin. The shared Axios client now resolves its base URL from VITE_API_BASE_URL or VITE_BACKEND_URL in api.js, and I updated .env.example plus README.md to document the production backend setting.

The likely deployment issue was that the app was POSTing to relative /api/supply-chain/trace-batch, which works only when a backend proxy exists on the same origin. On Vercel, that request stays on the frontend host unless the backend URL is configured explicitly.

Validation was partially blocked in this workspace because the frontend dependencies are not in a healthy installed state here: the build initially failed because Vite was missing, and npm install is running into preexisting node_modules extraction warnings. Before redeploying, make sure Vercel has a valid VITE_API_BASE_URL that points to the deployed FastAPI backend.


closes #1038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guides with improved environment variable documentation for API endpoint configuration.

* **New Features**
  * Added environment variable support for API endpoint configuration with automatic fallback detection for local and production deployments.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1143?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->