### PR TITLE
fix(feedback): raise ValueError for invalid ratings instead of silently defaulting 

### DIFF
--- a/feedback_validation.py
+++ b/feedback_validation.py
@@ -176,21 +176,40 @@ class FeedbackValidator:
     def validate_rating(cls, rating: int) -> int:
         """
         Validate rating (1-5).
-        
+
         Args:
             rating: User rating (1-5)
-            
+
         Returns:
-            Validated rating (clamped to 1-5 range)
+            Validated rating in the range [1, 5]
+
+        Raises:
+            ValueError: If the value cannot be coerced to an integer or is
+                outside the valid range [1, 5].
+
+        The previous implementation silently returned the default value 3
+        for any non-coercible input (e.g. "banana", None, {}) and clamped
+        out-of-range integers without raising an error.  A caller that
+        bypasses the Pydantic model and calls validate_feedback_data()
+        directly would silently store a fabricated rating of 3 in Firestore
+        for any invalid input.  Raising ValueError makes the contract
+        explicit and consistent with validate_message(), which also raises
+        on invalid input.
         """
         if not isinstance(rating, int):
             try:
                 rating = int(rating)
             except (ValueError, TypeError):
-                return 3  # Default rating
-                
-        # Clamp to valid range
-        return max(1, min(5, rating))
+                raise ValueError(
+                    f"Rating must be an integer between 1 and 5, got: {rating!r}"
+                )
+
+        if not (1 <= rating <= 5):
+            raise ValueError(
+                f"Rating must be between 1 and 5, got: {rating}"
+            )
+
+        return rating
     
     @classmethod
     def validate_message(cls, message: str) -> Optional[str]:


### PR DESCRIPTION
closes #1610

validate_rating() previously returned a hardcoded default of 3 when the input could not be coerced to int (e.g. 'banana', None, {}), and silently clamped out-of-range integers (e.g. 0, 6, 100) to the nearest boundary.

A caller that bypasses the Pydantic model and calls validate_feedback_data() directly would silently store a fabricated rating of 3 (or a clamped value) in Firestore for any invalid input, with no indication that validation failed.

Fix: raise ValueError for both non-coercible inputs and out-of-range integers. This makes the contract explicit and consistent with validate_message(), which also raises ValueError on invalid input. The Pydantic model (ge=1, le=5) still enforces the range at the API layer; this fix closes the gap for direct callers of validate_feedback_data().


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rating validation now enforces stricter requirements, rejecting invalid inputs and out-of-range values instead of using defaults or automatic adjustment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->