### PR TITLE
Bug — Rate-limiter memory leak + no cleanup

### DIFF
--- a/backend/routers/voice_assistant.py
+++ b/backend/routers/voice_assistant.py
@@ -27,6 +27,8 @@ Still requires admin/system role:
 import os
 import re
 import logging
+from threading import Lock
+from time import monotonic
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, File, HTTPException, Request, UploadFile
@@ -150,25 +152,51 @@ TEMP_UPLOAD_DIR = "./temp_audio_uploads"
 ALLOWED_EXTENSIONS = {".wav", ".mp3", ".ogg", ".webm", ".m4a"}
 
 _rate_limit_store: Dict[str, tuple] = {}
+_rate_limit_lock = Lock()
+_last_rate_limit_prune = 0.0
 RATE_LIMIT_COUNT = 10   # max uploads per window
 RATE_LIMIT_WINDOW = 60  # seconds
+RATE_LIMIT_PRUNE_INTERVAL = RATE_LIMIT_WINDOW
+
+
+def _prune_rate_limit_store(now: float) -> None:
+    """Drop expired rate-limit entries to bound in-memory state."""
+    global _last_rate_limit_prune
+
+    if now - _last_rate_limit_prune < RATE_LIMIT_PRUNE_INTERVAL:
+        return
+
+    expired_uids = [
+        uid
+        for uid, (_, window_start) in _rate_limit_store.items()
+        if now - window_start > RATE_LIMIT_WINDOW
+    ]
+    for uid in expired_uids:
+        _rate_limit_store.pop(uid, None)
+
+    _last_rate_limit_prune = now
 
 
 def _check_rate_limit(uid: str) -> bool:
     """Return True if the request is within the rate limit for this uid."""
-    import time
-    now = time.time()
-    if uid not in _rate_limit_store:
-        _rate_limit_store[uid] = (1, now)
+    now = monotonic()
+    with _rate_limit_lock:
+        _prune_rate_limit_store(now)
+
+        if uid not in _rate_limit_store:
+            _rate_limit_store[uid] = (1, now)
+            return True
+
+        count, window_start = _rate_limit_store[uid]
+        if now - window_start > RATE_LIMIT_WINDOW:
+            _rate_limit_store[uid] = (1, now)
+            return True
+
+        if count >= RATE_LIMIT_COUNT:
+            return False
+
+        _rate_limit_store[uid] = (count + 1, window_start)
         return True
-    count, window_start = _rate_limit_store[uid]
-    if now - window_start > RATE_LIMIT_WINDOW:
-        _rate_limit_store[uid] = (1, now)
-        return True
-    if count >= RATE_LIMIT_COUNT:
-        return False
-    _rate_limit_store[uid] = (count + 1, window_start)
-    return True
 
 
 def _validate_filename(filename: str) -> str:

--- a/tests/test_voice_assistant_rate_limit.py
+++ b/tests/test_voice_assistant_rate_limit.py
@@ -1,0 +1,21 @@
+from backend.routers import voice_assistant as voice_assistant_router
+
+
+def setup_function():
+    voice_assistant_router._rate_limit_store.clear()
+    voice_assistant_router._last_rate_limit_prune = 0.0
+
+
+def test_rate_limit_prunes_expired_entries(monkeypatch):
+    current_time = 100.0
+    monkeypatch.setattr(voice_assistant_router, "monotonic", lambda: current_time)
+
+    voice_assistant_router._rate_limit_store["stale-user"] = (
+        3,
+        current_time - voice_assistant_router.RATE_LIMIT_WINDOW - 1,
+    )
+    voice_assistant_router._rate_limit_store["fresh-user"] = (2, current_time)
+
+    assert voice_assistant_router._check_rate_limit("fresh-user") is True
+    assert "stale-user" not in voice_assistant_router._rate_limit_store
+    assert voice_assistant_router._rate_limit_store["fresh-user"] == (3, current_time)


### PR DESCRIPTION
Implemented the limiter fix in backend/routers/voice_assistant.py: the shared `_rate_limit_store` is now guarded by a `Lock`, uses `monotonic()` timing, and prunes expired entries periodically so stale UIDs do not accumulate indefinitely. The cleanup path is in the pruning helper and the synchronized request path is in the limiter check.

I also added a regression test in tests/test_voice_assistant_rate_limit.py that proves an expired entry is evicted on the next limiter access.

Validation passed with a direct behavior check and a syntax compile of the touched files. I did not get a clean `pytest` run for that new test file, so that remains the only small verification gap.


closes #1248

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Enhanced voice assistant upload rate limiter with improved reliability and memory management, ensuring proper function during system clock adjustments.

* **Tests**
  * Added tests for rate limiting behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1321?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->