### PR TITLE
fix(lms): validate uid after token extraction and use monotonic clock for cooldown

### DIFF
--- a/backend/routers/lms.py
+++ b/backend/routers/lms.py
@@ -152,6 +152,8 @@ async def complete_lesson(request: Request, body: CompleteLessonRequest):
 
     token_data = await _verify_role_fn(request)
     uid = token_data.get("uid")
+    if not uid:
+        raise HTTPException(status_code=401, detail="User identity missing from authentication token")
 
     lesson_id = body.lesson_id
     course_id = _LESSON_TO_COURSE.get(lesson_id)
@@ -197,6 +199,8 @@ async def get_progress(request: Request):
 
     token_data = await _verify_role_fn(request)
     uid = token_data.get("uid")
+    if not uid:
+        raise HTTPException(status_code=401, detail="User identity missing from authentication token")
 
     result = {}
     for course_id in COURSES:
@@ -239,14 +243,20 @@ async def get_certificate_data(request: Request, course_id: str):
 
     token_data = await _verify_role_fn(request)
     uid = token_data.get("uid")
+    if not uid:
+        raise HTTPException(status_code=401, detail="User identity missing from authentication token")
 
     # Per-user per-course cooldown to prevent Firestore cost abuse.
     # The entire check-then-update block is serialised with an asyncio lock
     # to prevent a TOCTOU race where two concurrent requests both pass the
     # cooldown check before either one records its timestamp.
+    # time.monotonic() is used instead of time.time() because monotonic
+    # time never runs backwards. A backward NTP jump on time.time() would
+    # reset (now - last) to a large positive number, clearing the cooldown
+    # and allowing repeated Firestore reads until the clock catches up again.
     key = (uid, course_id)
     async with _cert_cooldown_lock:
-        now = time.time()
+        now = time.monotonic()
         last = _last_cert_request.get(key)
         if last is not None and (now - last) < _CERT_COOLDOWN_SECONDS:
             raise HTTPException(


### PR DESCRIPTION
## Related Issue

closes #1387

## Overview

Two bugs in `backend/routers/lms.py` found during review of the file, following the LRU-eviction fix already in `main`:

1. Missing `uid` validation in all three endpoints
2. `time.time()` used for an elapsed-time comparison that requires a monotonic source

---

## Bug 1: Missing `uid` validation

### Root cause

All three handlers extract the user identity with:

```python
token_data = await _verify_role_fn(request)
uid = token_data.get("uid")
```

`dict.get()` returns `None` when the key is absent. No code path checks whether `uid` is actually set before using it.

### Impact

When a token is missing the `uid` claim (malformed token, wrong auth provider, or a partial decode that still returns a dict):

| Downstream effect | Symptom |
|---|---|
| `_db.collection("users").document(None)` | Invalid Firestore path; 500 with a confusing SDK error instead of a clear 401 |
| `(None, course_id)` inserted into cooldown store | Poisons the cache with a sentinel key that can never be a real user |
| `_make_cert_id(None, course_id)` | Certificate ID derived from `"None:course_id"` rather than a real identity |

### Fix

Added `if not uid: raise HTTPException(status_code=401, ...)` immediately after each `.get("uid")` call in `complete_lesson`, `get_progress`, and `get_certificate_data`.

---

## Bug 2: `time.time()` used for elapsed interval measurement

### Root cause

```python
now = time.time()
last = _last_cert_request.get(key)
if last is not None and (now - last) < _CERT_COOLDOWN_SECONDS:
    ...
```

`time.time()` returns wall-clock time, which is not guaranteed to be monotonically increasing.

### Impact

A backward clock jump (NTP correction, VM migration, leap second smearing) makes `now - last` artificially large. If the result exceeds `_CERT_COOLDOWN_SECONDS`, the cooldown guard is silently bypassed, allowing unlimited Firestore reads until the clock catches up again.

### Fix

Replaced `time.time()` with `time.monotonic()`. Monotonic time is guaranteed to never run backwards on the same process instance. Since the stored timestamps and the comparison are both monotonic, the semantics are identical for measuring elapsed durations within a single process lifetime.

---

## Changed file

`backend/routers/lms.py` (+11 lines, -1 line)

| Change | Location |
|---|---|
| `if not uid` guard | `complete_lesson` (line ~148) |
| `if not uid` guard | `get_progress` (line ~194) |
| `if not uid` guard + monotonic comment | `get_certificate_data` (line ~238) |
| `time.time()` replaced with `time.monotonic()` | `get_certificate_data` cooldown block |

## Test plan

- [ ] Request with a token missing the `uid` claim returns 401 on all three endpoints
- [ ] Valid authenticated request to each endpoint continues to work correctly
- [ ] Certificate cooldown still rejects a second request within 60 seconds
- [ ] Clock adjustments do not disable the cooldown

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added authentication validation to lesson completion, progress retrieval, and certificate endpoints
  * Improved certificate issuance cooldown logic for more reliable timing behavior

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1440?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->