### PR TITLE
fix(ml): prevent internal exception strings from leaking in prediction endpoints

### DIFF
--- a/backend/routers/ml.py
+++ b/backend/routers/ml.py
@@ -64,8 +64,11 @@ async def predict_yield(data: PredictRequest, request: Request):
         context = {"location": sanitised_location, "crop": data.Crop}
         predicted_yield = model_router.predict(input_data, context)
         return {"predicted_ExpYield": float(predicted_yield)}
-    except Exception as e:
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("predict_yield error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during prediction.")
 
 @router.post("/predict-yield-lag")
 async def predict_yield_lag(payload: YieldInput, request: Request):
@@ -81,8 +84,11 @@ async def predict_yield_lag(payload: YieldInput, request: Request):
             raise ValueError("Exactly 5 values required")
         prediction = model_lag.predict(data)
         return {"prediction": round(float(prediction[0]), 2), "model": "RandomForest Time Series"}
-    except Exception as e:
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("predict_yield_lag error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during prediction.")
 
 @router.post("/predict-yield-trend")
 async def predict_yield_trend(payload: YieldInput, request: Request):
@@ -128,5 +134,8 @@ async def predict_yield_trend(payload: YieldInput, request: Request):
             temp = temp[1:] + [pred_value]
 
         return {"trend": trend, "prediction": trend[-1], "model": "Dedicated Trend Forecast"}
-    except Exception as e:
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("predict_yield_trend error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during prediction.")


### PR DESCRIPTION
## 📝 Description

`predict_yield`, `predict_yield_lag`, and `predict_yield_trend` in `backend/routers/ml.py` all used a broad `except Exception as e: raise HTTPException(status_code=400, detail=str(e))` block. This forwarded raw Python exception messages — including library names, internal model paths, and stack context — directly to HTTP clients, aiding server fingerprinting.

## 🎯 Type of Change

- [x] 🐞 Bug fix

## 🔗 Related Issue

Closes #1506

## Changes Made

- `backend/routers/ml.py`: in all three prediction endpoints, split the broad exception handler into two cases:
  - `except ValueError as e` returns 400 with the error message (these are correctable input errors like "Exactly 5 values required").
  - `except Exception as e` logs the error server-side and returns a generic 500 with a fixed message that reveals no internal detail.

## 📸 Screenshots or Demo

Not applicable.

## 🧪 Testing Done

1. Submit an invalid payload to `/api/ml` that triggers a `ValueError` inside the model. Confirm the error message is returned to the client as a 400.
2. Simulate an unexpected model error. Confirm the client receives a generic 500 message and the error is visible only in server logs.

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!