### PR TITLE
fix: require authentication on platform /gemini/analyze-image and /simulate-climate

### DIFF
--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -405,7 +405,15 @@ async def rag_query(request: Request, body: RAGQuery):
 
 
 @router.post("/gemini/analyze-image")
-async def gemini_analyze_image(body: GeminiImageRequest):
+async def gemini_analyze_image(request: Request, body: GeminiImageRequest):
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
+
+    # Require a valid Firebase ID token to prevent unauthenticated callers
+    # from proxying arbitrary images through the server's GEMINI_API_KEY,
+    # exhausting quota and incurring billing charges.
+    await verify_role_fn(request)
+
     import httpx
 
     api_key = os.getenv("GEMINI_API_KEY", "").strip()
@@ -454,7 +462,15 @@ async def gemini_analyze_image(body: GeminiImageRequest):
 
 
 @router.post("/simulate-climate")
-async def simulate_climate(data: SimulationRequest):
+async def simulate_climate(request: Request, data: SimulationRequest):
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
+
+    # Require a valid Firebase ID token to prevent unauthenticated callers
+    # from consuming compute resources and to keep this route consistent with
+    # the authenticated /api/knowledge/simulate-climate endpoint.
+    await verify_role_fn(request)
+
     sensitivities = {
         "rice": {"temp": -0.05, "rain": 0.02},
         "wheat": {"temp": -0.06, "rain": 0.03},


### PR DESCRIPTION
Both routes were missing Firebase ID token verification, allowing any unauthenticated caller to:
  - POST /api/gemini/analyze-image: proxy arbitrary base64 image payloads through the server's GEMINI_API_KEY, exhausting Gemini quota and incurring billing charges with no attribution.
  - POST /api/simulate-climate: consume compute resources freely, and create an inconsistency with the authenticated equivalent route at /api/knowledge/simulate-climate.

Fix: add 
equest: Request parameter and wait verify_role_fn(request) to both handlers, matching the pattern already used by /api/rag/query in the same router and by all three routes in knowledge.py.

/api/rag/query was already protected — no change needed there.

Fixes #1138


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Image analysis endpoint now requires authenticated access.
  * Climate simulation endpoint now requires authenticated access.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->