### PR TITLE
fix(#1698): suppress raw exception detail in crop recommendation 500 responses

### DIFF
--- a/routers/crop_recommendation.py
+++ b/routers/crop_recommendation.py
@@ -612,5 +612,5 @@ async def recommend_crops(req: CropRecommendationRequest):
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Crop recommendation error: {str(e)}", exc_info=True)
-        raise HTTPException(status_code=500, detail=f"Recommendation failed: {str(e)}")
+        logger.error("Crop recommendation error: %s", str(e), exc_info=True)
+        raise HTTPException(status_code=500, detail="An error occurred while generating recommendations. Please try again.")


### PR DESCRIPTION
## Summary

Replaces the raw \`str(e)\` exception message returned to HTTP clients with a generic response, preventing internal implementation details from leaking to callers.

## Related Issue

Closes #1698

## Type of Change

- [x] Security fix

## Root Cause

\`\`\`python
# Before: full exception string returned to caller
except Exception as e:
    logger.error(f"Crop recommendation error: {str(e)}", exc_info=True)
    raise HTTPException(status_code=500, detail=f"Recommendation failed: {str(e)}")
\`\`\`

\`str(e)\` for common failure modes exposed Pydantic field paths, file system paths, and module names to any HTTP client.

## What Changed

- \`routers/crop_recommendation.py\`: replaced \`detail=f"Recommendation failed: {str(e)}"\` with a static \`"An error occurred while generating recommendations. Please try again."\`
- The full exception is still logged server-side with \`exc_info=True\` so operators can diagnose failures from logs.

## Testing

- [ ] Triggering an internal error (e.g. disconnecting the crop database) returns a generic 500 message with no internal details
- [ ] Server logs contain the full exception for debugging

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error message handling in the crop recommendation endpoint to provide standardized error responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->