### PR TITLE
fix(feedback): guard against non-numeric Content-Length in validate_request

### DIFF
--- a/feedback_api.py
+++ b/feedback_api.py
@@ -207,9 +207,14 @@ async def validate_request(request: Request) -> dict:
         raise HTTPException(status_code=415, detail="Unsupported media type")
     
     # Check request size
-    content_length = request.headers.get("content-length", 0)
-    if int(content_length) > 10240:  # 10KB max
-        raise HTTPException(status_code=413, detail="Request too large")
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            length_int = int(content_length)
+        except (ValueError, TypeError):
+            raise HTTPException(status_code=400, detail="Invalid Content-Length header")
+        if length_int > 10240:  # 10KB max
+            raise HTTPException(status_code=413, detail="Request too large")
     
     return {}
 


### PR DESCRIPTION
## Related Issue

Closes #1757

## Problem

`validate_request` called `int()` on the `Content-Length` header with no guard:

```python
content_length = request.headers.get("content-length", 0)
if int(content_length) > 10240:
```

A client sending `Content-Length: abc` or an empty string caused an unhandled `ValueError`, returning an unformatted HTTP 500 instead of HTTP 400.

## Fix

```python
content_length = request.headers.get("content-length")
if content_length is not None:
    try:
        length_int = int(content_length)
    except (ValueError, TypeError):
        raise HTTPException(status_code=400, detail="Invalid Content-Length header")
    if length_int > 10240:
        raise HTTPException(status_code=413, detail="Request too large")
```

When the header is absent the check is skipped entirely (valid for requests without a body). A non-numeric value raises HTTP 400.

## Files Changed

| File | Change |
|---|---|
| `feedback_api.py` | Wrap `int(content_length)` in try/except; skip check when header is absent |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!