### PR TITLE
Bug — backend/routers/knowledge.py uses global uninitialized state

### DIFF
--- a/backend/routers/knowledge.py
+++ b/backend/routers/knowledge.py
@@ -1,6 +1,6 @@
 """Knowledge Base Router - RAG, Climate Simulation, Seeds"""
 from typing import Optional
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel, Field, validator
 import logging
 
@@ -62,6 +62,30 @@ rbac_manager = None
 Permission = None
 seed_registry = None
 verify_role_fn = None
+
+
+def _require_verify_role_fn():
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+    return verify_role_fn
+
+
+def _require_rag_runtime():
+    verify_fn = _require_verify_role_fn()
+    if rag_generate_fn is None:
+        raise HTTPException(status_code=503, detail="RAG not available")
+    return rag_generate_fn, verify_fn
+
+
+def _require_simulation_runtime():
+    return _require_verify_role_fn()
+
+
+def _require_seed_runtime():
+    verify_fn = _require_verify_role_fn()
+    if seed_registry is None:
+        raise HTTPException(status_code=503, detail="Seed registry not initialized")
+    return verify_fn, seed_registry
 
 
 def init_knowledge(rg_fn, rbac, perm, sr, vr_fn):
@@ -295,19 +319,16 @@ def _build_recommendations(
 # ---------------------------------------------------------------------------
 
 @router.post("/rag/query")
-async def rag_query(request: Request, body: RAGQuery):
+async def rag_query(request: Request, body: RAGQuery, runtime=Depends(_require_rag_runtime)):
     """Query the AI knowledge base (RAG).
 
     Authentication is required to prevent unauthenticated callers from
     consuming Gemini API quota on the project's billing account and to
     enable per-user rate limiting in the future.
     """
-    if rag_generate_fn is None:
-        raise HTTPException(status_code=503, detail="RAG not available")
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
+    rag_fn, verify_fn = runtime
     # Raises HTTP 401 if the Firebase token is missing or invalid.
-    token_data = await verify_role_fn(request)
+    token_data = await verify_fn(request)
     rate_limited = enforce_compute_rate_limit(
         request,
         scope="knowledge.rag_query",
@@ -318,7 +339,7 @@ async def rag_query(request: Request, body: RAGQuery):
     if rate_limited is not None:
         return rate_limited
     try:
-        result = rag_generate_fn(body.query, body.top_k)
+        result = rag_fn(body.query, body.top_k)
         return {"success": True, "query": body.query, "results": result}
     except HTTPException:
         raise
@@ -328,16 +349,14 @@ async def rag_query(request: Request, body: RAGQuery):
 
 
 @router.post("/simulate-climate")
-async def simulate_climate(request: Request, data: SimulationRequest):
+async def simulate_climate(request: Request, data: SimulationRequest, verify_fn=Depends(_require_simulation_runtime)):
     """Run a climate impact simulation for a given crop.
 
     Authentication is required so that the endpoint is not freely
     accessible to scrapers and bots under the global rate limit.
     """
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
     # Raises HTTP 401 if the Firebase token is missing or invalid.
-    token_data = await verify_role_fn(request)
+    token_data = await verify_fn(request)
     rate_limited = enforce_compute_rate_limit(
         request,
         scope="knowledge.simulate_climate",
@@ -407,13 +426,12 @@ async def simulate_climate(request: Request, data: SimulationRequest):
 
 
 @router.post("/seeds/verify")
-async def verify_seed(request: Request, data: SeedVerifyRequest):
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
+async def verify_seed(request: Request, data: SeedVerifyRequest, runtime=Depends(_require_seed_runtime)):
+    verify_fn, registry = runtime
     try:
-        await verify_role_fn(request)
-        is_verified = seed_registry.get(data.code, {}).get("verified", False) if seed_registry else False
-        seed_info = seed_registry.get(data.code, {}) if seed_registry else {}
+        await verify_fn(request)
+        is_verified = registry.get(data.code, {}).get("verified", False)
+        seed_info = registry.get(data.code, {})
         return {"success": True, "code": data.code, "verified": is_verified, "seed_info": seed_info}
     except HTTPException:
         raise

--- a/tests/test_knowledge_router_state.py
+++ b/tests/test_knowledge_router_state.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routers import knowledge
+
+
+def test_seed_verify_requires_initialized_seed_registry(monkeypatch):
+    app = FastAPI()
+    app.include_router(knowledge.router, prefix="/api/knowledge")
+
+    called = False
+
+    async def verify(_request):
+        nonlocal called
+        called = True
+        return {"uid": "farmer-1"}
+
+    monkeypatch.setattr(knowledge, "verify_role_fn", verify)
+    monkeypatch.setattr(knowledge, "seed_registry", None)
+    monkeypatch.setattr(knowledge, "rag_generate_fn", lambda query, top_k=3: ["result"])
+
+    client = TestClient(app)
+    response = client.post("/api/knowledge/seeds/verify", json={"code": "FS-RICE-2026-A1"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Seed registry not initialized"
+    assert called is False


### PR DESCRIPTION
I fixed the knowledge router so endpoint state is validated through FastAPI dependencies before handlers run. `rag/query`, `simulate-climate`, and especially `seeds/verify` now fail fast if the required globals were never initialized, and `/seeds/verify` no longer falls through to a partially initialized `seed_registry` path. The router change is in backend/routers/knowledge.py.

I also added a regression test covering the broken case in tests/test_knowledge_router_state.py. Validation passed with `pytest tests/test_knowledge_router_state.py`, and `get_errors` reported no issues in the touched files.

closes #1456

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced error handling for knowledge endpoints: API now returns appropriate error codes (500, 503) with descriptive messages when required services are unavailable, improving debugging and user experience.

* **Tests**
  * Added test coverage for seed verification endpoint initialization validation.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Eshajha19/agri/pull/1554?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->