### PR TITLE
fix(referrals): replace datetime.utcnow() with timezone-aware datetime.now(timezone.utc)

### DIFF
--- a/backend/routers/referrals.py
+++ b/backend/routers/referrals.py
@@ -1,7 +1,7 @@
 """Farmer referral and village growth router."""
 import os
 import re
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, Optional
 
 from fastapi import APIRouter, HTTPException, Query, Request
@@ -33,7 +33,7 @@ def init_referrals(db_resolver, vr_fn):
 
 
 def _now_iso() -> str:
-    return datetime.utcnow().isoformat() + "Z"
+    return datetime.now(timezone.utc).isoformat()
 
 
 def _normalize_referral_code(code: str) -> str:


### PR DESCRIPTION
fixes #1524

_now_iso() returned datetime.utcnow().isoformat() + 'Z'. datetime.utcnow() produces a naive datetime with no tzinfo attached. Appending the literal string 'Z' does not make it timezone-aware in Python — it is just a string suffix. Any code that later parses these timestamps with datetime.fromisoformat() (Python 3.10 and earlier) gets a naive datetime back, and comparisons with timezone-aware datetimes from Firestore raise:
  TypeError: can't compare offset-naive and offset-aware datetimes

All six Firestore write sites that call _now_iso() are affected: referralCodeIssuedAt, createdAt, updatedAt (referral_codes collection), referralCodeIssuedAt (users collection), and created_at in the redemption transaction.

Fix: replace datetime.utcnow() with datetime.now(timezone.utc) and add timezone to the from-import. datetime.now(timezone.utc).isoformat() produces a timezone-aware datetime and an ISO 8601 string with an explicit UTC offset (+00:00) that is unambiguous to all parsers.

