### PR TITLE
fix: require auth and add Celery timeout on all ML prediction endpoints

### DIFF
--- a/backend/routers/ml.py
+++ b/backend/routers/ml.py
@@ -29,24 +29,29 @@ class YieldInput(BaseModel):
 model_router = None
 model_lag = None
 model_trend = None
+verify_role_fn = None
 
 TREND_MODEL_PATH = "trend_forecast_model.joblib"
 
-def init_router(r_instance, model_lag_instance, model_trend_instance=None):
-    global model_router, model_lag, model_trend
+def init_router(r_instance, model_lag_instance, model_trend_instance=None, verify_role=None):
+    global model_router, model_lag, model_trend, verify_role_fn
     model_router = r_instance
     model_lag = model_lag_instance
     model_trend = model_trend_instance
+    verify_role_fn = verify_role
 
 @router.get("")
 def predict_get():
     return {"predicted_yield": 2500, "note": "Use POST endpoint for actual prediction"}
 
 @router.post("", response_model=PredictResponse)
-def predict_yield(data: PredictRequest, request: Request):
+async def predict_yield(data: PredictRequest, request: Request):
     """Yield prediction using ML router"""
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
     if model_router is None:
         raise HTTPException(status_code=500, detail="ML model not initialized")
+    await verify_role_fn(request)
     try:
         input_data = data.model_dump() if hasattr(data, "model_dump") else data.dict()
         context = {"location": request.headers.get("X-User-Location", "Unknown"), "crop": data.Crop}
@@ -57,6 +62,9 @@ def predict_yield(data: PredictRequest, request: Request):
 
 @router.post("/predict-yield-lag")
 async def predict_yield_lag(payload: YieldInput, request: Request):
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
+    await verify_role_fn(request)
     if model_lag is None:
         raise HTTPException(status_code=500, detail="Model not loaded")
     try:
@@ -78,6 +86,10 @@ async def predict_yield_trend(payload: YieldInput, request: Request):
     to generate multi-step future predictions. Raises a clear error
     if the trend model is unavailable instead of silently using the wrong model.
     """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Auth service not initialized")
+    await verify_role_fn(request)
+
     global model_trend
 
     if model_trend is None:

--- a/lstm_yield_model.py
+++ b/lstm_yield_model.py
@@ -3,7 +3,8 @@ import numpy as np
 import logging
 import os
 from contextlib import asynccontextmanager
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI, HTTPException, Request
+from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from pydantic import BaseModel
 from typing import List
 from sklearn.preprocessing import MinMaxScaler
@@ -108,20 +109,59 @@ app = FastAPI(
     lifespan=lifespan
 )
 
+_bearer = HTTPBearer(auto_error=False)
+
+
+async def _require_firebase_auth(request: Request) -> str:
+    """Verify a Firebase ID token from the Authorization: Bearer header.
+
+    Returns the verified UID on success.  Raises HTTP 401 on any failure so
+    unauthenticated callers cannot reach the inference endpoint.
+    """
+    credentials: HTTPAuthorizationCredentials | None = await _bearer(request)
+    if credentials is None or not credentials.credentials:
+        raise HTTPException(status_code=401, detail="Missing authentication token")
+
+    token = credentials.credentials.strip()
+    try:
+        import firebase_admin
+        from firebase_admin import auth as firebase_auth
+
+        # Initialize the Firebase app lazily if it hasn't been done yet.
+        # In production the app is typically initialized by the parent process;
+        # this guard makes the standalone server self-contained.
+        if not firebase_admin._apps:
+            firebase_admin.initialize_app()
+
+        decoded = firebase_auth.verify_id_token(token)
+    except Exception as exc:
+        raise HTTPException(status_code=401, detail="Invalid or expired authentication token") from exc
+
+    uid = decoded.get("uid")
+    if not uid:
+        raise HTTPException(status_code=401, detail="Invalid authentication token")
+    return uid
+
 
 @app.post("/predict", response_model=PredictionResponse)
-async def predict(request: PredictionRequest):
+async def predict(request: Request, body: PredictionRequest):
     """
     Inference endpoint.
     Expects input features matching the sequence length used during training.
+
+    Requires a valid Firebase ID token in the Authorization: Bearer header.
+    Unauthenticated requests are rejected with HTTP 401 to prevent quota
+    exhaustion and automated scraping of model behaviour.
     """
+    await _require_firebase_auth(request)
+
     if model is None:
         raise HTTPException(status_code=503, detail="Model is not loaded. Cannot serve predictions.")
     
     try:
         # Convert request data to numpy array
         # Reshape to match the expected input shape: (batch_size, sequence_length, num_features)
-        input_data = np.array(request.features)
+        input_data = np.array(body.features)
         
         if len(input_data.shape) == 2:
             input_data = np.expand_dims(input_data, axis=0)
@@ -150,4 +190,4 @@ if __name__ == "__main__":
     # When run as a script, we start the inference server locally
     import uvicorn
     # Note: Run it on a specific port for the dedicated inference server
-    uvicorn.run("lstm_yield_model:app", host="0.0.0.0", port=8001, reload=False)
+    uvicorn.run("lstm_yield_model:app", host="0.0.0.0", port=8001, reload=False)

--- a/main.py
+++ b/main.py
@@ -242,7 +242,7 @@ async def lifespan(app: FastAPI):
     except Exception:
         model_trend = None
 
-    ml.init_router(ModelRouter(default_model="xgboost"), model_lag, model_trend)
+    ml.init_router(ModelRouter(default_model="xgboost"), model_lag, model_trend, verify_role)
 
     yield
     # Shutdown
@@ -701,6 +701,8 @@ async def predict_yield(data: PredictRequest, request: Request):
     missing required feature, so callers receive an actionable error message
     rather than a silently corrupted prediction.
     """
+    await verify_role(request)
+
     try:
         input_data = data.model_dump() if hasattr(data, "model_dump") else data.dict()
         input_data = _coerce_prediction_inputs(input_data)
@@ -714,7 +716,12 @@ async def predict_yield(data: PredictRequest, request: Request):
         from celery_worker import predict_yield_task
         task = predict_yield_task.delay(input_data, context)
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, task.get)
+        # timeout=30 prevents executor threads from blocking indefinitely when
+        # a Celery worker is slow or the broker is unreachable.
+        try:
+            result = await loop.run_in_executor(None, lambda: task.get(timeout=30))
+        except Exception as celery_exc:
+            raise HTTPException(status_code=504, detail="Prediction timed out or worker unavailable") from celery_exc
 
         if "error" in result:
             err_type = result.get("type")
@@ -736,12 +743,17 @@ async def predict_yield(data: PredictRequest, request: Request):
 @app.post("/predict-yield-lag")
 @limiter.limit("5/minute")
 async def predict_yield_lag(payload: YieldInput, request: Request):
+    await verify_role(request)
+
     try:
         # Offload time-series lag model prediction to Celery worker pool
         from celery_worker import predict_yield_lag_task
         task = predict_yield_lag_task.delay(payload.data)
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, task.get)
+        try:
+            result = await loop.run_in_executor(None, lambda: task.get(timeout=30))
+        except Exception as celery_exc:
+            raise HTTPException(status_code=504, detail="Prediction timed out or worker unavailable") from celery_exc
 
         if "error" in result:
             raise HTTPException(status_code=400, detail=result["error"])
@@ -755,12 +767,17 @@ async def predict_yield_lag(payload: YieldInput, request: Request):
 @app.post("/predict-yield-trend")
 @limiter.limit("5/minute")
 async def predict_yield_trend(payload: YieldInput, request: Request):
+    await verify_role(request)
+
     try:
         # Offload heavy iterative trend forecasting to Celery worker pool
         from celery_worker import predict_yield_trend_task
         task = predict_yield_trend_task.delay(payload.data)
         loop = asyncio.get_running_loop()
-        result = await loop.run_in_executor(None, task.get)
+        try:
+            result = await loop.run_in_executor(None, lambda: task.get(timeout=30))
+        except Exception as celery_exc:
+            raise HTTPException(status_code=504, detail="Prediction timed out or worker unavailable") from celery_exc
 
         if "error" in result:
             raise HTTPException(status_code=400, detail=result["error"])


### PR DESCRIPTION
Missing authentication
- main.py /predict, /predict-yield-lag, /predict-yield-trend: add await verify_role(request) before any model work. Unauthenticated callers now receive HTTP 401 instead of free model access.
- backend/routers/ml.py: same three routes lacked auth. Added verify_role_fn parameter to init_router() and guard calls in each handler. predict_yield() promoted from sync def to async def so await works correctly.
- lstm_yield_model.py /predict: standalone LSTM server had no auth at all. Added _require_firebase_auth() helper (HTTPBearer + firebase_admin verify_id_token) and call it at the top of the handler. Renamed the handler parameter from request: PredictionRequest to request: Request, body: PredictionRequest to avoid shadowing.

Unbounded Celery blocking
- main.py: replaced bare task.get (no timeout) with lambda: task.get(timeout=30) in all three run_in_executor calls. A stuck or slow worker now returns HTTP 504 after 30 s instead of blocking the thread-pool indefinitely.

Wiring
- main.py lifespan: pass verify_role to ml.init_router() so the router module receives the auth function at startup.

Fixes #1137