### PR TITLE
fix(lms): serialise cert cooldown check-then-update with asyncio.Lock

### DIFF
--- a/backend/routers/lms.py
+++ b/backend/routers/lms.py
@@ -7,6 +7,7 @@ Certificates are only issued when the server confirms 100% completion from
 Firestore. localStorage is used only as a UI cache; it is never trusted for
 authorization decisions.
 """
+import asyncio
 import hashlib
 import logging
 import time
@@ -35,6 +36,12 @@ _CERT_COOLDOWN_MAX_ENTRIES = 10_000
 # the most-recently-used entries at the tail; popitem(last=False) evicts
 # the least-recently-used entry from the head when the cap is reached.
 _last_cert_request: OrderedDict[Tuple[str, str], float] = OrderedDict()
+
+# Asyncio lock that serialises all reads and writes to _last_cert_request.
+# Without this lock, two concurrent requests for the same (uid, course_id)
+# can both pass the cooldown check before either one records a timestamp,
+# allowing the cooldown to be bypassed under load.
+_cert_cooldown_lock: asyncio.Lock = asyncio.Lock()
 
 # ---------------------------------------------------------------------------
 # Injected dependencies (wired in main.py lifespan via init_lms)
@@ -234,20 +241,24 @@ async def get_certificate_data(request: Request, course_id: str):
     uid = token_data.get("uid")
 
     # Per-user per-course cooldown to prevent Firestore cost abuse.
+    # The entire check-then-update block is serialised with an asyncio lock
+    # to prevent a TOCTOU race where two concurrent requests both pass the
+    # cooldown check before either one records its timestamp.
     key = (uid, course_id)
-    now = time.time()
-    last = _last_cert_request.get(key)
-    if last is not None and (now - last) < _CERT_COOLDOWN_SECONDS:
-        raise HTTPException(
-            status_code=429,
-            detail=f"Certificate already requested recently. Please wait {_CERT_COOLDOWN_SECONDS} seconds.",
-        )
-    # Evict the LRU entry before inserting when the cap is reached, then
-    # record the current timestamp and move the key to the MRU position.
-    if key not in _last_cert_request and len(_last_cert_request) >= _CERT_COOLDOWN_MAX_ENTRIES:
-        _last_cert_request.popitem(last=False)
-    _last_cert_request[key] = now
-    _last_cert_request.move_to_end(key)
+    async with _cert_cooldown_lock:
+        now = time.time()
+        last = _last_cert_request.get(key)
+        if last is not None and (now - last) < _CERT_COOLDOWN_SECONDS:
+            raise HTTPException(
+                status_code=429,
+                detail=f"Certificate already requested recently. Please wait {_CERT_COOLDOWN_SECONDS} seconds.",
+            )
+        # Evict the LRU entry before inserting when the cap is reached, then
+        # record the current timestamp and move the key to the MRU position.
+        if key not in _last_cert_request and len(_last_cert_request) >= _CERT_COOLDOWN_MAX_ENTRIES:
+            _last_cert_request.popitem(last=False)
+        _last_cert_request[key] = now
+        _last_cert_request.move_to_end(key)
 
     progress = _get_progress(uid, course_id)
     if not _is_complete(progress, course_id):


### PR DESCRIPTION
## Description

The certificate cooldown in `lms.py` used a check-then-update pattern on the module-level `_last_cert_request` `OrderedDict` without any synchronisation. Under concurrent load, two requests for the same `(uid, course_id)` could both pass the cooldown check before either one recorded a timestamp, allowing the 60-second limit to be bypassed.

The fix introduces `_cert_cooldown_lock` (an `asyncio.Lock`) and wraps the entire read-check-write block with `async with _cert_cooldown_lock`. Only one coroutine at a time can inspect and update the cooldown store, eliminating the race.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1385

## Testing Done

- [x] Tested locally
- [x] Verified API / backend changes (if applicable)

Confirmed that the lock serialises concurrent certificate requests: a second request for the same user and course issued within the cooldown window now consistently receives 429, even when both requests arrive simultaneously.

## Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken
