### PR TITLE
fix: guard against empty input_names in predict() to prevent IndexError (fixes #1626)

### DIFF
--- a/inference/onnx_runtime.py
+++ b/inference/onnx_runtime.py
@@ -40,6 +40,10 @@ class ONNXRuntimeModel:
         self.output_names = [out.name for out in self.sess.get_outputs()]
 
     def predict(self, x: np.ndarray) -> np.ndarray:
+        if not self.input_names:
+            raise RuntimeError(
+                f"ONNX model '{self.model_path}' has no inputs — model may be malformed"
+            )
         if not isinstance(x, np.ndarray):
             x = np.asarray(x)
 


### PR DESCRIPTION
## 📝 Description
predict() accessed self.input_names[0] directly with no bounds check. If the ONNX model is malformed or has no inputs, this raised an unhandled IndexError with no meaningful message, making it impossible to diagnose the root cause.

Fixed by adding an explicit check at the top of predict() that raises a descriptive RuntimeError including the model path when input_names is empty.

## 🎯 Type of Change
- [x] 🐞 Bug fix

## 🔗 Related Issue
Closes #1626

## 🧪 Testing Done
- [x] Tested locally
- [x] Verified API / backend changes (if applicable)

## 📸 Screenshots (if applicable)
N/A — backend-only change

## ✅ Checklist
- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

## 📌 Additional Notes
No breaking changes. Valid models with inputs are unaffected.