### PR TITLE
Overblocking risk due to broad removal of special characters

### DIFF
--- a/backend/routers/knowledge.py
+++ b/backend/routers/knowledge.py
@@ -1,6 +1,7 @@
 """Knowledge Base Router - RAG, Climate Simulation, Seeds"""
 from typing import Optional
 from fastapi import APIRouter, Depends, Request, HTTPException
+from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field, validator
 import logging
 
@@ -86,6 +87,14 @@ def _require_seed_runtime():
     if seed_registry is None:
         raise HTTPException(status_code=503, detail="Seed registry not initialized")
     return verify_fn, seed_registry
+
+
+def _coerce_rate_limit_response(rate_limited):
+    if rate_limited is None:
+        return None
+    if isinstance(rate_limited, JSONResponse):
+        return rate_limited
+    return JSONResponse(status_code=429, content=rate_limited)
 
 
 def init_knowledge(rg_fn, rbac, perm, sr, vr_fn):
@@ -336,6 +345,7 @@ async def rag_query(request: Request, body: RAGQuery, runtime=Depends(_require_r
         limit=12,
         window_seconds=60,
     )
+    rate_limited = _coerce_rate_limit_response(rate_limited)
     if rate_limited is not None:
         return rate_limited
     try:
@@ -364,6 +374,7 @@ async def simulate_climate(request: Request, data: SimulationRequest, verify_fn=
         limit=10,
         window_seconds=60,
     )
+    rate_limited = _coerce_rate_limit_response(rate_limited)
     if rate_limited is not None:
         return rate_limited
     try:

--- a/backend/routers/knowledge.py
+++ b/backend/routers/knowledge.py
@@ -1,6 +1,6 @@
 """Knowledge Base Router - RAG, Climate Simulation, Seeds"""
 from typing import Optional
-from fastapi import APIRouter, Request, HTTPException
+from fastapi import APIRouter, Depends, Request, HTTPException
 from pydantic import BaseModel, Field, validator
 import logging
 
@@ -62,6 +62,30 @@ rbac_manager = None
 Permission = None
 seed_registry = None
 verify_role_fn = None
+
+
+def _require_verify_role_fn():
+    if verify_role_fn is None:
+        raise HTTPException(status_code=500, detail="Not initialized")
+    return verify_role_fn
+
+
+def _require_rag_runtime():
+    verify_fn = _require_verify_role_fn()
+    if rag_generate_fn is None:
+        raise HTTPException(status_code=503, detail="RAG not available")
+    return rag_generate_fn, verify_fn
+
+
+def _require_simulation_runtime():
+    return _require_verify_role_fn()
+
+
+def _require_seed_runtime():
+    verify_fn = _require_verify_role_fn()
+    if seed_registry is None:
+        raise HTTPException(status_code=503, detail="Seed registry not initialized")
+    return verify_fn, seed_registry
 
 
 def init_knowledge(rg_fn, rbac, perm, sr, vr_fn):
@@ -295,19 +319,16 @@ def _build_recommendations(
 # ---------------------------------------------------------------------------
 
 @router.post("/rag/query")
-async def rag_query(request: Request, body: RAGQuery):
+async def rag_query(request: Request, body: RAGQuery, runtime=Depends(_require_rag_runtime)):
     """Query the AI knowledge base (RAG).
 
     Authentication is required to prevent unauthenticated callers from
     consuming Gemini API quota on the project's billing account and to
     enable per-user rate limiting in the future.
     """
-    if rag_generate_fn is None:
-        raise HTTPException(status_code=503, detail="RAG not available")
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
+    rag_fn, verify_fn = runtime
     # Raises HTTP 401 if the Firebase token is missing or invalid.
-    token_data = await verify_role_fn(request)
+    token_data = await verify_fn(request)
     rate_limited = enforce_compute_rate_limit(
         request,
         scope="knowledge.rag_query",
@@ -318,7 +339,7 @@ async def rag_query(request: Request, body: RAGQuery):
     if rate_limited is not None:
         return rate_limited
     try:
-        result = rag_generate_fn(body.query, body.top_k)
+        result = rag_fn(body.query, body.top_k)
         return {"success": True, "query": body.query, "results": result}
     except HTTPException:
         raise
@@ -328,16 +349,14 @@ async def rag_query(request: Request, body: RAGQuery):
 
 
 @router.post("/simulate-climate")
-async def simulate_climate(request: Request, data: SimulationRequest):
+async def simulate_climate(request: Request, data: SimulationRequest, verify_fn=Depends(_require_simulation_runtime)):
     """Run a climate impact simulation for a given crop.
 
     Authentication is required so that the endpoint is not freely
     accessible to scrapers and bots under the global rate limit.
     """
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
     # Raises HTTP 401 if the Firebase token is missing or invalid.
-    token_data = await verify_role_fn(request)
+    token_data = await verify_fn(request)
     rate_limited = enforce_compute_rate_limit(
         request,
         scope="knowledge.simulate_climate",
@@ -407,13 +426,12 @@ async def simulate_climate(request: Request, data: SimulationRequest):
 
 
 @router.post("/seeds/verify")
-async def verify_seed(request: Request, data: SeedVerifyRequest):
-    if verify_role_fn is None:
-        raise HTTPException(status_code=500, detail="Not initialized")
+async def verify_seed(request: Request, data: SeedVerifyRequest, runtime=Depends(_require_seed_runtime)):
+    verify_fn, registry = runtime
     try:
-        await verify_role_fn(request)
-        is_verified = seed_registry.get(data.code, {}).get("verified", False) if seed_registry else False
-        seed_info = seed_registry.get(data.code, {}) if seed_registry else {}
+        await verify_fn(request)
+        is_verified = registry.get(data.code, {}).get("verified", False)
+        seed_info = registry.get(data.code, {})
         return {"success": True, "code": data.code, "verified": is_verified, "seed_info": seed_info}
     except HTTPException:
         raise

--- a/backend/schemas/rag.py
+++ b/backend/schemas/rag.py
@@ -1,15 +1,47 @@
 """Shared request schema for RAG-style query routes."""
 
+from html.parser import HTMLParser
 import re
 
+import bleach
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+_DANGEROUS_HTML_BLOCK_TAGS = {"script", "style", "iframe", "object", "embed"}
 
-_DANGEROUS_HTML_BLOCK_RE = re.compile(
-    r"<(script|style|iframe|object|embed)\b[^>]*>.*?</\1\s*>",
-    flags=re.IGNORECASE | re.DOTALL,
-)
-_HTML_TAG_RE = re.compile(r"</?[A-Za-z][A-Za-z0-9:-]*(?:\s+[^<>]*?)?/?>")
+
+class _DangerousHtmlBlockStripper(HTMLParser):
+    """Remove dangerous block elements and their contents from a string."""
+
+    def __init__(self):
+        super().__init__(convert_charrefs=True)
+        self._parts: list[str] = []
+        self._drop_depth = 0
+
+    def handle_starttag(self, tag, attrs):
+        if tag.lower() in _DANGEROUS_HTML_BLOCK_TAGS:
+            self._drop_depth += 1
+
+    def handle_startendtag(self, tag, attrs):
+        if tag.lower() not in _DANGEROUS_HTML_BLOCK_TAGS:
+            return
+
+    def handle_endtag(self, tag):
+        if tag.lower() in _DANGEROUS_HTML_BLOCK_TAGS and self._drop_depth:
+            self._drop_depth -= 1
+
+    def handle_data(self, data):
+        if self._drop_depth == 0:
+            self._parts.append(data)
+
+    def get_text(self) -> str:
+        return "".join(self._parts)
+
+
+def _strip_dangerous_html_blocks(value: str) -> str:
+    parser = _DangerousHtmlBlockStripper()
+    parser.feed(value)
+    parser.close()
+    return parser.get_text()
 
 
 def _rewrite_markdown_links_safe(text: str) -> str:
@@ -93,13 +125,17 @@ class RAGQuery(BaseModel):
         if not value or not isinstance(value, str):
             raise ValueError("Query must be a non-empty string.")
 
-        value = _DANGEROUS_HTML_BLOCK_RE.sub("", value)
-        value = re.sub(r"</?script.*?>", "", value, flags=re.IGNORECASE)
-        value = re.sub(r"on\w+\s*=", "", value, flags=re.IGNORECASE)
-        value = re.sub(r"javascript:", "", value, flags=re.IGNORECASE)
-        value = re.sub(r"data:", "", value, flags=re.IGNORECASE)
-        value = re.sub(r"vbscript:", "", value, flags=re.IGNORECASE)
-        value = _HTML_TAG_RE.sub("", value)
+        value = _strip_dangerous_html_blocks(value)
+        value = bleach.clean(
+            value,
+            tags=[],
+            attributes={},
+            protocols=[],
+            strip=True,
+            strip_comments=True,
+        )
+        value = re.sub(r"&lt;(?=\s)", "<", value)
+        value = re.sub(r"&gt;(?=\s)", ">", value)
         value = _rewrite_markdown_links_safe(value)
         value = re.sub(r"[*_~`#]", "", value)
         value = re.sub(r"\s+", " ", value.strip())

--- a/backend/schemas/rag.py
+++ b/backend/schemas/rag.py
@@ -137,7 +137,6 @@ class RAGQuery(BaseModel):
         value = re.sub(r"&lt;(?=\s)", "<", value)
         value = re.sub(r"&gt;(?=\s)", ">", value)
         value = _rewrite_markdown_links_safe(value)
-        value = re.sub(r"[*_~`#]", "", value)
         value = re.sub(r"\s+", " ", value.strip())
 
         forbidden_patterns = [

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 pip
 setuptools
 wheel
+bleach
 fastapi
 uvicorn
 pandas

--- a/tests/test_knowledge_router_state.py
+++ b/tests/test_knowledge_router_state.py
@@ -25,3 +25,28 @@ def test_seed_verify_requires_initialized_seed_registry(monkeypatch):
     assert response.status_code == 503
     assert response.json()["detail"] == "Seed registry not initialized"
     assert called is False
+
+
+def test_rag_query_rate_limit_payload_is_returned_with_429(monkeypatch):
+    app = FastAPI()
+    app.include_router(knowledge.router, prefix="/api/knowledge")
+
+    async def verify(_request):
+        return {"uid": "farmer-1"}
+
+    monkeypatch.setattr(knowledge, "verify_role_fn", verify)
+    monkeypatch.setattr(knowledge, "rag_generate_fn", lambda query, top_k=3: ["result"])
+    monkeypatch.setattr(
+        knowledge,
+        "enforce_compute_rate_limit",
+        lambda *args, **kwargs: {
+            "success": False,
+            "error": {"code": "rate_limit_exceeded", "message": "Too many requests."},
+        },
+    )
+
+    client = TestClient(app)
+    response = client.post("/api/knowledge/rag/query", json={"query": "What should I plant?", "top_k": 3})
+
+    assert response.status_code == 429
+    assert response.json()["error"]["code"] == "rate_limit_exceeded"

--- a/tests/test_knowledge_router_state.py
+++ b/tests/test_knowledge_router_state.py
@@ -1,0 +1,27 @@
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from backend.routers import knowledge
+
+
+def test_seed_verify_requires_initialized_seed_registry(monkeypatch):
+    app = FastAPI()
+    app.include_router(knowledge.router, prefix="/api/knowledge")
+
+    called = False
+
+    async def verify(_request):
+        nonlocal called
+        called = True
+        return {"uid": "farmer-1"}
+
+    monkeypatch.setattr(knowledge, "verify_role_fn", verify)
+    monkeypatch.setattr(knowledge, "seed_registry", None)
+    monkeypatch.setattr(knowledge, "rag_generate_fn", lambda query, top_k=3: ["result"])
+
+    client = TestClient(app)
+    response = client.post("/api/knowledge/seeds/verify", json={"code": "FS-RICE-2026-A1"})
+
+    assert response.status_code == 503
+    assert response.json()["detail"] == "Seed registry not initialized"
+    assert called is False

--- a/tests/test_rag_schema.py
+++ b/tests/test_rag_schema.py
@@ -8,6 +8,14 @@ def test_rag_query_sanitizes_incoming_text_and_validates_assignment():
 
     assert query.query == "What is the best fertilizer for rice?"
 
+    scripted = RAGQuery(query='<ScRiPt type="text/javascript">alert(1)</sCrIpT>How to irrigate wheat?', top_k=3)
+
+    assert scripted.query == "How to irrigate wheat?"
+
+    dangerous_attr = RAGQuery(query='<img src="x" onerror="alert(1)">Can I use drip irrigation?', top_k=3)
+
+    assert dangerous_attr.query == "Can I use drip irrigation?"
+
     comparison_query = RAGQuery(query="Use 2 < 3 and 5 > 4 when comparing thresholds.", top_k=3)
 
     assert comparison_query.query == "Use 2 < 3 and 5 > 4 when comparing thresholds."

--- a/tests/test_rag_schema.py
+++ b/tests/test_rag_schema.py
@@ -20,6 +20,10 @@ def test_rag_query_sanitizes_incoming_text_and_validates_assignment():
 
     assert comparison_query.query == "Use 2 < 3 and 5 > 4 when comparing thresholds."
 
+    preserved_symbols = RAGQuery(query="Crop #12 *urgent* irrigation notes", top_k=3)
+
+    assert preserved_symbols.query == "Crop #12 *urgent* irrigation notes"
+
     query.query = "<b>Need irrigation advice for wheat</b>"
 
     assert query.query == "Need irrigation advice for wheat"


### PR DESCRIPTION
I removed the blanket special-character stripping from backend/schemas/rag.py, so benign query text like `#12` and `*urgent*` is preserved instead of being rewritten away. The sanitizer still blocks the HTML/script cases through `bleach` and the existing injection checks.

I added a regression test in tests/test_rag_schema.py to lock that behavior in. Validation passed with `pytest test_rag_schema.py tests/test_rag_safety.py`, and the touched files are syntax-clean.


closes #1459