### PR TITLE
fix(feedback): remove unreachable return statement after early return in try block

### DIFF
--- a/feedback_api.py
+++ b/feedback_api.py
@@ -323,31 +323,24 @@ async def submit_feedback(
         try:
             doc_ref = db.collection("feedback").add(validated_data)
             feedback_id = doc_ref[1].id
-            
-            logger.info(f"Feedback stored successfully. ID: {feedback_id}")
-            
+
+            logger.info("Feedback stored successfully. ID: %s", feedback_id)
+
+            # PII fields (ipAddress, userAgent) are stored server-side for
+            # audit purposes but must not be echoed back in the response.
             return FeedbackResponse(
                 success=True,
                 feedback_id=feedback_id,
                 message="Feedback submitted successfully",
-                timestamp=datetime.now(timezone.utc).isoformat()
+                timestamp=datetime.now(timezone.utc).isoformat(),
             )
-            
+
         except Exception as firestore_error:
             logger.error("Firestore error: %s", firestore_error)
             raise HTTPException(
                 status_code=500,
                 detail="Failed to store feedback. Please try again later.",
             )
-
-        # Return only non-PII fields — ipAddress and userAgent are stored
-        # server-side for audit purposes but must not be echoed back.
-        return FeedbackResponse(
-            success=True,
-            feedback_id=feedback_id,
-            message="Feedback submitted successfully",
-            timestamp=datetime.now(timezone.utc).isoformat(),
-        )
 
     except ValueError as ve:
         logger.warning("Validation error: %s", ve)


### PR DESCRIPTION
closes #1374

submit_feedback contained two return FeedbackResponse(...) statements inside the same try block. The first one fired immediately after a successful Firestore write and returned the response. The second one, placed after the inner try/except block with a comment saying 'Return only non-PII fields', could never execute because the first return had already exited the function.

This was a maintenance hazard: the comment on the dead return implied it was the intended canonical response, but the live return above it fired instead. Any future developer editing the first return might not notice the second one, leading to divergent response shapes or confusion about which return is authoritative.

Fix: remove the dead second return. The PII-exclusion comment is moved to the surviving return to preserve the documentation intent. Also convert the f-string logger call to a %-style call to match the rest of the file.


