### PR TITLE
fix(startup): remove silent exception swallow in init_ml_pipeline

### DIFF
--- a/main.py
+++ b/main.py
@@ -1356,17 +1356,14 @@ def get_signing_keys():
 
 
 def init_ml_pipeline() -> None:
-    try:
-        xgb_adapter = XGBoostAdapter()
-        model_path = "yield_model.joblib"
-        if os.path.exists(model_path):
-            xgb_adapter.load(model_path)
-            ModelRegistry.register("xgboost", xgb_adapter)
-            logger.info("ML Pipeline: Registered XGBoost model")
-        else:
-            logger.warning("ML Pipeline: %s not found", model_path)
-    except Exception as exc:
-        logger.warning("ML Pipeline initialization failed: %s", exc)
+    xgb_adapter = XGBoostAdapter()
+    model_path = "yield_model.joblib"
+    if os.path.exists(model_path):
+        xgb_adapter.load(model_path)
+        ModelRegistry.register("xgboost", xgb_adapter)
+        logger.info("ML Pipeline: Registered XGBoost model")
+    else:
+        logger.warning("ML Pipeline: %s not found, skipping registration", model_path)
 
 
 # Observability setup


### PR DESCRIPTION
## Related Issue

Closes #1760

## Problem

`init_ml_pipeline()` wrapped its entire body in `try/except Exception` and logged a warning on failure. Any error from `XGBoostAdapter()` instantiation or `xgb_adapter.load()` was silently swallowed, allowing the server to start with a non-functional ML pipeline. Prediction requests then failed at runtime with opaque 500 errors.

## Fix

Removed the `try/except` wrapper so exceptions propagate to the `lifespan` function, where the existing handler logs the failure with full traceback and re-raises, causing the server to refuse to start rather than serve broken predictions.

A missing model file is still handled gracefully with a warning since that is a recoverable condition.

## Files Changed

| File | Change |
|---|---|
| `main.py` | Remove `try/except` from `init_ml_pipeline`; keep missing-file warning |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!