### PR TITLE
fix(circuit-breaker): accept coroutine factory to eliminate coroutine leak

### DIFF
--- a/async_error_handler.py
+++ b/async_error_handler.py
@@ -329,8 +329,27 @@ class AsyncErrorHandler:
 
 
 class CircuitBreakerAsync:
-    """Circuit breaker for async operations"""
-    
+    """Circuit breaker for async operations.
+
+    Callers MUST pass a coroutine factory (a zero-argument callable that
+    returns a fresh coroutine each time it is called) rather than a bare
+    coroutine object.  This is required because:
+
+    1. A coroutine object can only be awaited once.  If the circuit is open
+       and the coroutine is rejected without being awaited, the object must
+       be explicitly closed to release its frame resources and suppress the
+       ``RuntimeWarning: coroutine '...' was never awaited`` warning.
+       Passing a factory means the circuit breaker never even creates the
+       coroutine when the circuit is open, so there is nothing to leak.
+
+    2. The previous API accepted a raw ``Coroutine`` object.  When the
+       circuit was open it called ``coro.close()`` to suppress the warning,
+       but ``close()`` sends a ``GeneratorExit`` into the coroutine frame
+       which can raise ``RuntimeError`` if the coroutine has already started
+       executing (e.g. in a half-open retry scenario).  Using a factory
+       avoids this entirely.
+    """
+
     def __init__(
         self,
         failure_threshold: int = 5,
@@ -340,38 +359,59 @@ class CircuitBreakerAsync:
         self.failure_threshold = failure_threshold
         self.recovery_timeout = recovery_timeout
         self.name = name
-        
+
         self.failure_count = 0
         self.last_failure_time = None
         self.state = "closed"  # closed, open, half_open
-    
+
     async def execute(
         self,
-        coro: Coroutine[Any, Any, T]
+        coro_factory: Callable[[], Coroutine[Any, Any, T]],
     ) -> tuple[Optional[T], bool]:
         """
-        Execute coroutine with circuit breaker
-        
-        Returns:
-            (result, is_healthy)
+        Execute a coroutine produced by *coro_factory* with circuit-breaker
+        protection.
+
+        Parameters
+        ----------
+        coro_factory:
+            A zero-argument callable that returns a **fresh** coroutine each
+            time it is called.  Example::
+
+                await cb.execute(lambda: my_async_fn(arg1, arg2))
+
+        Returns
+        -------
+        (result, is_healthy)
+            *result* is ``None`` and *is_healthy* is ``False`` when the
+            circuit is open or the execution raised an exception.
         """
-        
-        # Check if circuit should be opened
+        # When the circuit is open, reject immediately without creating a
+        # coroutine at all — nothing to close, nothing to leak.
         if self.state == "open":
             if self._should_attempt_recovery():
                 self.state = "half_open"
             else:
-                coro.close()
+                logger.debug(
+                    "Circuit breaker %s is open — request rejected", self.name
+                )
                 return None, False
-        
-        # Execute
+
+        # Create a fresh coroutine from the factory for this attempt.
+        coro = coro_factory()
         try:
             result = await coro
             self._on_success()
             return result, True
         except Exception as e:
             self._on_failure()
-            logger.warning(f"Circuit breaker {self.name}: {e}")
+            logger.warning("Circuit breaker %s caught exception: %s", self.name, e)
+            # Explicitly close the coroutine in case it was only partially
+            # driven before the exception propagated, ensuring frame cleanup.
+            try:
+                coro.close()
+            except Exception:
+                pass
             return None, False
     
     def _on_success(self):


### PR DESCRIPTION
fix #1379

CircuitBreakerAsync.execute() previously accepted a raw Coroutine object. This caused two bugs:

1. Open-state coroutine leak When the circuit was open and _should_attempt_recovery() returned False, the code called coro.close() to suppress the 'coroutine was never awaited' RuntimeWarning. coro.close() sends GeneratorExit into the coroutine frame, which can raise RuntimeError if the coroutine had already started executing (e.g. during a half-open probe that failed and re-opened the circuit). The close() call was also not wrapped in try/except, so any exception it raised would propagate out of execute() as an unhandled error.

2. Single-use coroutine prevents safe retry A coroutine object can only be awaited once. If execute() were ever called in a retry loop with the same coroutine instance, the second await would raise 'cannot reuse already awaited coroutine'. The factory pattern makes retries safe by construction.

Fix: change the parameter from Coroutine to Callable[[], Coroutine] (a coroutine factory). When the circuit is open the factory is never called, so no coroutine object is created and there is nothing to close or leak. When the circuit allows execution, a fresh coroutine is created from the factory for each attempt. After an exception the coroutine is closed in a try/except to release frame resources without risking a secondary exception.

Callers update their call sites from:
    await cb.execute(my_async_fn(arg1, arg2))
to:
    await cb.execute(lambda: my_async_fn(arg1, arg2))

closes #1379

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Updated `CircuitBreakerAsync` execute method to accept a coroutine factory function instead of a coroutine instance
  * Enhanced coroutine lifecycle management and resource handling
  * Improved error handling with proper exception cleanup and logging

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1383?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->