### PR TITLE
fix(blockchain): move contract_id from query parameter to path parameter

### DIFF
--- a/backend/routers/blockchain.py
+++ b/backend/routers/blockchain.py
@@ -254,7 +254,7 @@ async def create_contract(request: Request, data: CreateSmartContractRequest):
         logger.error(f"Contract error: {e}")
         raise HTTPException(status_code=400, detail=str(e))
 
-@router.post("/execute-contract")
+@router.post("/execute-contract/{contract_id}")
 async def execute_contract(request: Request, contract_id: str):
     """Execute a smart contract. Requires authentication.
 


### PR DESCRIPTION
closes #1609

execute_contract() was registered at POST /execute-contract with contract_id as a plain function parameter, which FastAPI interprets as a query parameter:
  POST /execute-contract?contract_id=CONTRACT-ABC123

This is semantically incorrect — a query parameter implies the value is optional and filterable rather than identifying a specific resource. It is also inconsistent with every other resource-specific endpoint in the same file (qr-code/{batch_id}, verify/{batch_id}, journey/{batch_id}, analytics/{batch_id}) which all use path parameters.

Fix: change the route to /execute-contract/{contract_id} so contract_id is a path parameter. FastAPI automatically binds the path segment to the function argument of the same name — no other code changes are needed.
