### PR TITLE
fix(crop): align CropRecommendationRequest Pydantic bounds with ValidationRules

### DIFF
--- a/routers/crop_recommendation.py
+++ b/routers/crop_recommendation.py
@@ -185,10 +185,10 @@ recommendation_cache = RecommendationCache()
 
 # ── Request Model ─────────────────────────────────────────────────────────────
 class CropRecommendationRequest(BaseModel):
-    soil_ph: float = Field(..., ge=4.0, le=9.0)
-    nitrogen: float = Field(..., ge=0, le=100)
-    phosphorus: float = Field(..., ge=0, le=50)
-    potassium: float = Field(..., ge=0, le=300)
+    soil_ph: float = Field(..., ge=4.5, le=8.5)
+    nitrogen: float = Field(..., ge=0, le=500)
+    phosphorus: float = Field(..., ge=0, le=100)
+    potassium: float = Field(..., ge=0, le=500)
     location: str
     season: str = "kharif"
     area_size: Optional[float] = None


### PR DESCRIPTION
## Related Issue

Closes #1756

## Problem

`CropRecommendationRequest` used `Field` bounds that were narrower than the `ValidationRules` dataclass. Pydantic rejects requests before they reach `validate_soil_parameters`, so valid agronomic values were silently returned as HTTP 422:

| Field | Pydantic max/min | ValidationRules max/min |
|---|---|---|
| `nitrogen` max | 100 | 500 |
| `phosphorus` max | 50 | 100 |
| `potassium` max | 300 | 500 |
| `soil_ph` min | 4.0 | 4.5 |
| `soil_ph` max | 9.0 | 8.5 |

## Fix

Updated the four `Field` definitions to match `ValidationRules`:

```python
soil_ph: float = Field(..., ge=4.5, le=8.5)
nitrogen: float = Field(..., ge=0, le=500)
phosphorus: float = Field(..., ge=0, le=100)
potassium: float = Field(..., ge=0, le=500)
```

## Files Changed

| File | Change |
|---|---|
| `routers/crop_recommendation.py` | Update 4 `Field` bounds to match `ValidationRules` constants |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!