### PR TITLE
fix(startup): hoist voice_assistant_router initialization before lifespan

### DIFF
--- a/main.py
+++ b/main.py
@@ -155,6 +155,20 @@ logging.basicConfig(
 logger = logging.getLogger(__name__)
 logger.addFilter(_context_filter)
 
+# Optional voice assistant router.
+# Declared here, before the lifespan function, so both the lifespan
+# startup handler (which calls init_voice_assistant) and the module-level
+# app.include_router call below can reference the same variable. If the
+# import fails the variable stays None and all call sites guard with
+# "if voice_assistant_router is not None" before use.
+voice_assistant_router = None
+
+try:
+    from backend.routers import voice_assistant as voice_assistant_router
+except Exception as exc:
+    logger.warning("Voice assistant router import skipped: %s", exc)
+
+
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     """
@@ -1474,143 +1488,6 @@ app.add_middleware(
     exclude_paths=["/docs", "/openapi.json", "/static", "/api/crop-disease/analyze-image", "/api/quality/assess", "/api/gemini/analyze-image"]
 )
 logger.info(print_rbac_matrix())
-
-# Import the voice assistant router at module level so app.include_router() can
-# reference it during router registration below. Its internal state is
-# initialized inside lifespan (above) once all domain engines are ready.
-# =============================================================================
-# OPTIONAL VOICE ASSISTANT ROUTER IMPORT
-# =============================================================================
-#
-# The voice assistant module is treated as an OPTIONAL feature.
-#
-# Why?
-#
-# In production systems some features may depend on:
-#
-# - extra ML libraries
-# - speech models
-# - external APIs
-# - GPU dependencies
-# - audio processing packages
-#
-# If any dependency is missing, importing the router could crash
-# the entire FastAPI application during startup.
-#
-# This defensive import pattern prevents total backend failure.
-#
-# -----------------------------------------------------------------------------
-# WHAT THIS CODE DOES
-# -----------------------------------------------------------------------------
-#
-# 1. Initializes the variable as None
-#
-#       voice_assistant_router = None
-#
-# This guarantees the variable always exists even if import fails.
-#
-# -----------------------------------------------------------------------------
-# 2. Attempts to import the optional router
-#
-#       from backend.routers import voice_assistant as voice_assistant_router
-#
-# If successful:
-#
-# - voice assistant APIs become available
-# - routes can later be registered safely
-#
-# -----------------------------------------------------------------------------
-# 3. Handles import failure gracefully
-#
-# If the import crashes because of:
-#
-# - missing package
-# - syntax error
-# - model loading failure
-# - missing environment variable
-# - incompatible dependency
-#
-# the backend DOES NOT crash.
-#
-# Instead:
-#
-#       logger.warning(...)
-#
-# records the issue in logs while allowing the rest
-# of the API system to continue working normally.
-#
-# -----------------------------------------------------------------------------
-# WHY THIS IS GOOD PRACTICE
-# -----------------------------------------------------------------------------
-#
-# Benefits:
-#
-# - improves backend reliability
-# - prevents startup crashes
-# - supports modular architecture
-# - allows optional AI features
-# - safer deployments
-# - easier debugging
-#
-# This pattern is commonly used in:
-#
-# - plugin systems
-# - AI microservices
-# - enterprise APIs
-# - feature-flag architectures
-#
-# -----------------------------------------------------------------------------
-# IMPORTANT NOTE
-# -----------------------------------------------------------------------------
-#
-# Because the router may remain None,
-# route registration MUST check:
-#
-#       if voice_assistant_router is not None:
-#
-# before calling:
-#
-#       app.include_router(...)
-#
-# Otherwise FastAPI may crash with:
-#
-#       AttributeError
-#
-# -----------------------------------------------------------------------------
-# EXAMPLE FLOW
-# -----------------------------------------------------------------------------
-#
-# SUCCESS CASE:
-#
-#   Import succeeds
-#   -> router loads
-#   -> APIs enabled
-#
-# FAILURE CASE:
-#
-#   Import fails
-#   -> warning logged
-#   -> backend still starts
-#   -> voice APIs disabled only
-#
-# -----------------------------------------------------------------------------
-# FINAL RESULT
-# -----------------------------------------------------------------------------
-#
-# This is a safe and production-friendly optional import pattern.
-#
-# =============================================================================
-
-voice_assistant_router = None
-
-try:
-    from backend.routers import voice_assistant as voice_assistant_router
-
-except Exception as exc:
-    logger.warning(
-        "Voice assistant router import skipped: %s",
-        exc
-    )
 
 # Router registration
 app.include_router(ml.router, prefix="/api/yield", tags=["ML Prediction"])


### PR DESCRIPTION
## Related Issue

Closes #1767

## Problem

`voice_assistant_router` was initialized to `None` and conditionally imported at the very bottom of `main.py` (previously around line 1604), well after the `lifespan` function definition at line 159. The `lifespan` function referenced `voice_assistant_router` at line 324, relying on the implicit guarantee that module-level code runs before `lifespan` is invoked by FastAPI.

This ordering was invisible at the point of use: a developer reading the `lifespan` function had no way to see where `voice_assistant_router` was initialized without scrolling ~1400 lines down. The pattern was also fragile: any future refactor that moved the initialization block inside the lifespan function (a natural next step) would silently break the startup sequence if the None guard was not preserved.

## Root Cause

Python executes module-level statements sequentially at import time. `lifespan` is only called later, so the bottom-of-file initialization is guaranteed to have run before `lifespan` executes. However, this dependency was implicit and undocumented at the point of use.

## Fix

Moved the initialization block to immediately before the `@asynccontextmanager` decorator, making the initialization order explicit in the source:

```python
# Optional voice assistant router.
# Declared here, before the lifespan function, so both the lifespan
# startup handler (which calls init_voice_assistant) and the module-level
# app.include_router call below can reference the same variable.
voice_assistant_router = None

try:
    from backend.routers import voice_assistant as voice_assistant_router
except Exception as exc:
    logger.warning("Voice assistant router import skipped: %s", exc)


@asynccontextmanager
async def lifespan(app: FastAPI):
    ...
```

The variable is now visibly in scope before `lifespan` is defined. The two existing None guards (at the `init_voice_assistant` call inside `lifespan` and at `app.include_router`) are left unchanged.

Also removed the 120-line documentation block that explained the optional-import pattern in detail. The pattern is self-evident from the code and the short comment at the new location.

## Files Changed

| File | Change |
|---|---|
| `main.py` | Move `voice_assistant_router` init block from line ~1604 to before `lifespan`; remove verbose inline comment block |

## Behaviour

No change to runtime behaviour. The same initialization logic runs at the same point in the process lifecycle. The only change is source-code location.

---

Could you please add appropriate labels to this PR when you get a chance? It would help with tracking. Thank you!