### PR TITLE
fix: missing OrderedDict import added

### DIFF
--- a/image_processing_queue.py
+++ b/image_processing_queue.py
@@ -8,7 +8,7 @@ Provides:
 - Async processing with callbacks
 - Optional Redis support for distributed deployments
 """
-
+from collections import OrderedDict
 import asyncio
 import uuid
 import json


### PR DESCRIPTION
## 📝 Description
LRUCache class uses OrderedDict but collections.OrderedDict is never imported, causing NameError. 
This PR fixes this issue, added 'from collections import OrderedDict' in the file.


---

## 🎯 Type of Change
Please select the type of change this PR introduces:

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue
Closes #1761 

---

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal maintenance update with no user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->