### PR TITLE
fix(marketplace): replace datetime.utcnow() with datetime.now(timezone.utc)

### DIFF
--- a/backend/routers/marketplace.py
+++ b/backend/routers/marketplace.py
@@ -23,7 +23,7 @@ Authentication
 import logging
 import threading
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -78,7 +78,7 @@ def _seed_listings() -> None:
                 "ownerUid": None,   # seed listings have no registered owner
                 "available": item["available"],
                 "rating": 4.5,
-                "createdAt": datetime.utcnow().isoformat() + "Z",
+                "createdAt": datetime.now(timezone.utc).isoformat(),
             }
 
 _seed_listings()
@@ -179,7 +179,7 @@ async def list_equipment(request: Request, data: ListEquipmentRequest):
         "ownerUid": uid,
         "available": True,
         "rating": 5.0,
-        "createdAt": datetime.utcnow().isoformat() + "Z",
+        "createdAt": datetime.now(timezone.utc).isoformat(),
     }
 
     with _lock:
@@ -238,7 +238,7 @@ async def book_equipment(request: Request, data: BookEquipmentRequest):
             "priceUnit": listing["priceUnit"],
             "totalCost": listing["price"] * data.duration,
             "status": "pending",   # pending → confirmed → completed / cancelled
-            "createdAt": datetime.utcnow().isoformat() + "Z",
+            "createdAt": datetime.now(timezone.utc).isoformat(),
         }
 
         _bookings[bid] = booking


### PR DESCRIPTION
fixes #1378

datetime.utcnow() returns a naive datetime object with no tzinfo attached. Appending the literal string 'Z' does not make it timezone-aware in Python — it is just a string suffix. Any code that later parses these timestamps with datetime.fromisoformat() (Python 3.10 and earlier) gets a naive datetime back, and comparisons with timezone-aware datetimes (e.g. from Firestore) raise:
  TypeError: can't compare offset-naive and offset-aware datetimes

Three call sites fixed:
  - _seed_listings()     — seed listing createdAt
  - list_equipment()     — new listing createdAt
  - book_equipment()     — new booking createdAt

All replaced with datetime.now(timezone.utc).isoformat(), which produces a timezone-aware datetime and an ISO 8601 string with explicit UTC offset (+00:00) that is unambiguous to all parsers. The 'timezone' name is now imported alongside 'datetime' in the from-import at the top of the file.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timestamp handling for marketplace listings and bookings to use standardized timezone-aware date formatting, ensuring consistent and accurate timestamp representation across the platform.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1389?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->