### PR TITLE
fix(blockchain): remove redundant hasattr guards around always-present attributes

### DIFF
--- a/backend/routers/blockchain.py
+++ b/backend/routers/blockchain.py
@@ -230,7 +230,7 @@ async def create_batch(request: Request, data: CreateProductBatchRequest):
             data.planting_date, data.harvesting_date, data.farmer_name,
             owner_uid=uid,
         )
-        return {"success": True, "batch": asdict(batch) if hasattr(batch, '__dataclass_fields__') else batch}
+        return {"success": True, "batch": asdict(batch)}
     except Exception as e:
         logger.error(f"Batch error: {e}")
         raise HTTPException(status_code=400, detail=str(e))
@@ -418,8 +418,8 @@ async def get_stats(request: Request):
     try:
         stats = {
             "total_records": supply_chain_blockchain.get_blockchain_record_count(),
-            "actors": len(supply_chain_blockchain.verified_actors if hasattr(supply_chain_blockchain, 'verified_actors') else []),
-            "contracts": len(supply_chain_blockchain.smart_contracts if hasattr(supply_chain_blockchain, 'smart_contracts') else [])
+            "actors": len(supply_chain_blockchain.verified_actors),
+            "contracts": len(supply_chain_blockchain.smart_contracts)
         }
         return {"success": True, "stats": stats}
     except Exception as e:


### PR DESCRIPTION
closes #1613

Three hasattr() guards wrapped attributes that are unconditionally initialised in SupplyChainBlockchain.__init__:

  verified_actors  = {}   (always present)
  smart_contracts  = {}   (always present)
  ProductBatch     is a dataclass (always has __dataclass_fields__)

The guards can never evaluate to False, making them dead code that:
- Implies the attributes might be absent, misleading future maintainers.
- Adds visual noise that obscures the actual logic.
- May cause static analysis tools to flag unreachable branches.

Fix: remove all three hasattr() guards and call the attributes directly.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified `/create-batch` endpoint to consistently return batch data without conditional fallback logic.
  * Updated `/stats` endpoint to directly count verified entities, removing conditional attribute checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->