### PR TITLE
fix(#1703): cap dict field sizes before writing farm intelligence history to Firestore

### DIFF
--- a/backend/routers/advisory.py
+++ b/backend/routers/advisory.py
@@ -585,14 +585,26 @@ async def create_advisory(payload: AdvisoryRequest, request: Request):
 async def create_farm_intelligence(payload: "FarmIntelligenceRequest", request: Request):
     uid = await _get_authenticated_uid(request)
     result = _build_farm_graph(payload)
+    # Cap each user-supplied dict to at most _HISTORY_DICT_KEY_CAP entries before
+    # writing to Firestore. The advisory engine only inspects a small set of known
+    # keys, so truncating any excess is safe and prevents permanently storing
+    # multi-kilobyte documents from over-sized request payloads.
+    _HISTORY_DICT_KEY_CAP = 30
+
+    def _cap_dict(d: dict) -> dict:
+        if not isinstance(d, dict):
+            return {}
+        items = list(d.items())[:_HISTORY_DICT_KEY_CAP]
+        return dict(items)
+
     history_entry = {
         "uid": uid,
         "crop_type": payload.crop_type,
         "location": payload.location,
-        "weather": payload.weather,
-        "soil": payload.soil,
-        "pest": payload.pest,
-        "market": payload.market,
+        "weather": _cap_dict(payload.weather),
+        "soil": _cap_dict(payload.soil),
+        "pest": _cap_dict(payload.pest),
+        "market": _cap_dict(payload.market),
         "graph": result["graph"],
         "reasoning": result["reasoning"],
         "recommendations": result["recommendations"],


### PR DESCRIPTION
## Summary

Prevents authenticated users from permanently storing multi-kilobyte Firestore documents by capping the user-supplied dict fields before the history write.

## Related Issue

Closes #1703

## Type of Change

- [x] Bug fix
- [x] Security fix

## Root Cause

\`create_farm_intelligence\` wrote the full \`payload.weather\`, \`payload.soil\`, \`payload.pest\`, and \`payload.market\` dicts directly into the Firestore history entry when \`store_history=True\` (the default). Because those fields had no size constraints, a caller could repeatedly submit requests with thousands of keys, permanently accumulating large documents in the user's Firestore sub-collection.

## What Changed

- \`backend/routers/advisory.py\`: added a local \`_cap_dict(d)\` helper inside \`create_farm_intelligence\` that limits each dict to at most 30 entries. Wrapped all four dict fields with \`_cap_dict\` before building \`history_entry\`.

## Testing

- [ ] Submitting a request with \`weather\` containing 200 keys stores only 30 in Firestore
- [ ] A normal request with fewer than 30 keys is stored without modification
- [ ] Setting \`store_history=False\` bypasses the write entirely (unchanged behaviour)

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data handling in farm intelligence recommendations by optimizing how historical data is stored, ensuring better system stability and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->