### PR TITLE
fix(whatsapp): enforce E.164 format and length bounds on phone_number (issue #1149)

### DIFF
--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ from typing import Optional, Dict, Any
 from fastapi import FastAPI, HTTPException, Request, Form, Query, Response, WebSocket, WebSocketDisconnect
 from fastapi.middleware.cors import CORSMiddleware
 from contextlib import asynccontextmanager
-from pydantic import BaseModel, Field, ConfigDict, validator
+from pydantic import BaseModel, Field, ConfigDict, field_validator, validator
 
 class SimulationRequest(BaseModel):
     crop_type: str
@@ -418,14 +418,29 @@ class PredictRequest(BaseModel):
 class PredictResponse(BaseModel):
     predicted_ExpYield: float
 
+_E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")
+
+
 class WhatsAppSubscribeRequest(BaseModel):
-    phone_number: str
-    name: str
+    # E.164 format: + followed by 7-15 digits, no spaces or dashes.
+    # Examples: +919876543210, +14155552671
+    # max_length=16 covers the longest valid E.164 number (+<15 digits>).
+    phone_number: str = Field(..., min_length=8, max_length=16)
+    name: str = Field(..., min_length=1, max_length=100)
     region_id: Optional[str] = Field(default=None, max_length=100)
     # user_id is accepted for backward compatibility but is IGNORED by the
-    # endpoint — the authoritative user identity is always derived from the
+    # endpoint -- the authoritative user identity is always derived from the
     # verified Firebase ID token, never from client-supplied data.
     user_id: Optional[str] = None
+
+    @field_validator("phone_number")
+    @classmethod
+    def validate_e164(cls, v: str) -> str:
+        if not _E164_RE.match(v):
+            raise ValueError(
+                "phone_number must be in E.164 format (e.g. +919876543210)"
+            )
+        return v
 
 class YieldInput(BaseModel):
     data: list[float]

--- a/tests/test_whatsapp_phone_validation.py
+++ b/tests/test_whatsapp_phone_validation.py
@@ -1,0 +1,132 @@
+"""Tests for WhatsAppSubscribeRequest E.164 phone number validation.
+
+Verifies that:
+- Valid E.164 numbers are accepted.
+- Numbers missing the + prefix are rejected.
+- Numbers with spaces, dashes, or parentheses are rejected.
+- Numbers that are too short or too long are rejected.
+- Arbitrary strings are rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+# Import directly from main to test the actual model used by the endpoint.
+from main import WhatsAppSubscribeRequest
+
+
+def _make(phone: str) -> WhatsAppSubscribeRequest:
+    return WhatsAppSubscribeRequest(phone_number=phone, name="Test Farmer")
+
+
+# ---------------------------------------------------------------------------
+# Valid numbers
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phone",
+    [
+        "+919876543210",   # India (12 chars)
+        "+14155552671",    # US (11 chars)
+        "+447911123456",   # UK (12 chars)
+        "+12125551234",    # US with area code
+        "+85212345678",    # Hong Kong (11 chars)
+        "+1234567",        # minimum valid: +1 followed by 6 digits (7 total digits)
+    ],
+)
+def test_valid_e164_numbers(phone: str) -> None:
+    req = _make(phone)
+    assert req.phone_number == phone
+
+
+# ---------------------------------------------------------------------------
+# Missing or wrong prefix
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phone",
+    [
+        "919876543210",     # missing + prefix
+        "0919876543210",    # leading zero instead of +
+        "00919876543210",   # double-zero prefix
+    ],
+)
+def test_rejects_missing_plus_prefix(phone: str) -> None:
+    with pytest.raises(ValidationError, match="E.164"):
+        _make(phone)
+
+
+# ---------------------------------------------------------------------------
+# Formatting characters not allowed
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phone",
+    [
+        "+91 98765 43210",     # spaces
+        "+91-9876-543210",     # dashes
+        "+91(98765)43210",     # parentheses
+        "+91.9876.543210",     # dots
+    ],
+)
+def test_rejects_formatted_numbers(phone: str) -> None:
+    with pytest.raises(ValidationError, match="E.164"):
+        _make(phone)
+
+
+# ---------------------------------------------------------------------------
+# Length constraints
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_too_short() -> None:
+    # + followed by only 5 digits -- fewer than the minimum 6 after country code
+    with pytest.raises(ValidationError):
+        _make("+12345")
+
+
+def test_rejects_too_long() -> None:
+    # 17-character string exceeds max_length=16
+    with pytest.raises(ValidationError):
+        _make("+1" + "9" * 15)
+
+
+# ---------------------------------------------------------------------------
+# Arbitrary / injection strings
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "phone",
+    [
+        "",
+        "not-a-phone",
+        "+",
+        "++919876543210",
+        "+91987654321012345678",   # way too long
+        "'; DROP TABLE subscribers; --",
+    ],
+)
+def test_rejects_arbitrary_strings(phone: str) -> None:
+    with pytest.raises(ValidationError):
+        _make(phone)
+
+
+# ---------------------------------------------------------------------------
+# name field bounds (added as part of this fix)
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_empty_name() -> None:
+    with pytest.raises(ValidationError):
+        WhatsAppSubscribeRequest(phone_number="+919876543210", name="")
+
+
+def test_rejects_name_over_100_chars() -> None:
+    with pytest.raises(ValidationError):
+        WhatsAppSubscribeRequest(phone_number="+919876543210", name="A" * 101)


### PR DESCRIPTION
## Summary

Fixes #1149.

`WhatsAppSubscribeRequest.phone_number` accepted any arbitrary string with no format or length constraint. The value was forwarded directly to the Twilio API without validation, enabling:

- **Financial drain**: premium-rate numbers silently accepted and messaged
- **Phone-number oracle**: Twilio error codes distinguish reachable vs unreachable numbers
- **Unbounded payload**: no max_length allowed arbitrarily long strings into the API

## Changes

**`main.py`**

- Added `_E164_RE = re.compile(r"^\+[1-9]\d{6,14}$")` module-level constant
- Added `field_validator` to `WhatsAppSubscribeRequest.validate_e164` that enforces E.164 format
- Tightened `phone_number` field bounds: `min_length=8`, `max_length=16`
- Added `min_length=1`, `max_length=100` to `name` field (was unbounded)
- Added `field_validator` to the existing `pydantic` import

**`tests/test_whatsapp_phone_validation.py`** (new)

- 23 test cases: valid E.164 numbers, missing `+` prefix, formatting characters (spaces, dashes, parentheses), length extremes, injection strings, and `name` field bounds

## Test results

```
23 passed in 0.02s
```

## Before / After

```python
# Before
class WhatsAppSubscribeRequest(BaseModel):
    phone_number: str   # no validation whatsoever
    name: str

# After
class WhatsAppSubscribeRequest(BaseModel):
    phone_number: str = Field(..., min_length=8, max_length=16)
    name: str = Field(..., min_length=1, max_length=100)

    @field_validator("phone_number")
    @classmethod
    def validate_e164(cls, v: str) -> str:
        if not _E164_RE.match(v):
            raise ValueError("phone_number must be in E.164 format (e.g. +919876543210)")
        return v
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Stricter phone number validation now enforces E.164 format (requires + prefix)
  * Added character length constraints for phone numbers and user names in WhatsApp subscriptions

* **Tests**
  * Added comprehensive test coverage for WhatsApp subscription field validation

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1235?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->