### PR TITLE
fix: remove stray review text from farm diary modal

### DIFF
--- a/frontend/FarmDiary.jsx
+++ b/frontend/FarmDiary.jsx
@@ -283,7 +283,7 @@ export default function FarmDiary({ onClose }) {
                 onChange={handleInputChange}
                 className="diary-input"
               />
-            </div>Expand commentComment on lines R217 to R278Resolved
+            </div>
           </div>
 
           <div className="form-actions">


### PR DESCRIPTION
## 📝 Description
This PR removes unintended GitHub review/comment text that was being rendered inside the Digital Farm Diary modal. The fix cleans up the modal UI so only the intended form fields and action buttons are shown, improving layout consistency and user experience.

---

## 🎯 Type of Change
- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue
Closes #1039 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected JSX markup in the reminder date field form to ensure proper HTML structure and container closure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->