### PR TITLE
fix: remove PII from feedback submission response body

### DIFF
--- a/feedback_api.py
+++ b/feedback_api.py
@@ -106,11 +106,16 @@ class FeedbackRequest(BaseModel):
 
 
 class FeedbackResponse(BaseModel):
-    """Response model for feedback submission"""
+    """Response model for feedback submission.
+
+    validated_data is intentionally absent.  The stored document contains
+    server-collected PII fields (ipAddress, userAgent) that must never be
+    echoed back in the HTTP response body — they would be captured by CDN
+    access logs, browser devtools, and any proxy between client and server.
+    """
     success: bool
     feedback_id: Optional[str] = None
     message: str
-    validated_data: Optional[dict] = None
     timestamp: str
 
 
@@ -275,7 +280,6 @@ async def submit_feedback(
                 success=True,
                 feedback_id=feedback_id,
                 message="Feedback submitted successfully",
-                validated_data=validated_data,
                 timestamp=datetime.now(timezone.utc).isoformat()
             )
             


### PR DESCRIPTION
POST /api/feedback was returning the entire validated_data dict in the HTTP response body via the FeedbackResponse.validated_data field.

validated_data contained server-collected PII fields added just before the Firestore write:

    validated_data['ipAddress'] = request.client.host
    validated_data['userAgent'] = request.headers.get('user-agent', '')

Returning these fields in the response body means:
  - The caller's IP address is echoed back in the JSON response.
  - The User-Agent string is echoed back in the JSON response.
  - Any userEmail supplied in the request body is also echoed back.
  - All three fields are captured by CDN access logs, browser devtools, API gateway logs, and any proxy between client and server — violating GDPR Article 5 (data minimisation).

The admin stats endpoint already applied a _PII_FIELDS stripping step before returning recent_feedbacks, confirming the developer knew these fields were PII but forgot to apply the same treatment to the submission response.

Fix:
  - Remove validated_data field from FeedbackResponse model entirely.
  - Remove validated_data=validated_data from the return statement.
  - ipAddress and userAgent continue to be stored in Firestore for audit and abuse-investigation purposes — only the response is changed.

Fixes #1298
