### PR TITLE
fix(security): remove /metrics from RBACMiddleware public path exemptions 

### DIFF
--- a/rbac.py
+++ b/rbac.py
@@ -508,7 +508,12 @@ class RBACMiddleware:
     avoid unnecessary latency and Firebase API calls.
     """
 
-    PUBLIC_PATH_PREFIXES = frozenset({"/", "/health", "/metrics", "/favicon"})
+    # /metrics is intentionally excluded from this set.  The endpoint
+    # requires admin authentication (verify_role with required_roles=["admin"])
+    # and must be logged by this middleware like any other protected route.
+    # Listing it here would suppress RBAC audit logging for denied access
+    # attempts and incorrectly classify it in the same trust tier as /health.
+    PUBLIC_PATH_PREFIXES = frozenset({"/", "/health", "/favicon"})
 
     def __init__(self, app):
         self.app = app


### PR DESCRIPTION
fixes #1140 
RBACMiddleware.PUBLIC_PATH_PREFIXES contained '/metrics', placing the Prometheus metrics endpoint in the same trust tier as '/health' and '/favicon'. This had two consequences:

1. The middleware skipped RBAC audit logging for /metrics requests, meaning denied access attempts (wrong role, missing token) were never recorded in the audit trail — making reconnaissance attempts invisible to operators.

2. It signalled architectural intent that /metrics is a public, unauthenticated path, which is incorrect. The endpoint already requires admin authentication via verify_role(request, required_roles=['admin']) in main.py, but the middleware classification contradicted that intent and could mislead future maintainers into treating it as safe to leave open.

Fix: remove '/metrics' from PUBLIC_PATH_PREFIXES. The endpoint now flows through the full RBAC middleware path like any other protected route — access attempts are logged, denied requests appear in the audit trail, and the classification correctly reflects that this endpoint requires authentication.

Note: Instrumentator().instrument(app) is called without .expose(), so no secondary unauthenticated /metrics route is auto-registered by prometheus-fastapi-instrumentator. The only /metrics route is the manually defined @app.get('/metrics') handler in main.py which gates on verify_role admin check.

