### PR TITLE
[Bug]: Certified/Bank Report Generation Not Working Even After User Login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,6 +27,9 @@ TWILIO_WHATSAPP_NUMBER=+14155238886
 # Google Cloud KMS / Secret Manager
 GOOGLE_CLOUD_PROJECT=your-project-id
 REPORT_SIGNING_SECRET_NAME=report-signing-key
+# Optional deployment fallback when Secret Manager is unavailable.
+# Store the full PEM-encoded Ed25519 private key here for the report signer.
+# REPORT_SIGNING_PRIVATE_KEY_PEM="-----BEGIN PRIVATE KEY-----\n...\n-----END PRIVATE KEY-----"
 
 # Rate Limiting (SlowAPI)
 # Default limits are hardcoded in main.py but can be extended here

--- a/README.md
+++ b/README.md
@@ -206,6 +206,8 @@ REACT_APP_BACKEND_URL=http://localhost:5000
 VITE_API_BASE_URL=https://your-backend.onrender.com
 ```
 
+For Vercel deployments, set `VITE_API_BASE_URL` to the live backend origin in the project environment variables. Without it, browser requests stay on the static frontend host and marketplace API calls will fail.
+
 ---
 
 ## 🧩 API Endpoints (Examples)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ VITE_API_BASE_URL=https://your-backend.onrender.com
 
 For Vercel deployments, set `VITE_API_BASE_URL` to the live backend origin in the project environment variables. Without it, browser requests stay on the static frontend host and marketplace API calls will fail.
 
+For certified/bank report generation, the backend also needs a signing key source. In production, configure either Google Cloud Secret Manager (`GOOGLE_CLOUD_PROJECT` + `REPORT_SIGNING_SECRET_NAME`) or `REPORT_SIGNING_PRIVATE_KEY_PEM` with a PEM-encoded Ed25519 private key.
+
 ---
 
 ## 🧩 API Endpoints (Examples)

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ REACT_APP_FIREBASE_API_KEY=xxxxxxxxxxxx
 REACT_APP_FIREBASE_AUTH_DOMAIN=your-app.firebaseapp.com
 REACT_APP_FIREBASE_PROJECT_ID=your-app
 REACT_APP_BACKEND_URL=http://localhost:5000
+VITE_API_BASE_URL=https://your-backend.onrender.com
 ```
 
 ---

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -10,5 +10,7 @@ VITE_FIREBASE_APP_ID=
 # Set GEMINI_API_KEY in the backend .env instead (see root .env.example).
 VITE_OPENWEATHER_API_KEY=
 VITE_API_KEY=
-# Base URL of the backend API (leave empty for same-origin / Vite proxy)
+# Base URL of the backend API.
+# Leave empty only for local development when the Vite proxy is active.
+# Example production value: https://your-backend.onrender.com
 VITE_API_BASE_URL=

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -189,6 +189,38 @@ const getRetryDelayMs = (retryCount, retryDelayMs) => {
 
 const wait = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 
+const normalizeBaseUrl = (value) => {
+  if (!value) {
+    return '';
+  }
+
+  return String(value).replace(/\/$/, '');
+};
+
+const resolveApiBaseUrl = () => {
+  const configuredBaseUrl = normalizeBaseUrl(
+    import.meta.env.VITE_API_BASE_URL || import.meta.env.VITE_BACKEND_URL
+  );
+
+  if (configuredBaseUrl) {
+    return configuredBaseUrl;
+  }
+
+  // Local development relies on the Vite proxy; production deployments need
+  // an explicit backend URL so requests do not stay on the static frontend host.
+  if (typeof window !== 'undefined') {
+    const hostname = window.location.hostname;
+    const isLocalhost =
+      hostname === 'localhost' ||
+      hostname === '127.0.0.1' ||
+      hostname.endsWith('.localhost');
+
+    return isLocalhost ? '' : window.location.origin;
+  }
+
+  return '';
+};
+
 /**
  * Retrieve the current Firebase ID token for the signed-in user.
  *
@@ -227,7 +259,7 @@ async function getFirebaseIdToken() {
 }
 
 const axiosClient = axios.create({
-  baseURL: '', // Use relative path to leverage Vite proxy
+  baseURL: resolveApiBaseUrl(),
   timeout: API_TIMEOUT_MS,
   headers: {
     'Content-Type': 'application/json',

--- a/frontend/services/api.js
+++ b/frontend/services/api.js
@@ -206,18 +206,6 @@ const resolveApiBaseUrl = () => {
     return configuredBaseUrl;
   }
 
-  // Local development relies on the Vite proxy; production deployments need
-  // an explicit backend URL so requests do not stay on the static frontend host.
-  if (typeof window !== 'undefined') {
-    const hostname = window.location.hostname;
-    const isLocalhost =
-      hostname === 'localhost' ||
-      hostname === '127.0.0.1' ||
-      hostname.endsWith('.localhost');
-
-    return isLocalhost ? '' : window.location.origin;
-  }
-
   return '';
 };
 

--- a/frontend/tests/apiClient.test.js
+++ b/frontend/tests/apiClient.test.js
@@ -109,4 +109,14 @@ describe('services/api', () => {
     expect(axiosMocks.request).toHaveBeenCalledTimes(2);
     vi.useRealTimers();
   });
+
+  it('uses the configured backend base URL when provided', async () => {
+    vi.stubEnv('VITE_API_BASE_URL', 'https://api.example.com/');
+
+    await import('../services/api.js');
+
+    expect(axiosMocks.create).toHaveBeenCalledWith(expect.objectContaining({
+      baseURL: 'https://api.example.com',
+    }));
+  });
 });

--- a/main.py
+++ b/main.py
@@ -888,8 +888,9 @@ except Exception as e:
     _kms_init_error = str(e)
 
 ALLOW_INSECURE_FALLBACK = os.getenv("ALLOW_INSECURE_KEY_FALLBACK", "false").lower() == "true"
+REPORT_SIGNING_PRIVATE_KEY_PEM = os.getenv("REPORT_SIGNING_PRIVATE_KEY_PEM", "").strip()
 
-if os.getenv("GOOGLE_CLOUD_PROJECT") and not HAS_GCP_KMS:
+if os.getenv("GOOGLE_CLOUD_PROJECT") and not HAS_GCP_KMS and not REPORT_SIGNING_PRIVATE_KEY_PEM:
     logger.error(
         f"KMS initialization failed: GOOGLE_CLOUD_PROJECT is set but GCP Secret Manager is unavailable. "
         f"Error: {_kms_init_error}. Set ALLOW_INSECURE_KEY_FALLBACK=true to permit local key fallback (NOT RECOMMENDED)."
@@ -906,6 +907,14 @@ def get_signing_keys():
     global _cached_private_key
 
     if _cached_private_key is not None:
+        return _cached_private_key
+
+    if REPORT_SIGNING_PRIVATE_KEY_PEM:
+        _cached_private_key = serialization.load_pem_private_key(
+            REPORT_SIGNING_PRIVATE_KEY_PEM.encode("utf-8"),
+            password=None,
+        )
+        logger.info("Successfully loaded signing key from REPORT_SIGNING_PRIVATE_KEY_PEM")
         return _cached_private_key
 
     project_id = os.getenv("GOOGLE_CLOUD_PROJECT")


### PR DESCRIPTION
The certified report failure was coming from the backend signing-key path, not the PDF renderer itself. I added a production-safe fallback so main.py can load the report-signing Ed25519 key from `REPORT_SIGNING_PRIVATE_KEY_PEM` when GCP Secret Manager isn’t available, and I documented that deployment variable in .env.example and README.md.

That removes the hard dependency on GCP KMS for deployments like Vercel/Render while keeping the existing secure path intact. I also validated the edited backend file for syntax and found no errors.

closes #1043