### PR TITLE
fix(crop): include area_size in recommendation cache key

### DIFF
--- a/routers/crop_recommendation.py
+++ b/routers/crop_recommendation.py
@@ -148,15 +148,15 @@ class RecommendationCache:
         self._lock = threading.Lock()
 
     def _generate_key(self, ph: float, nitrogen: float, phosphorus: float,
-                     potassium: float, season: str) -> str:
+                     potassium: float, season: str, area_size: Optional[float]) -> str:
         """Generate cache key from parameters"""
-        key_data = f"{ph}:{nitrogen}:{phosphorus}:{potassium}:{season}"
+        key_data = f"{ph}:{nitrogen}:{phosphorus}:{potassium}:{season}:{area_size}"
         return hashlib.md5(key_data.encode()).hexdigest()
 
     def get(self, ph: float, nitrogen: float, phosphorus: float,
-            potassium: float, season: str) -> Optional[Dict]:
+            potassium: float, season: str, area_size: Optional[float] = None) -> Optional[Dict]:
         """Get cached recommendation, or None if absent or expired."""
-        key = self._generate_key(ph, nitrogen, phosphorus, potassium, season)
+        key = self._generate_key(ph, nitrogen, phosphorus, potassium, season, area_size)
         with self._lock:
             entry = self.cache.get(key)
             if entry is None:
@@ -168,9 +168,9 @@ class RecommendationCache:
             return result
 
     def set(self, ph: float, nitrogen: float, phosphorus: float,
-            potassium: float, season: str, result: Dict):
+            potassium: float, season: str, area_size: Optional[float], result: Dict):
         """Cache recommendation result with the current timestamp."""
-        key = self._generate_key(ph, nitrogen, phosphorus, potassium, season)
+        key = self._generate_key(ph, nitrogen, phosphorus, potassium, season, area_size)
         with self._lock:
             if len(self.cache) >= self._MAX_SIZE:
                 # Evict the oldest entry to maintain the size cap
@@ -540,7 +540,7 @@ async def recommend_crops(req: CropRecommendationRequest):
 
         # Check cache for existing recommendation
         cached_result = recommendation_cache.get(
-            req.soil_ph, req.nitrogen, req.phosphorus, req.potassium, req.season
+            req.soil_ph, req.nitrogen, req.phosphorus, req.potassium, req.season, req.area_size
         )
         if cached_result:
             logger.info("Returning cached recommendation")
@@ -625,7 +625,7 @@ async def recommend_crops(req: CropRecommendationRequest):
 
         # Cache the result for future queries
         recommendation_cache.set(
-            req.soil_ph, req.nitrogen, req.phosphorus, req.potassium, req.season, result
+            req.soil_ph, req.nitrogen, req.phosphorus, req.potassium, req.season, req.area_size, result
         )
         logger.info(f"Cached recommendation for {req.location}/{req.season}")
 


### PR DESCRIPTION
## Related Issue

Closes #1752

## Problem

`RecommendationCache._generate_key()` built its key from `soil_ph`, `nitrogen`, `phosphorus`, `potassium`, and `season` only. `area_size` was excluded.

Fertilizer recommendation strings reference `area_size` directly (e.g. "For 5.0 hectares: Apply Urea 100kg/ha"). A second request with the same soil parameters but `area_size=10.0` received a cached response labeled for 5.0 hectares, giving the farmer incorrect fertilizer quantities.

## Fix

Added `area_size` as the sixth parameter to `_generate_key`, `get`, and `set`. Updated both call sites (`recommendation_cache.get` and `recommendation_cache.set`) to pass `req.area_size`.

```python
key_data = f"{ph}:{nitrogen}:{phosphorus}:{potassium}:{season}:{area_size}"
```

## Files Changed

| File | Change |
|---|---|
| `routers/crop_recommendation.py` | Add `area_size` to `_generate_key`, `get`, `set`, and both call sites |

---

Could you please add appropriate labels to this PR? It would help with tracking. Thank you!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved crop recommendation accuracy by ensuring recommendations properly account for different area sizes. Previously, cached recommendations from one area size could be incorrectly reused for other sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->