### PR TITLE
fix(csrf): import verify_csrf_token_dependency in main.py

### DIFF
--- a/main.py
+++ b/main.py
@@ -94,7 +94,7 @@ from ml.preprocessing import UnknownCategoryError, MissingFeatureError
 from alert_rules import generate_alerts
 from whatsapp_service import send_whatsapp_message, format_alert_message
 from whatsapp_store import subscriber_store
-from csrf_protection import generate_token, reject_cross_origin
+from csrf_protection import generate_token, reject_cross_origin, verify_csrf_token_dependency
 from ml.security import verify_and_load_joblib
 from error_recovery_middleware import ErrorRecoveryMiddleware
 from security_hygiene import RuntimeProtectionMiddleware


### PR DESCRIPTION
## Related Issue

Closes #1762

## Problem

`csrf_middleware` in `main.py` called `verify_csrf_token_dependency(request)` but the name was never imported. The function exists in `csrf_protection.py` (line 93) and is already imported by `feedback_api.py` and `backend/routers/platform.py`, but `main.py` only imported `generate_token` and `reject_cross_origin`.

```python
# Before
from csrf_protection import generate_token, reject_cross_origin
```

Any non-GET/HEAD/OPTIONS request (except the WhatsApp webhook) would raise `NameError: name 'verify_csrf_token_dependency' is not defined`, causing the CSRF middleware to crash the request with an unhandled 500 instead of returning the intended 403.

## Fix

Added `verify_csrf_token_dependency` to the existing import at line 97:

```python
from csrf_protection import generate_token, reject_cross_origin, verify_csrf_token_dependency
```

## Files Changed

| File | Change |
|---|---|
| `main.py` | Add `verify_csrf_token_dependency` to the `csrf_protection` import |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!