### PR TITLE
fix(ml): add missing re import to ml.py router

### DIFF
--- a/backend/routers/ml.py
+++ b/backend/routers/ml.py
@@ -1,5 +1,6 @@
 """ML Prediction Router - Yield prediction endpoints"""
 import os
+import re
 import logging
 import threading
 from fastapi import APIRouter, Request, HTTPException


### PR DESCRIPTION
predict_yield() sanitises the X-User-Location header with:
  re.sub(r'[^\w\s,.-]', '', raw_location)
but re was never imported. Every authenticated POST to /api/yield raised NameError: name 're' is not defined, crashing the request with a 500 instead of returning a prediction.


closes #1372
