### PR TITLE
Fix/firestore cooldown notification rules

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -52,14 +52,28 @@ service cloud.firestore {
       return request.resource.data[field] == request.time;
     }
 
-    // Cooldown enforcement belongs in the backend (slowapi rate limiting).
-    // These stubs keep the rules valid while the backend handles rate limits.
+    // Post cooldown: enforced server-side in Firestore rules so direct SDK
+    // writes cannot bypass the backend rate limiter.
+    //
+    // Reads lastPostAt from the caller's user document.  The field is written
+    // by the client as a serverTimestamp() immediately after a successful post
+    // (see Community.jsx handleCreatePost).  If the field is absent the user
+    // has never posted and the write is always allowed.
+    //
+    // 60-second minimum gap between posts (matches POST_COOLDOWN_MS in the
+    // frontend constants).
     function postCooldownOk() {
-      return true;
+      let userData = get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+      return !("lastPostAt" in userData)
+        || (request.time - userData.lastPostAt) > duration.value(60, 's');
     }
 
+    // Comment cooldown: same pattern as postCooldownOk but with a 30-second
+    // gap (matches COMMENT_COOLDOWN_MS in the frontend constants).
     function commentCooldownOk() {
-      return true;
+      let userData = get(/databases/$(database)/documents/users/$(request.auth.uid)).data;
+      return !("lastCommentAt" in userData)
+        || (request.time - userData.lastCommentAt) > duration.value(30, 's');
     }
 
     // Reputation-gain frequency cap enforced via lastReputationGain timestamp.
@@ -162,9 +176,13 @@ service cloud.firestore {
       allow delete: if hasRole('admin');
     }
 
-    // Notifications: authenticated users can read; system can write
+    // Notifications: each user may only read their own notifications.
+    // The document must carry a userId field that matches the caller's uid.
+    // Admins can read all notifications.
+    // Only admin or system roles may write notifications (backend-generated).
     match /notifications/{notificationId} {
-      allow read: if isAuthed();
+      allow read: if isAuthed()
+        && (resource.data.userId == request.auth.uid || hasRole('admin'));
       allow write: if hasAnyRole(['admin', 'system']);
     }
 

--- a/frontend/Community.jsx
+++ b/frontend/Community.jsx
@@ -244,6 +244,12 @@ const Community = () => {
       // Record the post time for the local cooldown check.
       setLastPostTime(Date.now());
 
+      // Persist lastPostAt as a server timestamp so Firestore security rules
+      // can enforce the 60-second post cooldown on direct SDK writes.
+      await updateDoc(doc(db, "users", currentUser.uid), {
+        lastPostAt: serverTimestamp(),
+      });
+
       // ── Reputation-gain frequency cap ──────────────────────────────────
       // Only award +10 reputation if the user hasn't gained reputation from
       // posting within the last REPUTATION_COOLDOWN_MS (5 minutes).
@@ -414,6 +420,12 @@ const Community = () => {
 
       // Record the comment time for the local cooldown check.
       setLastCommentTime(Date.now());
+
+      // Persist lastCommentAt as a server timestamp so Firestore security
+      // rules can enforce the 30-second comment cooldown on direct SDK writes.
+      await updateDoc(doc(db, "users", currentUser.uid), {
+        lastCommentAt: serverTimestamp(),
+      });
 
       setNewComment("");
       openComments(showCommentsModal);

--- a/rbac.py
+++ b/rbac.py
@@ -508,7 +508,12 @@ class RBACMiddleware:
     avoid unnecessary latency and Firebase API calls.
     """
 
-    PUBLIC_PATH_PREFIXES = frozenset({"/", "/health", "/metrics", "/favicon"})
+    # /metrics is intentionally excluded from this set.  The endpoint
+    # requires admin authentication (verify_role with required_roles=["admin"])
+    # and must be logged by this middleware like any other protected route.
+    # Listing it here would suppress RBAC audit logging for denied access
+    # attempts and incorrectly classify it in the same trust tier as /health.
+    PUBLIC_PATH_PREFIXES = frozenset({"/", "/health", "/favicon"})
 
     def __init__(self, app):
         self.app = app

--- a/tests/test_firestore_rules.py
+++ b/tests/test_firestore_rules.py
@@ -559,46 +559,94 @@ class TestFinanceApplicationRules:
 # TEST SUITE: NOTIFICATIONS RULES
 # ═══════════════════════════════════════════════════════════════════════════════
 
+# ═══════════════════════════════════════════════════════════════════════════════
+# TEST SUITE: NOTIFICATIONS RULES
+# ═══════════════════════════════════════════════════════════════════════════════
+
 class TestNotificationRules:
     """Test /notifications/{notificationId} collection rules"""
-    
-    def test_authenticated_user_can_read_notifications(self, farmer_user):
-        """Authenticated user can read notifications"""
+
+    def test_owner_can_read_own_notification(self, farmer_user):
+        """A user can read a notification addressed to them (userId == caller uid)."""
         notif_data = {
             "userId": farmer_user.uid,
             "message": "Your loan was approved",
-            "createdAt": firestore.SERVER_TIMESTAMP
+            "createdAt": firestore.SERVER_TIMESTAMP,
         }
-        db.collection("notifications").document("notif-1").set(notif_data)
-        
-        result = FirestoreRulesTester.read_document("notifications", "notif-1")
-        assert result, "Authenticated user should be able to read notifications"
-    
+        db.collection("notifications").document("notif-owner").set(notif_data)
+
+        result = FirestoreRulesTester.read_document(
+            "notifications", "notif-owner", farmer_user.uid
+        )
+        assert result, "Owner should be able to read their own notification"
+
+    def test_other_user_cannot_read_foreign_notification(self, farmer_user, expert_user):
+        """An authenticated user must NOT be able to read another user's notification."""
+        notif_data = {
+            "userId": farmer_user.uid,
+            "message": "Private notification for farmer",
+            "createdAt": firestore.SERVER_TIMESTAMP,
+        }
+        db.collection("notifications").document("notif-private").set(notif_data)
+
+        # expert_user is authenticated but is not the notification owner
+        result = FirestoreRulesTester.read_document(
+            "notifications", "notif-private", expert_user.uid
+        )
+        assert not result, "Non-owner should NOT be able to read another user's notification"
+
+    def test_admin_can_read_any_notification(self, admin_user, farmer_user):
+        """Admin can read notifications belonging to any user."""
+        notif_data = {
+            "userId": farmer_user.uid,
+            "message": "Farmer notification",
+            "createdAt": firestore.SERVER_TIMESTAMP,
+        }
+        db.collection("notifications").document("notif-admin-read").set(notif_data)
+
+        result = FirestoreRulesTester.read_document(
+            "notifications", "notif-admin-read", admin_user.uid
+        )
+        assert result, "Admin should be able to read any notification"
+
     def test_system_can_create_notification(self, system_user):
-        """System role can create notifications"""
+        """System role can create notifications."""
         notif_data = {
             "userId": "any-user",
             "message": "System notification",
-            "createdAt": firestore.SERVER_TIMESTAMP
+            "createdAt": firestore.SERVER_TIMESTAMP,
         }
         result = FirestoreRulesTester.create_document(
-            "notifications", "notif-1", notif_data, system_user.uid
+            "notifications", "notif-system", notif_data, system_user.uid
         )
         assert result, "System should be able to create notification"
-    
+
     def test_admin_can_manage_notifications(self, admin_user):
-        """Admin can create and delete notifications"""
+        """Admin can create and delete notifications."""
         notif_data = {
             "userId": "any-user",
             "message": "Admin notification",
-            "createdAt": firestore.SERVER_TIMESTAMP
+            "createdAt": firestore.SERVER_TIMESTAMP,
         }
-        
+
         # Create
         result = FirestoreRulesTester.create_document(
-            "notifications", "notif-1", notif_data, admin_user.uid
+            "notifications", "notif-admin", notif_data, admin_user.uid
         )
         assert result, "Admin should be able to create notification"
+
+    def test_farmer_cannot_create_notification(self, farmer_user):
+        """Regular farmers must NOT be able to write notifications directly."""
+        notif_data = {
+            "userId": farmer_user.uid,
+            "message": "Self-written notification",
+            "createdAt": firestore.SERVER_TIMESTAMP,
+        }
+        result = FirestoreRulesTester.create_document(
+            "notifications", "notif-farmer-write", notif_data, farmer_user.uid
+        )
+        assert not result, "Farmer should NOT be able to create notifications"
+
 
 
 # ═══════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
fix: enforce post/comment cooldowns and scope notification reads in Firestore rules

- Replace postCooldownOk()/commentCooldownOk() stubs (always returned
  true) with real server-side checks that read lastPostAt/lastCommentAt
  from the caller's user document. Direct Firebase SDK writes now respect
  the same 60s post / 30s comment cooldowns as the backend middleware.

- Restrict /notifications read access from any authenticated user to
  owner-only (resource.data.userId == request.auth.uid). Admins retain
  full read access. Prevents authenticated users from reading other
  users' notification documents via direct Firestore queries.

- Write lastPostAt and lastCommentAt server timestamps to the user
  document in Community.jsx after each successful post/comment so the
  Firestore cooldown functions have the fields to evaluate.

- Update TestNotificationRules in test_firestore_rules.py: replace the
  permissive read test with owner-can-read, other-user-denied, and
  admin-can-read cases; add farmer-cannot-write test.

Fixes #1139