### PR TITLE
fix: warn when _TRUSTED_ORIGINS is empty to surface misconfiguration (fixes #1622)

### DIFF
--- a/csrf_protection.py
+++ b/csrf_protection.py
@@ -9,7 +9,7 @@ import hmac
 import hashlib
 import secrets
 import time
-import
+import os
 from typing import List, Optional
 from urllib.parse import urlparse
 
@@ -47,6 +47,11 @@ def reject_cross_origin(request: Request) -> None:
     (e.g. Twilio webhooks), while browser-originated cross-origin POSTs
     are rejected.
     """
+    if not _TRUSTED_ORIGINS:
+        import logging
+        logging.getLogger(__name__).warning(
+            "CSRF: _TRUSTED_ORIGINS is empty — all browser requests will be rejected. Call configure() on startup."
+        )
     client_origin = _extract_origin(request)
     if client_origin is None:
         return
@@ -55,7 +60,6 @@ def reject_cross_origin(request: Request) -> None:
             status_code=403,
             detail="Cross-origin request rejected",
         )
-
 
 def generate_token(uid: str) -> str:
     """Return a stateless HMAC-signed token tied to *uid*, valid 1 hour."""


### PR DESCRIPTION
## 📝 Description
_TRUSTED_ORIGINS defaulted to an empty list with no warning. If configure() was never called on startup, every browser request with an Origin header got rejected with a silent 403 — no log, no indication of misconfiguration.

This fix adds a warning log inside reject_cross_origin() when _TRUSTED_ORIGINS is empty, so operators immediately see the misconfiguration in logs instead of debugging silent 403s.

## 🎯 Type of Change
- [x] 🐞 Bug fix

## 🔗 Related Issue
Closes #1622

## 🧪 Testing Done
- [x] Tested locally
- [x] Verified API / backend changes (if applicable)

## 📸 Screenshots (if applicable)
N/A — backend-only change

## ✅ Checklist
- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

## 📌 Additional Notes
No breaking changes. Existing behaviour is preserved — the warning fires only when _TRUSTED_ORIGINS is empty, which was already causing silent 403s before this fix.