### PR TITLE
fix(alerts): add missing logging import and logger definition to alerts.py

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -1,6 +1,7 @@
 """Alerts & Notifications Router"""
 from datetime import datetime
 from typing import Any, Optional
+import logging
 
 from fastapi import APIRouter, Form, HTTPException, Query, Request
 from twilio_webhook_security import handle_inbound_whatsapp_webhook
@@ -9,6 +10,7 @@ from geo_alerts import notification_matches_regions, profile_can_broadcast_regio
 from backend.schemas import AlertTriggerRequest
 
 router = APIRouter()
+logger = logging.getLogger(__name__)
 
 
 notification_store = None


### PR DESCRIPTION

subscribe_whatsapp() and trigger_whatsapp_alert() both call logger.error(...) in their exception handlers, but logging was never imported and logger was never defined. When either exception branch was hit, Python raised NameError: name 'logger' is not defined, masking the original exception and producing a confusing 500 response with no useful log output.
closes #1373