### PR TITLE
fix(quality): decode batch images one at a time to reduce peak memory

### DIFF
--- a/backend/routers/quality.py
+++ b/backend/routers/quality.py
@@ -86,22 +86,50 @@ async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
         raise HTTPException(status_code=403, detail=str(e))
     try:
         import base64
-        image_bytes_list = []
+        from datetime import datetime
+
+        # Decode and assess one image at a time so peak in-process memory is
+        # O(single image) rather than O(total batch size).
+        #
+        # The previous implementation decoded all images into image_bytes_list
+        # before calling batch_grade_crops, holding up to ~37.5 MB of raw
+        # bytes simultaneously (50 MB base64 cap × ~0.75 decode ratio).
+        # Under concurrent load this multiplied across requests.
+        #
+        # batch_grade_crops itself iterates images sequentially, so passing
+        # a pre-built list provided no parallelism benefit — only memory cost.
+        # We replicate its per-image logic here and discard each decoded bytes
+        # object immediately after assessment, keeping only the result dict.
+        assessments = []
         for idx, img in enumerate(data.images_base64):
             try:
-                image_bytes_list.append(base64.b64decode(img))
+                image_bytes = base64.b64decode(img)
             except Exception as decode_err:
-                logger.error(f"Batch decode error at index {idx}: {decode_err}")
+                logger.error("Batch decode error at index %d: %s", idx, decode_err)
                 raise HTTPException(
                     status_code=400,
                     detail=f"Invalid base64 encoding at image index {idx}",
                 )
-        results = crop_quality_grader.batch_grade_crops(image_bytes_list, data.crop_type)
-        return {"success": True, "crop_type": data.crop_type, "batch_results": results}
+            try:
+                assessment = crop_quality_grader.assess_crop_image(image_bytes, data.crop_type)
+                from dataclasses import asdict
+                assessments.append(asdict(assessment) if hasattr(assessment, '__dataclass_fields__') else assessment)
+            except Exception as assess_err:
+                assessments.append({
+                    "error": str(assess_err),
+                    "index": idx,
+                    "timestamp": datetime.now().isoformat(),
+                })
+            finally:
+                # Explicitly release the decoded bytes for this image before
+                # moving to the next one.
+                del image_bytes
+
+        return {"success": True, "crop_type": data.crop_type, "batch_results": assessments}
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Batch error: {e}")
+        logger.error("Batch error: %s", e)
         raise HTTPException(status_code=400, detail=str(e))
 
 @router.post("/trends")


### PR DESCRIPTION
fixes #1428

assess_batch_crops previously decoded all images into image_bytes_list before calling batch_grade_crops, holding the entire decoded batch in memory simultaneously:

  50 MB base64 cap x ~0.75 decode ratio = ~37.5 MB raw bytes per request

Under concurrent load (e.g. 10 simultaneous batch requests) this multiplied to ~375 MB of image data held in memory at once, before the grader even started processing.

batch_grade_crops itself iterates images sequentially inside a for loop, so passing a pre-built list provided no parallelism benefit — only the memory cost of materialising the entire decoded batch upfront.

Fix: decode and assess one image at a time in the router, collecting only the result dict (a few hundred bytes) before moving to the next image. The decoded bytes object is explicitly deleted in a finally block after each assessment so the GC can reclaim it immediately. Peak memory per request is now O(single image) instead of O(total batch size).
