### PR TITLE
fix(blockchain): use digestmod keyword argument in hmac.new() calls

### DIFF
--- a/blockchain_supply_chain.py
+++ b/blockchain_supply_chain.py
@@ -220,11 +220,7 @@ class SupplyChainBlockchain:
 
         signature = ""
         if self._qr_signing_secret:
-            signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
 
         latest_hash = self.chain[-1].hash if self.chain else ""
         return {
@@ -239,11 +235,7 @@ class SupplyChainBlockchain:
         if proof_hash != expected["proof_hash"]:
             return False
         if self._qr_signing_secret:
-            expected_signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            expected_signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
             return hmac.compare_digest(signature or "", expected_signature)
         return True
 
@@ -275,11 +267,7 @@ class SupplyChainBlockchain:
 
         signature = ""
         if self._qr_signing_secret:
-            signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
 
         latest_hash = self.chain[-1].hash if self.chain else ""
         return {
@@ -294,11 +282,7 @@ class SupplyChainBlockchain:
         if proof_hash != expected["proof_hash"]:
             return False
         if self._qr_signing_secret:
-            expected_signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            expected_signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
             return hmac.compare_digest(signature or "", expected_signature)
         return True
 
@@ -329,11 +313,7 @@ class SupplyChainBlockchain:
 
         signature = ""
         if self._qr_signing_secret:
-            signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
 
         latest_hash = self.chain[-1].hash if self.chain else ""
         return {
@@ -348,11 +328,7 @@ class SupplyChainBlockchain:
         if proof_hash != expected["proof_hash"]:
             return False
         if self._qr_signing_secret:
-            expected_signature = hmac.new(
-                self._qr_signing_secret.encode("utf-8"),
-                proof_hash.encode("utf-8"),
-                hashlib.sha256,
-            ).hexdigest()
+            expected_signature = hmac.new(self._qr_signing_secret.encode("utf-8"), proof_hash.encode("utf-8"), digestmod=hashlib.sha256).hexdigest()
             return hmac.compare_digest(signature or "", expected_signature)
         return True
 


### PR DESCRIPTION
closes #1518

All six hmac.new() calls in _build_trace_proof() and verify_trace_proof() passed hashlib.sha256 as a positional argument:

  hmac.new(key, msg, hashlib.sha256)

The Python hmac.new() signature is:
  hmac.new(key, msg=None, digestmod='')

Passing digestmod positionally works in current CPython but is not the documented form. If the argument order ever changes in a future Python version, or if a linter/type-checker validates against the documented signature, the call silently breaks or raises a warning.

Fix: use the keyword form digestmod=hashlib.sha256 on all six call sites, matching the documented API and making the intent explicit.
