### PR TITLE
fix(security): add auth and rate limiting to /api/log-error, remove duplicate 

### DIFF
--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -19,9 +19,12 @@ from reportlab.lib import colors
 from reportlab.lib.pagesizes import letter
 from reportlab.lib.units import inch
 from reportlab.pdfgen import canvas
+from slowapi import Limiter
+from slowapi.util import get_remote_address
 
 router = APIRouter()
 logger = logging.getLogger(__name__)
+limiter = Limiter(key_func=get_remote_address)
 
 
 class WhatsAppSubscribeRequest(BaseModel):
@@ -342,9 +345,26 @@ async def generate_signed_report(request: Request, data: ReportRequest):
 
 
 @router.post("/log-error")
-async def log_error(body: ClientErrorReport):
-    if sanitise_log_field_fn is None:
-        raise HTTPException(status_code=500, detail="Log sanitizer not initialized")
+@limiter.limit("10/minute")
+async def log_error(request: Request, body: ClientErrorReport):
+    """
+    Receive a client-side error report and write it to the server log.
+
+    Security controls applied:
+    - Authentication required (Firebase ID token) — prevents unauthenticated
+      callers from flooding the log pipeline.
+    - Rate-limited to 10 requests/minute per IP — caps log volume even from
+      authenticated users, preventing log-flooding DoS.
+    - All string fields are sanitised via sanitise_log_field_fn before being
+      written, preventing log-injection via ANSI escape sequences or newlines.
+    """
+    if sanitise_log_field_fn is None or verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Log service not initialized")
+
+    # Require a valid Firebase ID token.  Any authenticated user (farmer,
+    # expert, admin) may report errors; the token is not used for RBAC here,
+    # only to confirm the caller is a real registered user.
+    await verify_role_fn(request)
 
     level = sanitise_log_field_fn(body.level).lower()
     message = sanitise_log_field_fn(body.message)

--- a/backend/routers/reports.py
+++ b/backend/routers/reports.py
@@ -50,13 +50,6 @@ def _parse_acres(value: str) -> float:
     return float(cleaned)
 
 
-class ClientErrorReport(BaseModel):
-    message: str = Field(..., min_length=1, max_length=500)
-    source: Optional[str] = Field(default=None, max_length=200)
-    stack: Optional[str] = Field(default=None, max_length=2000)
-    level: str = Field(default="error", max_length=20)
-
-
 class ReportRequest(BaseModel):
     name: str = Field(..., max_length=100)
     crop: str = Field(..., max_length=50)
@@ -277,22 +270,7 @@ async def generate_signed_report(request: Request, data: ReportRequest):
     )
 
 
-@router.post("/log-error")
-async def log_error(request: Request, body: ClientErrorReport):
-    if sanitise_log_field_fn is None or logger_instance is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
-    try:
-        message = sanitise_log_field_fn(body.message)
-        source = sanitise_log_field_fn(body.source or "")
-        level = sanitise_log_field_fn(body.level).upper()
-        logger_instance.info(f"Client [{level}] from {source}: {message}")
-        return {"success": True, "message": "Error logged"}
-    except Exception as e:
-        logger.error(f"Log error: {e}")
-        raise HTTPException(status_code=500, detail="Failed to log error")
 
-
-# ---------------------------------------------------------------------------
 # Admin: role assignment with custom-claim sync
 # ---------------------------------------------------------------------------
 

--- a/frontend/AsyncErrorBoundary.jsx
+++ b/frontend/AsyncErrorBoundary.jsx
@@ -147,17 +147,32 @@ class AsyncErrorBoundary extends React.Component {
 
   reportErrorToBackend = async (errorId, error, category, severity) => {
     try {
+      // Require an authenticated Firebase user — the backend enforces a valid
+      // ID token on /api/log-error to prevent unauthenticated log flooding.
+      // Dynamically import firebase/auth to avoid a hard dependency in the
+      // error boundary (which must render even before Firebase initialises).
+      const { getAuth } = await import('firebase/auth');
+      const user = getAuth().currentUser;
+      if (!user) return;
+
+      let idToken;
+      try {
+        idToken = await user.getIdToken();
+      } catch {
+        return; // Token refresh failed — skip silently
+      }
+
       await fetch("/api/log-error", {
         method: "POST",
-        headers: { "Content-Type": "application/json" },
+        headers: {
+          "Content-Type": "application/json",
+          "Authorization": `Bearer ${idToken}`,
+        },
         body: JSON.stringify({
-          error_id: errorId,
           message: error.message,
-          category,
-          severity,
-          stack: error.stack,
           source: "frontend_error_boundary",
-          timestamp: new Date().toISOString(),
+          stack: error.stack,
+          level: severity === "low" ? "warn" : "error",
         }),
       });
     } catch (err) {

--- a/frontend/utils/errorReporting.js
+++ b/frontend/utils/errorReporting.js
@@ -3,6 +3,8 @@
  * Sends error details to the backend for monitoring and debugging
  */
 
+import { getAuth } from 'firebase/auth';
+
 const ERROR_LOG_ENDPOINT = '/api/log-error';
 
 /**
@@ -16,29 +18,43 @@ const ERROR_LOG_ENDPOINT = '/api/log-error';
  */
 export const reportErrorToBackend = async (errorData) => {
   try {
+    // Only attempt to report in browser environments
+    if (typeof fetch === 'undefined') return;
+
+    // Require an authenticated user — the backend now enforces a valid
+    // Firebase ID token on /api/log-error to prevent unauthenticated log
+    // flooding.  If no user is signed in we skip the report silently rather
+    // than crashing the error boundary.
+    const auth = getAuth();
+    const user = auth.currentUser;
+    if (!user) return;
+
+    let idToken;
+    try {
+      idToken = await user.getIdToken();
+    } catch {
+      // Token refresh failed (e.g. network offline) — skip silently.
+      return;
+    }
+
     const payload = {
       message: errorData.error?.message || 'Unknown error',
       stack: errorData.error?.stack || '',
-      context: errorData.context,
-      timestamp: errorData.timestamp,
-      userAgent: errorData.userAgent || navigator.userAgent,
-      severity: errorData.severity || 'high',
-      url: window.location.href,
+      source: errorData.context,
+      level: errorData.severity === 'low' ? 'warn' : 'error',
     };
 
-    // Only attempt to report in browser environments
-    if (typeof fetch !== 'undefined') {
-      await fetch(ERROR_LOG_ENDPOINT, {
-        method: 'POST',
-        headers: {
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      }).catch(() => {
-        // Silently fail if backend logging endpoint is unavailable
-        // This prevents errors in error reporting from breaking the app
-      });
-    }
+    await fetch(ERROR_LOG_ENDPOINT, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Authorization': `Bearer ${idToken}`,
+      },
+      body: JSON.stringify(payload),
+    }).catch(() => {
+      // Silently fail if backend logging endpoint is unavailable
+      // This prevents errors in error reporting from breaking the app
+    });
   } catch (e) {
     // Prevent error reporting from causing cascading failures
     if (import.meta.env.MODE === 'development') {


### PR DESCRIPTION
fixes #1142

The /api/log-error endpoint was fully unauthenticated and had no rate limiting, allowing any external client to flood the log pipeline with valid payloads, saturate observability systems, and amplify storage costs.

Changes:

backend/routers/platform.py (canonical endpoint)
- Add @limiter.limit('10/minute') — caps log volume per IP even for authenticated users, preventing burst flooding.
- Add await verify_role_fn(request) — requires a valid Firebase ID token. Any authenticated role (farmer/expert/admin) is accepted; the check exists solely to block unauthenticated callers, not to gate by role.
- Add Request parameter required by both verify_role and slowapi.
- Improve init guard to also check verify_role_fn is set.

backend/routers/reports.py (duplicate removed)
- Remove the duplicate /log-error handler mounted at /api/admin/log-error. Having two endpoints for the same capability created architectural drift and doubled the attack surface. The canonical endpoint in platform.py (mounted at /api/log-error) is the single source of truth.
- Remove the now-unused ClientErrorReport model from this file.

frontend/utils/errorReporting.js
- Fetch the Firebase ID token via getAuth().currentUser.getIdToken() and send it as Authorization: Bearer <token> on every report request.
- Skip silently when no user is signed in or token refresh fails — the error boundary must never crash because of a failed error report.
- Remove fields not in the backend schema (context, timestamp, userAgent, url) to avoid Pydantic validation errors.

frontend/AsyncErrorBoundary.jsx
- Same token injection pattern: dynamically import firebase/auth, get the current user's ID token, and attach it as the Authorization header.
- Remove extra fields not accepted by ClientErrorReport schema.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security & Reliability**
  * Error reporting endpoint now requires user authentication via Firebase ID token
  * Rate limiting enforced on error reporting endpoint (10 requests per minute)

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1211?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->