### PR TITLE
fix(quality): prevent internal exception strings from leaking in quality endpoints

### DIFF
--- a/backend/routers/quality.py
+++ b/backend/routers/quality.py
@@ -69,9 +69,11 @@ async def assess_single_crop(request: Request, data: CropQualityGradingRequest):
         image_bytes = base64.b64decode(data.image_base64)
         result = crop_quality_grader.assess_crop_image(image_bytes, data.crop_type)
         return {"success": True, "crop_type": data.crop_type, "assessment": result}
-    except Exception as e:
-        logger.error(f"Assessment error: {e}")
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("assess_single_crop error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during quality assessment.")
 
 @router.post("/assess-batch")
 async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
@@ -128,9 +130,11 @@ async def assess_batch_crops(request: Request, data: CropQualityBatchRequest):
         return {"success": True, "crop_type": data.crop_type, "batch_results": assessments}
     except HTTPException:
         raise
-    except Exception as e:
-        logger.error("Batch error: %s", e)
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("assess_batch_crops error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred during batch assessment.")
 
 @router.post("/trends")
 async def get_quality_trends(request: Request, data: QualityTrendsRequest):
@@ -146,9 +150,11 @@ async def get_quality_trends(request: Request, data: QualityTrendsRequest):
     try:
         trends = crop_quality_grader.get_quality_trends(data.crop_type, data.days)
         return {"success": True, "crop_type": data.crop_type, "days": data.days, "trends": trends}
-    except Exception as e:
-        logger.error(f"Trends error: {e}")
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("get_quality_trends error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred fetching quality trends.")
 
 @router.get("/supported-crops")
 async def get_supported_crops(request: Request):
@@ -180,6 +186,8 @@ async def calculate_market_price(request: Request, data: CropQualityGradingReque
         image_bytes = base64.b64decode(data.image_base64)
         assessment = crop_quality_grader.assess_crop_image(image_bytes, data.crop_type)
         return {"success": True, "crop_type": data.crop_type, "grade": getattr(assessment, 'grade', 'A'), "assessment": assessment}
-    except Exception as e:
-        logger.error(f"Price error: {e}")
+    except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
+    except Exception as e:
+        logger.error("calculate_market_price error: %s", e)
+        raise HTTPException(status_code=500, detail="An unexpected error occurred calculating market price.")


### PR DESCRIPTION
## 📝 Description

`assess_single_crop`, `assess_batch_crops`, `get_quality_trends`, and `calculate_market_price` in `backend/routers/quality.py` all used `except Exception as e: raise HTTPException(status_code=400, detail=str(e))`. This forwarded raw Python exception messages (model internals, library names, file paths) directly to HTTP clients.

## 🎯 Type of Change

- [x] 🐞 Bug fix

## 🔗 Related Issue

Closes #1507

## Changes Made

- `backend/routers/quality.py`: in all four endpoints, split the broad exception handler into:
  - `except ValueError as e` returns 400 with the error string (correctable input errors).
  - `except Exception as e` logs the full error server-side via `logger.error` and returns a generic 500 with a fixed message that reveals no internal detail.

## 📸 Screenshots or Demo

Not applicable.

## 🧪 Testing Done

1. Submit an invalid base64 image. Confirm the specific error is returned as 400.
2. Simulate an unexpected grader error. Confirm the client sees a generic 500 while the details appear only in server logs.

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!