### PR TITLE
fix(governance): remove duplicate DriftCheckRequest definition

### DIFF
--- a/backend/routers/governance.py
+++ b/backend/routers/governance.py
@@ -45,11 +45,6 @@ class RegisterModelVersionRequest(BaseModel):
             )
         return v
 
-class DriftCheckRequest(BaseModel):
-    model_name: str = Field(..., min_length=1, max_length=50)
-    prediction: float
-    actual_value: float
-
 drift_detector = None
 shadow_evaluator = None
 version_manager = None


### PR DESCRIPTION
DriftCheckRequest was defined twice in governance.py. In Python, when a class body defines the same name twice, only the last definition survives — the first is silently discarded. The second (duplicate) definition was a stripped-down copy missing the field_validator and Field constraints present in the first.

More critically, having two definitions of the same model in the same module is a maintenance hazard: a developer editing what they believe is the authoritative definition may be editing the shadowed copy that has no effect, or vice versa.

Fix: remove the second (duplicate) definition. The first definition (with proper Field constraints) is the canonical one and is already referenced correctly by check_drift().

closes #1523 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed duplicate code to improve codebase maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->