### PR TITLE
fix(notification_auth): guard uid None/empty to prevent unauthorized notification access (fixes #1683)

### DIFF
--- a/notification_auth.py
+++ b/notification_auth.py
@@ -17,7 +17,12 @@ def notification_visible_to_user(
     Broadcast notifications omit ``recipient_uid`` (or set it to None) and are
     visible to every authenticated user. Targeted notifications include
     ``recipient_uid`` and are only visible to that user.
+
+    Returns False immediately when ``uid`` is None or empty to prevent
+    unauthenticated or malformed callers from accessing any notification.
     """
+    if not uid:
+        return False
     recipient = notification.get("recipient_uid")
     if recipient is None:
         return True
@@ -29,4 +34,6 @@ def filter_notifications_for_user(
     uid: str,
 ) -> List[Dict[str, Any]]:
     """Return notifications visible to ``uid``, preserving order."""
+    if not uid:
+        return []
     return [n for n in notifications if notification_visible_to_user(n, uid)]


### PR DESCRIPTION
## Summary
Fixes #1683

`notification_visible_to_user()` had no guard against `uid` being `None` or empty string, causing two security issues:
- `uid=None` (unauthenticated caller) could see broadcast notifications stored with `recipient_uid=None`
- `uid=''` could match targeted notifications with `recipient_uid=''` (legacy/bad data)

## Changes
- Added `if not uid: return False` guard in `notification_visible_to_user()` 
- Added same guard in `filter_notifications_for_user()` to prevent bypass via direct filter call

## Test cases fixed
| uid | recipient_uid | Before | After |
|-----|--------------|--------|-------|
| `None` | `None` (broadcast) | `True` ❌ | `False` ✅ |
| `""` | `""` (bad data) | `True` ❌ | `False` ✅ |
| `"user1"` | `None` (broadcast) | `True` ✅ | `True` ✅ |
| `"user1"` | `"user1"` | `True` ✅ | `True` ✅ |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication validation by explicitly rejecting unauthenticated requests at the entry point, preventing unauthorized notification access.
  * Enhanced security by validating user credentials earlier in the process, reducing unnecessary processing for invalid callers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->