### PR TITLE
fix(#1704): add rate limit to POST /advisory to protect against unauthenticated abuse

### DIFF
--- a/backend/routers/advisory.py
+++ b/backend/routers/advisory.py
@@ -544,20 +544,34 @@ class FarmIntelligenceRequest(BaseModel):
 @router.post("/advisory")
 async def create_advisory(payload: AdvisoryRequest, request: Request):
     """
-    Generate rule-based farm advisories for the authenticated user.
+    Generate rule-based farm advisories.
 
     If store_alerts is True the generated alerts are persisted server-side
-    under the caller's verified Firebase UID — never under a client-supplied
-    user_id — so they can be retrieved later via GET /advisory/me.
+    under the caller's verified Firebase UID so they can be retrieved later
+    via GET /advisory/me.
 
-    Authentication is required when store_alerts is True so that:
+    Authentication is required when store_alerts is True:
     1. Alerts are always bound to a verified identity.
-    2. An unauthenticated caller cannot pollute another user's alert store
-       by guessing or enumerating Firebase UIDs (IDOR).
+    2. An unauthenticated caller cannot pollute another user's alert store.
 
-    Unauthenticated callers may still generate transient advisories
-    (store_alerts=False) for the climate simulator and public widgets.
+    Unauthenticated callers may generate transient advisories
+    (store_alerts=False) for the climate simulator and public widgets but are
+    subject to a rate limit to prevent unbounded advisory engine load.
     """
+    # Rate-limit all callers (authenticated and anonymous alike) to prevent
+    # unbounded rule-evaluation passes triggered by anonymous clients sending
+    # large payloads at high frequency.
+    from compute_rate_limit import enforce_compute_rate_limit
+    rate_response = enforce_compute_rate_limit(
+        request,
+        scope="advisory",
+        uid=None,
+        limit=30,
+        window_seconds=60,
+    )
+    if rate_response is not None:
+        return rate_response
+
     alerts = generate_advisories(
         weather=payload.weather,
         soil=payload.soil,


### PR DESCRIPTION
## Summary

Adds a rate limit to \`POST /advisory\` so that anonymous callers cannot trigger unlimited advisory engine evaluations at arbitrary request rates.

## Related Issue

Closes #1704

## Type of Change

- [x] Security fix
- [x] Bug fix

## Root Cause

\`create_advisory\` had no \`enforce_compute_rate_limit\` call and no rate-limit decorator. An anonymous caller could send thousands of requests per minute, each triggering a full \`generate_advisories()\` evaluation pass. Combined with unconstrained \`weather\` and \`soil\` dict fields, this was a CPU exhaustion vector.

## What Changed

- \`backend/routers/advisory.py\`: added \`enforce_compute_rate_limit(request, scope="advisory", uid=None, limit=30, window_seconds=60)\` at the top of \`create_advisory\`, before the advisory engine runs. The limit applies to all callers (authenticated and unauthenticated).

## Testing

- [ ] Sending more than 30 requests per minute to \`POST /advisory\` without auth returns 429
- [ ] The 31st request within a 60-second window returns a \`Retry-After\` header
- [ ] A legitimate request within the limit succeeds as before

## Checklist

- [x] No hardcoded secrets or credentials
- [x] Single focused change

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Rate limiting is now enforced on the advisory endpoint for all API requests to ensure consistent service availability and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->