### PR TITLE
fix(cache): evict oldest entry when TTL eviction leaves weather cache over limit

### DIFF
--- a/weather_alerts.py
+++ b/weather_alerts.py
@@ -333,6 +333,14 @@ class WeatherAlertsService:
                         self._weather_cache[cache_key] = (weather, datetime.now())
                         if len(self._weather_cache) > self._max_cache_size:
                             self._evict_expired()
+                            # If all entries are still within TTL, _evict_expired removes
+                            # nothing. Evict the oldest entry to enforce the hard cap.
+                            if len(self._weather_cache) > self._max_cache_size:
+                                oldest_key = min(
+                                    self._weather_cache,
+                                    key=lambda k: self._weather_cache[k][1]
+                                )
+                                del self._weather_cache[oldest_key]
                         return weather
         except asyncio.TimeoutError:
             logger.warning(f"Weather API timeout for {location}")


### PR DESCRIPTION
## Related Issue

Closes #1759

## Problem

`WeatherAlertsService._evict_expired()` only removes entries older than `cache_duration`. If all cached entries are within TTL, every call to `fetch_weather` adds one entry, `_evict_expired` removes nothing, and `_weather_cache` grows past `_max_cache_size` without bound.

## Fix

After calling `_evict_expired()`, added a second size check. If the cache is still over `_max_cache_size`, the entry with the oldest timestamp is found with `min()` and removed unconditionally, enforcing a hard upper bound.

```python
if len(self._weather_cache) > self._max_cache_size:
    self._evict_expired()
    if len(self._weather_cache) > self._max_cache_size:
        oldest_key = min(self._weather_cache, key=lambda k: self._weather_cache[k][1])
        del self._weather_cache[oldest_key]
```

## Files Changed

| File | Change |
|---|---|
| `weather_alerts.py` | Add LRU fallback eviction after TTL eviction in `fetch_weather` |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!