### PR TITLE
fix(ml): cap YieldInput.data list length to prevent memory exhaustion

### DIFF
--- a/backend/routers/ml.py
+++ b/backend/routers/ml.py
@@ -26,7 +26,12 @@ class PredictResponse(BaseModel):
     predicted_ExpYield: float
 
 class YieldInput(BaseModel):
-    data: list[float]
+    # Cap the list length to prevent a single request from allocating an
+    # arbitrarily large numpy array. predict_yield_lag expects exactly 5
+    # values; predict_yield_trend uses 5 values internally. 1000 items is
+    # several orders of magnitude above any legitimate use case and keeps
+    # peak memory bounded at roughly 8 kB (1000 float64 values).
+    data: list[float] = Field(..., min_items=1, max_items=1000)
 
 model_router = None
 model_lag = None


### PR DESCRIPTION
## 📝 Description

`YieldInput.data` was declared as `list[float]` with no upper bound. An authenticated caller could submit a list of millions of floats, causing `numpy` to allocate an arbitrarily large array in `predict_yield_lag` and `predict_yield_trend`. A single such request could exhaust available server memory and crash the process.

## 🎯 Type of Change

- [x] 🐞 Bug fix

## 🔗 Related Issue

Closes #1505

## Changes Made

- `backend/routers/ml.py`: changed `YieldInput.data` from `list[float]` to `list[float] = Field(..., min_items=1, max_items=1000)`. 1000 items is orders of magnitude above any legitimate use case (both endpoints use exactly 5 values internally), caps peak numpy allocation at approximately 8 kB, and rejects oversized payloads at the Pydantic validation layer before any array allocation occurs.

## 📸 Screenshots or Demo

Not applicable.

## 🧪 Testing Done

1. Submit `POST /api/ml/predict-yield-lag` with a list of 10,000 floats. Confirm Pydantic returns a 422 validation error before the endpoint is reached.
2. Submit with exactly 5 floats. Confirm the prediction succeeds as expected.
3. Submit with 0 items. Confirm 422 error (min_items=1).

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

Could you please add the appropriate NSoC'26 label to this PR? It helps with tracking and scoring under NSoC 2026. Thank you!