### PR TITLE
fix(feedback): sort feedbacks by timestamp before slicing recent entries

### DIFF
--- a/feedback_api.py
+++ b/feedback_api.py
@@ -430,7 +430,11 @@ async def get_feedback_stats(
         # Strip PII fields before returning to the caller.
         # Use the module-level _PII_FIELDS constant — avoids shadowing it
         # with a local re-definition that could silently diverge over time.
-        recent_raw = feedbacks[-10:] if len(feedbacks) > 10 else feedbacks
+        # Sort by timestamp descending before slicing so recent_feedbacks
+        # always contains the 10 most recently submitted entries, not an
+        # arbitrary tail of whatever order Firestore stream() returned.
+        feedbacks.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
+        recent_raw = feedbacks[:10]
         recent = [
             {k: v for k, v in entry.items() if k not in _PII_FIELDS}
             for entry in recent_raw


### PR DESCRIPTION
## Related Issue

Closes #1758

## Problem

`get_feedback_stats` sliced the last 10 items from the raw Firestore `stream()` result:

```python
recent_raw = feedbacks[-10:] if len(feedbacks) > 10 else feedbacks
```

Firestore `stream()` does not guarantee insertion order, so the slice returned an arbitrary 10 documents rather than the 10 most recently submitted.

## Fix

Sort the collected list by `timestamp` in descending order before slicing, then take the first 10:

```python
feedbacks.sort(key=lambda e: e.get("timestamp", ""), reverse=True)
recent_raw = feedbacks[:10]
```

`timestamp` is stored as an ISO-8601 string at submission time, so lexicographic descending sort matches chronological descending order.

## Files Changed

| File | Change |
|---|---|
| `feedback_api.py` | Sort `feedbacks` by `timestamp` desc before slicing `recent_raw` |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!