### PR TITLE
fix(celery): add missing joblib import to celery_worker.py (#1371)

### DIFF
--- a/celery_worker.py
+++ b/celery_worker.py
@@ -1,4 +1,5 @@
 import os
+import joblib
 from ml.security import verify_and_load_joblib
 import numpy as np
 from celery import Celery


### PR DESCRIPTION
_get_lag_model() and _get_trend_model() both call joblib.load() but joblib was never imported at the module level. The only related import was 'from ml.security import verify_and_load_joblib', which is a different function. When either lazy-load function was invoked for the first time in a Celery worker process, Python raised:

  NameError: name 'joblib' is not defined

causing the predict_yield_lag_task and predict_yield_trend_task Celery tasks to fail with a cryptic error instead of a clear model-loading failure. Add 'import joblib' to the module-level imports.

closes #1371