### PR TITLE
Fix: unused import duplicate statements

### DIFF
--- a/main.py
+++ b/main.py
@@ -12,7 +12,6 @@ import hashlib
 import collections
 import threading
 import time
-import asyncio
 from datetime import datetime, timedelta
 from typing import Optional, Dict, Any
 
@@ -50,15 +49,11 @@ class RAGQuery(BaseModel):
     top_k: int = Field(default=3, ge=1, le=5)
 
 # Rate Limiting
-from slowapi import Limiter
-from slowapi.errors import RateLimitExceeded
 from rate_limit_config import build_limiter, rate_limit_exceeded_handler
 
 import firebase_admin
 from cryptography.hazmat.primitives import serialization
 from cryptography.hazmat.primitives.asymmetric import ed25519
-from fastapi import FastAPI, HTTPException, Request
-from fastapi.middleware.cors import CORSMiddleware
 from firebase_admin import auth, credentials, firestore, storage
 from slowapi import Limiter, _rate_limit_exceeded_handler
 from slowapi.errors import RateLimitExceeded
@@ -114,10 +109,7 @@ from weather_alerts import weather_service
 from reportlab.lib.pagesizes import letter
 from reportlab.pdfgen import canvas
 from reportlab.lib import colors
-from reportlab.lib.pagesizes import letter
 from reportlab.lib.units import inch
-from cryptography.hazmat.primitives.asymmetric import ed25519
-from cryptography.hazmat.primitives import serialization
 
 # KMS Support
 try:

--- a/main.py
+++ b/main.py
@@ -2,13 +2,9 @@
 import os
 import asyncio
 import itertools
-import io
-import json
 import logging
 import math
 import re
-import joblib
-import hashlib
 import collections
 import threading
 import time


### PR DESCRIPTION
## 📝 Description
Multiple modules imported twice (FastAPI, CORSMiddleware, reportlab.lib.pagesizes), cluttering the code and potentially causing confusion.
---

## 🎯 Type of Change
Please select the type of change this PR introduces:

- [ ] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [x] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue
Closes #1766 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization improvements with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->