### PR TITLE
fix(pii): replace real phone number in whatsapp_subscribers.json with empty store

### DIFF
--- a/whatsapp_subscribers.json
+++ b/whatsapp_subscribers.json
@@ -1,1 +1,1 @@
-{"user_Farmer": {"phone_number": "+91 7020504675", "name": "Farmer", "subscribed_at": "2026-04-29T18:23:21.698935"}}
+{}


### PR DESCRIPTION
## Description

`whatsapp_subscribers.json` contained a real Indian mobile number committed directly to the public repository. Although the file is listed in `.gitignore`, it was added to version control before that entry was written, so git continued tracking it and the data remained publicly visible.

This PR replaces the file content with an empty JSON object (`{}`), removing the exposed PII from the working tree and all future builds.

**Note:** the phone number is still visible in git history and must be purged separately using BFG Repo Cleaner or `git filter-repo` once this PR is merged.

## Type of Change

- [x] Bug fix

## Related Issue

Closes #1388

## Testing Done

- [x] Tested locally
- [x] Verified API / backend changes (if applicable)

Confirmed the WhatsApp subscriber module handles an empty store without errors (no active subscribers, zero notifications sent).

## Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

## Additional Notes

To fully remove the PII from git history, the maintainer should run:
```
bfg --delete-files whatsapp_subscribers.json
git reflog expire --expire=now --all
git gc --prune=now --aggressive
git push --force
```
