### PR TITLE
fix(finance): move _IDOR_GUARD sentinel to module level to prevent bypass

### DIFF
--- a/farm_finance_ai.py
+++ b/farm_finance_ai.py
@@ -8,6 +8,17 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+# Sentinel used by FarmFinanceAI.get_application() to distinguish between
+# "caller explicitly passed None (admin bypass)" and "caller omitted the
+# argument (deny by default)".
+#
+# Defined at module level rather than as a class attribute so that:
+# 1. It cannot be read via FarmFinanceAI._IDOR_GUARD and passed back to
+#    bypass the ownership check.
+# 2. It is created exactly once for the lifetime of the module, regardless
+#    of how many FarmFinanceAI instances are created or destroyed.
+_OWNER_UID_NOT_PROVIDED = object()
+
 
 @dataclass(frozen=True)
 class LoanProduct:
@@ -287,9 +298,7 @@ class FarmFinanceAI:
             "estimated_emi": analysis["estimated_emi"],
         }
 
-    _IDOR_GUARD = object()
-
-    def get_application(self, application_id: str, owner_uid: Any = _IDOR_GUARD) -> Optional[Dict[str, Any]]:
+    def get_application(self, application_id: str, owner_uid: Any = _OWNER_UID_NOT_PROVIDED) -> Optional[Dict[str, Any]]:
         """
         Retrieve a finance application by ID.
 
@@ -304,7 +313,7 @@ class FarmFinanceAI:
             Pass None to bypass the ownership check (admins / experts).
             When omitted, access is denied by default.
         """
-        if owner_uid is self._IDOR_GUARD:
+        if owner_uid is _OWNER_UID_NOT_PROVIDED:
             return None
         # Try repository first
         if self.repository:


### PR DESCRIPTION
closes #1417 

_IDOR_GUARD was defined as a class attribute on FarmFinanceAI:

  _IDOR_GUARD = object()

This had two problems:

1. Public accessibility — any code that imports FarmFinanceAI can read FarmFinanceAI._IDOR_GUARD and pass it directly to get_application(), bypassing the ownership check entirely: ai.get_application(id, owner_uid=FarmFinanceAI._IDOR_GUARD) This would return the application without any ownership enforcement, defeating the IDOR protection the sentinel was designed to provide.

2. Multiple sentinel objects — object() is evaluated once at class definition time, but if the class were ever subclassed or the sentinel re-assigned (e.g. in tests via monkeypatching), the identity check 'owner_uid is self._IDOR_GUARD' could silently fail, causing the method to fall through to the ownership check with an unexpected value.

Fix: move the sentinel to module level as _OWNER_UID_NOT_PROVIDED with a leading underscore, making it a private module constant. It is:
- Created exactly once for the lifetime of the module.
- Not accessible via the class public API.
- Referenced directly by name in the default argument and the identity check, with no indirection through self or the class.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal authorization handling to improve clarity between explicit and default access control behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1441?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->