### PR TITLE
feat(security): activate RuntimeProtectionMiddleware for secrets scan…

### DIFF
--- a/main.py
+++ b/main.py
@@ -96,6 +96,7 @@ from whatsapp_service import send_whatsapp_message, format_alert_message
 from whatsapp_store import subscriber_store
 from csrf_protection import generate_token, reject_cross_origin
 from error_recovery_middleware import ErrorRecoveryMiddleware
+from security_hygiene import RuntimeProtectionMiddleware
 from geo_alerts import notification_matches_regions, profile_can_broadcast_region, profile_regions, region_matches, resolve_subscription_regions, normalize_region_identifier
 from notification_auth import filter_notifications_for_user
 from realtime_notifications import notification_broker
@@ -138,6 +139,7 @@ class ContextFilter(logging.Filter):
 # Configure structured logging with detailed formatting
 _context_filter = ContextFilter()
 _handler = logging.StreamHandler()
+_handler.addFilter(_context_filter)
 _formatter = logging.Formatter(
     '%(asctime)s - %(name)s - %(levelname)s - %(funcName)s:%(lineno)d - [%(context)s] - %(message)s',
     datefmt='%Y-%m-%d %H:%M:%S'
@@ -1440,6 +1442,10 @@ app.add_middleware(
 import csrf_protection as _csrf
 _csrf.configure(_CORS_ORIGINS)
 app.add_middleware(RBACMiddleware)
+app.add_middleware(
+    RuntimeProtectionMiddleware,
+    exclude_paths=["/docs", "/openapi.json", "/static", "/api/crop-disease/analyze-image", "/api/quality/assess", "/api/gemini/analyze-image"]
+)
 logger.info(print_rbac_matrix())
 
 # Import the voice assistant router at module level so app.include_router() can

--- a/persistence/repositories.py
+++ b/persistence/repositories.py
@@ -222,7 +222,7 @@ class NotificationRepository(BaseRepository):
             return False
 
     def get(self, notification_id: str) -> Optional[Dict[str, Any]]:
-         notification_id = str(notification_id
+        notification_id = str(notification_id)
         """Retrieve a notification by ID."""
         if self.db is None:
             return None

--- a/security_hygiene.py
+++ b/security_hygiene.py
@@ -56,34 +56,60 @@ class SecretHygieneProgram:
                 findings.append(Finding(category, match.group(0), location))
         return findings
 
-class RuntimeProtectionMiddleware(BaseHTTPMiddleware):
-    """FastAPI Middleware to block requests containing cleartext secrets."""
-    def __init__(self, app, program: SecretHygieneProgram = None):
-        super().__init__(app)
+class RuntimeProtectionMiddleware:
+    """FastAPI/ASGI Middleware to block requests containing cleartext secrets."""
+    def __init__(self, app, program: SecretHygieneProgram = None, exclude_paths: List[str] = None):
+        self.app = app
         self.program = program or SecretHygieneProgram()
+        self.exclude_paths = exclude_paths or []
 
-    async def dispatch(self, request: Request, call_next):
-        # Scan request body for secret leakages before passing to route handlers
+    async def __call__(self, scope, receive, send):
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        path = scope.get("path", "")
+        if any(path.startswith(prefix) for prefix in self.exclude_paths):
+            await self.app(scope, receive, send)
+            return
+
+        body_bytes = b""
+        more_body = True
+        received_messages = []
+
         try:
-            body_bytes = await request.body()
+            while more_body:
+                message = await receive()
+                received_messages.append(message)
+                if message["type"] == "http.request":
+                    body_bytes += message.get("body", b"")
+                    more_body = message.get("more_body", False)
+                elif message["type"] == "http.disconnect":
+                    break
+
             body_str = body_bytes.decode("utf-8", errors="ignore")
             findings = self.program.scan_text(body_str, location="middleware")
             if findings:
-                return JSONResponse(
+                response = JSONResponse(
                     status_code=400,
                     content={"error": "Request blocked by secrets hygiene policy"}
                 )
-            
-            # Reset body read pointer so downstream handlers can consume it
-            async def receive():
-                return {"type": "http.request", "body": body_bytes, "more_body": False}
-            request._receive = receive
+                await response(scope, receive, send)
+                return
         except Exception:
-            # Fallback in case of body read failures to avoid crashing the server
+            # Fallback to normal request execution if body buffering fails
             pass
 
-        response = await call_next(request)
-        return response
+        message_idx = 0
+        async def mock_receive():
+            nonlocal message_idx
+            if message_idx < len(received_messages):
+                msg = received_messages[message_idx]
+                message_idx += 1
+                return msg
+            return await receive()
+
+        await self.app(scope, mock_receive, send)
 
 def build_secret_fingerprint(value: str) -> str:
     """Generate a cryptographically stable fingerprint of a secret value."""

--- a/test_validation_simple.py
+++ b/test_validation_simple.py
@@ -212,6 +212,64 @@ def test_boundary_values():
     return True
 
 
+def test_runtime_secrets_protection():
+    """Test that RuntimeProtectionMiddleware blocks requests containing cleartext secrets."""
+    print("Testing Runtime Protection Middleware (Secrets Scanning)...")
+    try:
+        from fastapi.testclient import TestClient
+        from main import app
+        if app is None:
+            print("  ⚠️ Skipping middleware test: FastAPI app unavailable")
+            return True
+    except Exception as e:
+        print(f"  ⚠️ Skipping middleware test: Failed to import app ({e})")
+        return True
+
+    with TestClient(app) as client:
+        secret_payload = {
+            "Crop": "Rice",
+            "CropCoveredArea": 10.0,
+            "CHeight": 5,
+            "CNext": "None",
+            "CLast": "None",
+            "CTransp": "None",
+            "IrriType": "None",
+            "IrriSource": "None",
+            "IrriCount": 2,
+            "WaterCov": 50,
+            "Season": "Kharif",
+            "aws_key": "AKIA1234567890ABCDEF"
+        }
+        response = client.post("/predict", json=secret_payload)
+        assert response.status_code == 400, f"Expected 400, got {response.status_code}"
+        assert response.json() == {"error": "Request blocked by secrets hygiene policy"}
+        print("  ✓ Request with AWS key blocked with 400 Bad Request")
+
+        normal_payload = {
+            "Crop": "Rice",
+            "CropCoveredArea": 10.0,
+            "CHeight": 5,
+            "CNext": "None",
+            "CLast": "None",
+            "CTransp": "None",
+            "IrriType": "None",
+            "IrriSource": "None",
+            "IrriCount": 2,
+            "WaterCov": 50,
+            "Season": "Kharif"
+        }
+        response = client.post("/predict", json=normal_payload)
+        assert response.status_code in (401, 403, 422), f"Expected auth block (401/403) or validation error (422), got {response.status_code}"
+        print("  ✓ Request without secrets bypassed middleware successfully")
+
+        response = client.post("/api/crop-disease/analyze-image", json={"image_base64": "AKIA1234567890ABCDEF"})
+        assert response.status_code != 400, "Excluded path was incorrectly blocked by middleware"
+        print("  ✓ Excluded path bypassed secrets scanning successfully")
+
+    print("✓ All Runtime Protection Middleware tests passed\n")
+    return True
+
+
 def main():
     """Run all tests."""
     print("=" * 60)
@@ -225,6 +283,7 @@ def main():
         test_invalid_types()
         test_full_input_validation()
         test_boundary_values()
+        test_runtime_secrets_protection()
         
         print("=" * 60)
         print("✓ ALL TESTS PASSED")


### PR DESCRIPTION
## 📝 Description
`RuntimeProtectionMiddleware` in `security_hygiene.py` was fully implemented to scan
incoming request bodies for cleartext secrets (AWS keys, Stripe secrets, raw PII) but
was never registered in the FastAPI app — leaving the protection completely inactive.

This PR activates the middleware, refactors it from `BaseHTTPMiddleware` to raw ASGI
(to fix a Starlette body-read race condition), adds path exclusions for image/file upload
routes, and covers it with integration tests. Also fixes a pre-existing syntax error in
`persistence/repositories.py` (unclosed parenthesis on line 225).

---

## 🎯 Type of Change
- [x] 🐞 Bug fix
- [x] ✨ New feature

---

## 🔗 Related Issue
Closes #1738 

---

## 🧪 Testing Done
- [x] Tested locally
- [x] Verified API / backend changes (if applicable)

**Test cases added in `test_validation_simple.py`:**
- POST with embedded AWS key (`AKIA...`) → blocked with `400 Bad Request`
- POST without secrets → passes middleware, hits route normally
- POST to excluded path (e.g. `/api/crop-disease/analyze-image`) → not blocked even with secret-like payload

---

## ✅ Checklist
- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

---

## 📌 Additional Notes
- Refactored to raw ASGI `__call__(scope, receive, send)` to avoid Starlette's
  `BaseHTTPMiddleware` bug where reading the body causes `RuntimeError: Unexpected
  message received: http.request` on subsequent client calls.
- Excluded paths: `/docs`, `/openapi.json`, `/static`, `/api/crop-disease/analyze-image`,
  `/api/quality/assess`, `/api/gemini/analyze-image`
