### PR TITLE
fix(#1700): add authentication to GET /weather/alerts/history

### DIFF
--- a/backend/routers/platform.py
+++ b/backend/routers/platform.py
@@ -418,7 +418,17 @@ def init_platform(
 
 
 @router.get("/weather/alerts/history")
-async def get_alerts_history():
+async def get_alerts_history(request: Request):
+    """Return the most recent server-side weather alerts.
+
+    Requires a valid authenticated session. The alert history is internal
+    operational data and must not be exposed to unauthenticated callers.
+    """
+    if verify_role_fn is None:
+        raise HTTPException(status_code=503, detail="Auth service unavailable")
+
+    await verify_role_fn(request)
+
     if weather_service is None:
         raise HTTPException(status_code=503, detail="Weather service unavailable")
 


### PR DESCRIPTION
## Summary

Adds an authentication check to \`GET /weather/alerts/history\` so that the server-side alert history is not accessible to unauthenticated callers.

## Related Issue

Closes #1700

## Type of Change

- [x] Security fix

## Root Cause

\`get_alerts_history()\` had no \`verify_role_fn\` call. All adjacent endpoints on the same router (\`/whatsapp/subscribe\`, \`/whatsapp/trigger-alert\`, \`/reports/generate\`, \`/log-error\`) call \`await verify_role_fn(request)\` before proceeding; this endpoint was the sole exception.

## What Changed

- \`backend/routers/platform.py\`: added \`request: Request\` parameter and \`await verify_role_fn(request)\` to \`get_alerts_history()\`, consistent with all other authenticated endpoints on this router.

## Testing

- [ ] \`GET /weather/alerts/history\` without an Authorization header returns 401
- [ ] Authenticated request with a valid token returns the alert history as before

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change