### PR TITLE
fix(feedback): apply sanitize_string and dangerous-pattern check to userEmail 

### DIFF
--- a/feedback_validation.py
+++ b/feedback_validation.py
@@ -270,10 +270,20 @@ class FeedbackValidator:
         if 'userId' in data:
             validated['userId'] = str(data['userId'])
         if 'userEmail' in data:
-            # Basic email validation
-            email = str(data['userEmail'])
-            if '@' in email and '.' in email and len(email) <= 254:
-                validated['userEmail'] = email
+            # Apply the same sanitization and dangerous-pattern checks used
+            # for every other string field.  The previous implementation only
+            # checked for '@', '.', and length — a crafted email containing a
+            # MongoDB operator (e.g. {"$where":"..."}@example.com) or a script
+            # tag would pass those checks and be stored in Firestore unsanitised.
+            email = cls.sanitize_string(str(data['userEmail']), 254)
+            if email and '@' in email and '.' in email:
+                safe = True
+                for pattern in cls.DANGEROUS_PATTERNS:
+                    if re.search(pattern, email, re.IGNORECASE):
+                        safe = False
+                        break
+                if safe:
+                    validated['userEmail'] = email
                 
         return validated
     


### PR DESCRIPTION
closes #1611

validate_feedback_data() validated userEmail with only three checks:
  '@' in email, '.' in email, len(email) <= 254

Unlike every other string field (name, location, message), userEmail was never passed through sanitize_string() or checked against DANGEROUS_PATTERNS. A crafted email address containing a MongoDB operator (e.g. {'':'...'}@example.com) or a script tag would pass the '@' and '.' checks and be stored in Firestore without sanitisation.

Fix: apply cls.sanitize_string() first (strips control characters, collapses whitespace, enforces max length), then check all DANGEROUS_PATTERNS before storing. The '@' and '.' structural checks are retained as a secondary guard. This matches the treatment of all other string fields in the method.
