### PR TITLE
fix(#1696): use UUID-based version IDs to prevent duplicate IDs after cleanup

### DIFF
--- a/ml/governance/model_versioning.py
+++ b/ml/governance/model_versioning.py
@@ -99,7 +99,11 @@ class ModelVersionManager:
         Returns:
             Version ID
         """
-        version_id = f"{model_name}_v{len([v for v in self.versions.values() if v.model_name == model_name]) + 1}"
+        # Use a UUID suffix so version IDs are unique even after cleanup_old_versions()
+        # removes earlier entries.  A count-based suffix would collide with any deleted
+        # version once the count dropped below the deleted entry's sequence number.
+        import uuid as _uuid
+        version_id = f"{model_name}_{_uuid.uuid4().hex[:8]}"
         
         version = ModelVersion(
             version_id=version_id,


### PR DESCRIPTION
## Summary

Replaces the count-based version ID with a UUID-derived suffix to ensure uniqueness even after \`cleanup_old_versions()\` removes earlier entries.

## Related Issue

Closes #1696

## Type of Change

- [x] Bug fix

## Root Cause

\`register_version()\` computed the version ID by counting how many versions currently existed for the model:
\`\`\`python
version_id = f"{model_name}_v{len([v for v in self.versions.values() if v.model_name == model_name]) + 1}"
\`\`\`
After \`cleanup_old_versions()\` removed old entries, the count dropped and the next registration produced an ID already used by a deleted version. The new version silently reused the old ID, corrupting version history.

## What Changed

- \`ml/governance/model_versioning.py\`: replaced count-based suffix with \`uuid.uuid4().hex[:8]\` so version IDs are unique regardless of how many entries have been removed.

## Testing

- [ ] Register 3 versions, call \`cleanup_old_versions()\`, then register a 4th: the new ID does not collide with any of the previous three
- [ ] Version history entries all have unique IDs

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change