### PR TITLE
fix(#1695,#1699): fix deadlock and cap evaluations list in ShadowEvaluator

### DIFF
--- a/ml/governance/shadow_evaluator.py
+++ b/ml/governance/shadow_evaluator.py
@@ -64,7 +64,9 @@ class ShadowEvaluator:
         self.confidence_threshold = confidence_threshold
         
         # Tracking
-        self.evaluations: List[ShadowEvaluation] = []
+        # Bounded deque: oldest evaluations are discarded once the limit is
+        # reached, preventing unbounded heap growth in long-running deployments.
+        self.evaluations: deque = deque(maxlen=500)
         self.active_evaluations: Dict[str, Dict[str, Any]] = {}  # eval_id -> data
         self._lock = threading.Lock()
     
@@ -193,7 +195,9 @@ class ShadowEvaluator:
             )
         
             self.evaluations.append(result)
-            self.cleanup_evaluation(eval_id)
+        # cleanup_evaluation acquires self._lock itself; call it outside the
+        # with block to avoid deadlock with a non-reentrant threading.Lock.
+        self.cleanup_evaluation(eval_id)
         logger.info(
             f"Evaluation {eval_id} complete: {recommendation.upper()} "
             f"(error reduction: {error_reduction:.2%}, confidence: {confidence_score:.2%})"


### PR DESCRIPTION
## Summary

Fixes a thread deadlock and an unbounded memory growth issue in \`ml/governance/shadow_evaluator.py\`.

## Related Issues

Closes #1695
Closes #1699

## Type of Change

- [x] Bug fix

## Root Cause

**#1695 (Deadlock):** \`evaluate_candidate()\` called \`cleanup_evaluation()\` while holding \`self._lock\`. \`cleanup_evaluation()\` attempts to acquire the same \`threading.Lock\`. Since \`threading.Lock\` is not reentrant, the second \`acquire()\` blocks forever.

**#1699 (Unbounded list):** \`self.evaluations\` was a plain \`List[ShadowEvaluation]\` with no maximum length. Every completed evaluation was appended but never pruned, causing steady heap growth in long-running deployments.

## What Changed

- \`ml/governance/shadow_evaluator.py\`:
  - **#1695**: Moved \`self.cleanup_evaluation(eval_id)\` to after the \`with self._lock:\` block exits, so it no longer re-enters the non-reentrant lock.
  - **#1699**: Changed \`self.evaluations\` from a plain list to \`collections.deque(maxlen=500)\` (the \`deque\` import was already present). Oldest entries are automatically discarded at the cap.

## Testing

- [ ] Calling \`evaluate_candidate()\` with a completed evaluation no longer hangs
- [ ] After 501 evaluations, \`len(evaluator.evaluations)\` remains at 500
- [ ] \`get_evaluations(limit=N)\` still returns the N most recent evaluations

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change (both fixes are in the same file and related)