### PR TITLE
fix(marketplace): derive stable seed listing IDs from content hash 

### DIFF
--- a/backend/routers/marketplace.py
+++ b/backend/routers/marketplace.py
@@ -20,6 +20,7 @@ Authentication
 - POST /marketplace/bookings  — requires auth (farmer must be logged in)
 - GET  /marketplace/bookings  — requires auth (returns caller's bookings)
 """
+import hashlib
 import logging
 import threading
 import uuid
@@ -61,12 +62,30 @@ _SEED_LISTINGS = [
     {"name": "Massey Ferguson 9500",          "type": "Tractor",   "price": 950,  "priceUnit": "hr",  "location": "Patna, Bihar",           "owner": "Manoj Singh",         "available": False},
 ]
 
+def _stable_seed_id(item: dict) -> str:
+    """Derive a deterministic listing ID from the seed item's content.
+
+    Using uuid.uuid4() produced a different ID on every process start,
+    so each Uvicorn worker seeded the same 16 logical listings with
+    different UUIDs.  A client that bookmarked a listing ID from worker A
+    would get a 404 from worker B.
+
+    The ID is derived from the item name (unique across seed data) via
+    SHA-256 so every worker always produces the same stable ID for the
+    same logical listing, regardless of restart order or worker count.
+    """
+    digest = hashlib.sha256(item["name"].encode("utf-8")).hexdigest()
+    # Format as a UUID-shaped string so it is indistinguishable from
+    # user-created listing IDs in API responses.
+    return f"{digest[:8]}-{digest[8:12]}-{digest[12:16]}-{digest[16:20]}-{digest[20:32]}"
+
+
 def _seed_listings() -> None:
     with _lock:
         if _listings:
             return
         for item in _SEED_LISTINGS:
-            lid = str(uuid.uuid4())
+            lid = _stable_seed_id(item)
             _listings[lid] = {
                 "id": lid,
                 "name": item["name"],


### PR DESCRIPTION
closes #1421

_seed_listings() previously called str(uuid.uuid4()) for every seed listing's id field on each process start. The guard 'if _listings: return' prevented double-seeding within a single process, but in a multi-worker deployment each Uvicorn worker starts with an empty _listings dict and seeds independently, producing 16 different UUIDs per worker for the same 16 logical equipment items.

A client that bookmarked a listing ID from worker A would receive a 404 from worker B. Bookings created against a listing ID on one worker would be invisible on another worker that seeded the same item with a different ID.

Fix: replace uuid.uuid4() with _stable_seed_id(), which derives the listing ID deterministically from the item name via SHA-256 and formats the digest as a UUID-shaped string. Every worker always produces the same stable ID for the same logical listing, regardless of restart order or worker count. User-created listing IDs continue to use uuid.uuid4() and are unaffected.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed marketplace listing IDs that were inconsistent across different server processes. Seeded marketplace items now maintain stable and predictable identifiers, ensuring users always see consistent listing references and can reliably reference specific items within the marketplace.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1476?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->