### PR TITLE
fix(voice): evict oldest 25% when rate limit store is full (#1790)

### DIFF
--- a/backend/routers/voice_assistant.py
+++ b/backend/routers/voice_assistant.py
@@ -186,18 +186,12 @@ def _check_rate_limit(uid: str) -> bool:
         _prune_rate_limit_store(now)
 
         if len(_rate_limit_store) >= RATE_LIMIT_MAX_ENTRIES:
-            cutoff = now - RATE_LIMIT_WINDOW
             sorted_uids = sorted(
-                _rate_limit_store.keys(),
+                _rate_limit_store,
                 key=lambda u: _rate_limit_store[u][1],
             )
-            evicted = 0
-            for uid_candidate in sorted_uids:
-                if evicted >= max(1, len(sorted_uids) // 4):
-                    break
-                if _rate_limit_store[uid_candidate][1] < cutoff:
-                    _rate_limit_store.pop(uid_candidate, None)
-                    evicted += 1
+            for uid_candidate in sorted_uids[: max(1, len(sorted_uids) // 4)]:
+                _rate_limit_store.pop(uid_candidate, None)
 
         if uid not in _rate_limit_store:
             _rate_limit_store[uid] = (1, now)


### PR DESCRIPTION
## Summary
- Fixes rate limit store eviction in `backend/routers/voice_assistant.py` when `_rate_limit_store` reaches `RATE_LIMIT_MAX_ENTRIES` (10,000).
- Previously, capacity eviction only removed entries older than `RATE_LIMIT_WINDOW`. Under sustained load, all entries could be recent, so nothing was evicted and new `uid`s could not be registered.
- Now evicts the oldest 25% of entries (at least 1), sorted by `window_start`, so new users are not permanently blocked.

Closes #1790

## Test plan
- [ ] Fill `_rate_limit_store` to `RATE_LIMIT_MAX_ENTRIES` with entries whose `window_start` is within the current window.
- [ ] Call `_check_rate_limit` with a new `uid` and confirm it returns `True` and the new `uid` is stored.
- [ ] Confirm existing per-uid rate limits (10 requests / 60s) still work after eviction.
- [ ] Smoke-test voice upload endpoint under normal load.