### PR TITLE
fix(rbac): add explicit __all__ to declare public exports

### DIFF
--- a/rbac.py
+++ b/rbac.py
@@ -27,6 +27,18 @@ from typing import Callable, Dict, List, Optional
 import firebase_admin
 from fastapi import HTTPException, Request, status
 from starlette.middleware.base import BaseHTTPMiddleware
+
+__all__ = [
+    "RBACManager",
+    "Permission",
+    "RBACMiddleware",
+    "RBACMatrix",
+    "AuthContext",
+    "Role",
+    "require_permission",
+    "print_rbac_matrix",
+]
+
 from firebase_admin import auth as firebase_auth, firestore
 
 logger = logging.getLogger(__name__)


### PR DESCRIPTION
## Related Issue

Closes #1763

## Problem

`rbac.py` had no `__all__` list. Without an explicit public interface, it was impossible to tell at a glance which names were intended to be imported by other modules. `main.py` imports `RBACManager`, `Permission`, `RBACMiddleware`, and `print_rbac_matrix`, but nothing prevented accidental removal or renaming of those names without immediate feedback.

## Fix

Added `__all__` enumerating all names currently consumed by `main.py` and other modules. Any future removal or renaming of a listed name will surface as an `ImportError` at import time rather than silently breaking callers.

## Files Changed

| File | Change |
|---|---|
| `rbac.py` | Add `__all__` listing `RBACManager`, `Permission`, `RBACMiddleware`, `RBACMatrix`, `AuthContext`, `Role`, `require_permission`, `print_rbac_matrix` |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!