### PR TITLE
fix(middleware): replace no-op string literals in except blocks with comments

### DIFF
--- a/error_recovery_middleware.py
+++ b/error_recovery_middleware.py
@@ -146,7 +146,7 @@ class ErrorRecoveryMiddleware(BaseHTTPMiddleware):
             return response
 
         except HTTPException as http_exc:
-            """Handle HTTP exceptions"""
+            # Handle HTTP exceptions
             duration = time.time() - start_time
 
             logger.warning(
@@ -168,7 +168,7 @@ class ErrorRecoveryMiddleware(BaseHTTPMiddleware):
             )
 
         except ValueError as val_exc:
-            """Handle validation errors"""
+            # Handle validation errors
             duration = time.time() - start_time
 
             logger.warning(
@@ -190,7 +190,7 @@ class ErrorRecoveryMiddleware(BaseHTTPMiddleware):
             )
 
         except TimeoutError as timeout_exc:
-            """Handle timeout errors"""
+            # Handle timeout errors
             duration = time.time() - start_time
 
             logger.error(
@@ -215,7 +215,7 @@ class ErrorRecoveryMiddleware(BaseHTTPMiddleware):
             )
 
         except Exception as exc:
-            """Handle unexpected errors"""
+            # Handle unexpected errors
             duration = time.time() - start_time
             error_id = str(uuid.uuid4())
 


### PR DESCRIPTION
fixes #1607 

The four except blocks in ErrorRecoveryMiddleware.dispatch() each opened with a triple-quoted string literal. In Python, a string literal as the first statement of an except block is not a docstring - only functions, classes, and modules have docstrings. It is a no-op expression statement that is evaluated and immediately discarded at runtime. Static analysis tools flag these as dead code (W0105 pointless string statement).

Fix: convert all four string literals to # comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated internal code documentation format for exception handling.

**Note:** This release contains no functional changes or user-facing impacts. Changes are limited to code documentation style improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->