### PR TITLE
Log safe rate limit decorator failures

### DIFF
--- a/backend/core/limiter.py
+++ b/backend/core/limiter.py
@@ -1,9 +1,14 @@
+import logging
+
 from slowapi.errors import RateLimitExceeded
 
 from rate_limit_config import (
     build_limiter,
     rate_limit_exceeded_handler,
 )
+
+
+logger = logging.getLogger(__name__)
 
 
 def setup_rate_limiter(app):
@@ -25,7 +30,13 @@ def setup_rate_limiter(app):
             try:
                 return original_limit(rate)(fn)
 
-            except Exception:
+            except Exception as exc:
+                logger.error(
+                    "Rate limit decorator failed for rate=%s on %s: %s. Endpoint is UNPROTECTED.",
+                    rate,
+                    getattr(fn, "__name__", fn),
+                    exc,
+                )
                 return fn
 
         return decorator

--- a/tests/test_limiter_safe_limit.py
+++ b/tests/test_limiter_safe_limit.py
@@ -1,0 +1,37 @@
+from types import SimpleNamespace
+
+from backend.core import limiter as limiter_module
+
+
+class _FakeApp:
+    def __init__(self):
+        self.state = SimpleNamespace()
+        self.exception_handlers = {}
+
+    def add_exception_handler(self, exception_class, handler):
+        self.exception_handlers[exception_class] = handler
+
+
+class _FailingLimiter:
+    def limit(self, rate):
+        def decorator(fn):
+            raise ValueError("invalid rate")
+
+        return decorator
+
+
+def test_safe_limit_logs_failed_decorator(monkeypatch, caplog):
+    monkeypatch.setattr(limiter_module, "build_limiter", lambda default_limits: _FailingLimiter())
+    caplog.set_level("ERROR", logger=limiter_module.__name__)
+    app = _FakeApp()
+
+    limiter = limiter_module.setup_rate_limiter(app)
+
+    def endpoint():
+        return {"ok": True}
+
+    decorated = limiter.limit("abc/minute")(endpoint)
+
+    assert decorated is endpoint
+    assert "Rate limit decorator failed for rate=abc/minute on endpoint" in caplog.text
+    assert "Endpoint is UNPROTECTED" in caplog.text


### PR DESCRIPTION
Closes #1798

Added error logging when safe_limit fails to apply the original rate limit decorator. The log now includes the rate, endpoint function, exception message, and a clear warning that the endpoint is unprotected.

Also added a regression test covering the fallback path.

Verification:
- Direct safe_limit logging regression check passed.
- Could not run pytest locally because pytest and slowapi are not installed in this environment.