### PR TITLE
fix(finance): eliminate duplicate marketplace endpoint body (#1375)

### DIFF
--- a/backend/routers/finance.py
+++ b/backend/routers/finance.py
@@ -166,8 +166,11 @@ def get_finance_products():
         raise HTTPException(status_code=500, detail="Not initialized")
     return {"success": True, "data": farm_finance_ai.list_marketplace()}
 
+
+# /marketplace is kept as an alias for /products so existing frontend
+# integrations that call either path continue to work without changes.
+# Both routes delegate to the same handler — there is a single code path
+# and a single place to update if the response shape ever changes.
 @router.get("/marketplace")
 def get_finance_marketplace():
-    if farm_finance_ai is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
-    return {"success": True, "data": farm_finance_ai.list_marketplace()}
+    return get_finance_products()


### PR DESCRIPTION
GET /products and GET /marketplace were two separate handlers with identical bodies — both called farm_finance_ai.list_marketplace() and returned the same payload. This meant:

- Any future change to the response shape had to be applied in two places.
- The API surface was misleadingly wide, implying the two paths might diverge in behaviour.
- The router was registered twice in main.py (/api/farm-finance and /api/finance legacy), producing four distinct URLs for the same data.

Fix: make /marketplace delegate to get_finance_products() so there is a single code path and a single place to update. The /marketplace path is kept as an alias (not removed) to avoid breaking existing frontend integrations that may call either URL.

closes #1375
<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified the marketplace endpoint to share the same handler as the products endpoint for improved consistency and maintainability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1392?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->