### PR TITLE
fix: remove double token verification and TOCTOU race in get_feedback_stats

### DIFF
--- a/feedback_api.py
+++ b/feedback_api.py
@@ -307,31 +307,24 @@ async def get_feedback_stats(
     request: Request,
     admin_user: dict = Depends(verify_admin),
 ):
-    """Get feedback statistics (admin only)"""
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        raise HTTPException(status_code=401, detail="Missing auth token")
+    """Get feedback statistics (admin only).
 
-    try:
-        id_token = auth_header.split(" ")[1]
-        decoded = firebase_auth.verify_id_token(id_token)
-    except Exception:
-        raise HTTPException(status_code=401, detail="Invalid or expired token")
+    Authentication and role enforcement are handled entirely by the
+    verify_admin dependency — a single Firebase token verification and a
+    single Firestore role read per request.
 
-    uid = decoded["uid"]
+    The previous implementation re-verified the token and re-read the
+    Firestore role a second time inside the handler body, which:
+      1. Created a TOCTOU window: the role could change between the two
+         Firestore reads, making the authorization decision non-atomic.
+      2. Doubled Firebase SDK and Firestore round-trips on every request.
+      3. Used a default of 'farmer' for a missing role field on the second
+         read, which could produce inconsistent 403s for legitimate admins
+         whose documents were momentarily unavailable.
 
-    try:
-        user_doc = db.collection("users").document(uid).get()
-    except Exception:
-        raise HTTPException(status_code=503, detail="Authorization service unavailable")
-
-    if not user_doc.exists:
-        raise HTTPException(status_code=403, detail="User profile not found")
-
-    user_role = user_doc.to_dict().get("role", "farmer")
-    if user_role != "admin":
-        raise HTTPException(status_code=403, detail="Access denied: admin role required")
-
+    The uid resolved by verify_admin is passed through admin_user so the
+    handler has the caller's identity without any additional I/O.
+    """
     try:
         feedback_ref = db.collection("feedback")
         docs = feedback_ref.limit(1000).stream()
@@ -356,9 +349,7 @@ async def get_feedback_stats(
         total_count = len(feedbacks)
         avg_rating = total_rating / total_count if total_count > 0 else 0
 
-        # Return only the last 10 entries for the recent list, and strip
-        # PII fields (ipAddress, userAgent, userEmail) so sensitive data
-        # is never serialised into the HTTP response body.
+        # Strip PII fields before returning to the caller.
         _PII_FIELDS = {"ipAddress", "userAgent", "userEmail"}
         recent_raw = feedbacks[-10:] if len(feedbacks) > 10 else feedbacks
         recent = [


### PR DESCRIPTION
The get_feedback_stats handler was performing a full Firebase token verification and a Firestore role read inside the handler body, after the verify_admin dependency had already done both:

  1. TOCTOU race condition: the role could be changed between the dependency's Firestore read (T1) and the handler's second read (T2), making the authorization decision non-atomic. A role revocation applied between T1 and T2 would not be enforced.

  2. Inconsistent denial for legitimate admins: the handler's second read used .get('role', 'farmer') as a default. If the Firestore document was momentarily unavailable after the dependency had already granted access, the handler would raise HTTP 403 for a legitimately authenticated admin.

  3. Doubled I/O cost: every stats request triggered two firebase_auth.verify_id_token() calls (each a potential network round-trip to fetch Google's public keys) and two Firestore reads of the same users/{uid} document.

Fix: remove the redundant inline verification block entirely. The verify_admin dependency is the single authoritative auth check. The uid resolved by verify_admin is available via admin_user['uid'] if the handler ever needs it.

Fixes #1301

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Streamlined authorization handling in the feedback statistics endpoint.

* **Security & Privacy**
  * Updated feedback statistics to exclude personally identifiable information from returned data.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1304?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->