### PR TITLE
Avoid duplicate finance token verification

### DIFF
--- a/backend/routers/finance.py
+++ b/backend/routers/finance.py
@@ -3,6 +3,7 @@ import logging
 from fastapi import APIRouter, Request, HTTPException
 from pydantic import BaseModel, Field
 from typing import Optional
+from rbac import RBACMatrix, Role
 from rbac_audit import audit_rbac_event
 
 logger = logging.getLogger(__name__)
@@ -32,38 +33,22 @@ def init_finance(ffa, rbac, perm):
     Permission = perm
 
 
-def _extract_uid_from_verified_token(request: Request) -> Optional[str]:
-    """
-    Extract the Firebase UID by cryptographically verifying the JWT token.
-
-    Performs full signature verification via ``firebase_admin.auth.verify_id_token``.
-    This is safe to call regardless of whether upstream verification has occurred,
-    because every invocation independently validates the token's signature, expiry,
-    and issuer.
-    """
-    from firebase_admin import auth as firebase_auth
-
-    auth_header = request.headers.get("Authorization", "")
-    if not auth_header.startswith("Bearer "):
-        return None
-    token = auth_header.split(" ", 1)[1]
-    try:
-        decoded = firebase_auth.verify_id_token(token)
-        return decoded.get("uid")
-    except Exception as exc:
-        logger.error("Failed to verify JWT token: %s", exc)
-        return None
+def _context_has_permission(ctx, permission) -> bool:
+    return RBACMatrix.has_permission(Role(ctx.role), permission)
 
 
-async def _has_permission(request: Request, permission) -> bool:
-    """Return True if the caller has the given permission (no exception raised)."""
-    try:
-        await rbac_manager.raise_if_unauthorized(request, [permission], require_all=False)
-        return True
-    except HTTPException as e:
-        if e.status_code == 403:
-            return False
-        raise
+async def _authorize_with_context(request: Request, permissions, require_all: bool = False):
+    ctx = await rbac_manager.resolve_auth_context(request, allow_unauthenticated=False)
+    checks = [_context_has_permission(ctx, permission) for permission in permissions]
+    has_permission = all(checks) if require_all else any(checks)
+    if not has_permission:
+        logger.warning(
+            "Unauthorized access attempt with role: %s, required: %s",
+            ctx.role,
+            [permission.value for permission in permissions],
+        )
+        raise HTTPException(status_code=403, detail="Insufficient permissions")
+    return ctx
 
 
 @router.post("/analyze")
@@ -86,16 +71,8 @@ async def create_finance_application(request: Request, body: FinanceAssessmentRe
     if farm_finance_ai is None or rbac_manager is None:
         raise HTTPException(status_code=500, detail="Not initialized")
     try:
-        await rbac_manager.raise_if_unauthorized(request, [Permission.FINANCE_CREATE], require_all=False)
-        # Bind the application to the authenticated caller so ownership can be
-        # enforced on subsequent reads.  The token was already verified by
-        # raise_if_unauthorized above; decode the payload without a second
-        # cryptographic verification to avoid duplicate latency.
-        owner_uid = _extract_uid_from_verified_token(request)
-        if owner_uid is None:
-            # raise_if_unauthorized passed, so the token is valid — a missing
-            # uid here indicates a malformed token that should not proceed.
-            raise HTTPException(status_code=401, detail="Unable to determine caller identity")
+        ctx = await _authorize_with_context(request, [Permission.FINANCE_CREATE], require_all=False)
+        owner_uid = ctx.uid
         application = farm_finance_ai.create_application(body.model_dump(), owner_uid=owner_uid)
         return {"success": True, "data": application}
     except HTTPException:
@@ -120,19 +97,16 @@ async def get_finance_application(application_id: str, request: Request, resourc
         raise HTTPException(status_code=500, detail="Not initialized")
     try:
         # Require at least one of the two read permissions
-        await rbac_manager.raise_if_unauthorized(
+        ctx = await _authorize_with_context(
             request,
             [Permission.FINANCE_READ_OWN, Permission.FINANCE_READ_ALL],
             require_all=False,
         )
 
-        caller_uid = _extract_uid_from_verified_token(request)
-        ctx = await rbac_manager.resolve_auth_context(request, allow_unauthenticated=False)
-
         # Admins/experts with FINANCE_READ_ALL can override ownership in-tenant.
         # Farmers with only FINANCE_READ_OWN remain scoped to their own records.
-        has_read_all = await _has_permission(request, Permission.FINANCE_READ_ALL)
-        owner_uid_filter = caller_uid
+        has_read_all = _context_has_permission(ctx, Permission.FINANCE_READ_ALL)
+        owner_uid_filter = ctx.uid
 
         if has_read_all:
             try:

--- a/tests/test_finance_auth_context.py
+++ b/tests/test_finance_auth_context.py
@@ -1,0 +1,89 @@
+import pytest
+from fastapi import Request
+
+from backend.routers import finance
+from rbac import AuthContext, Permission
+
+
+def _request() -> Request:
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/finance/applications",
+        "headers": [(b"authorization", b"Bearer test-token")],
+    }
+
+    async def receive():
+        return {"type": "http.request", "body": b"", "more_body": False}
+
+    return Request(scope, receive)
+
+
+def _body() -> finance.FinanceAssessmentRequest:
+    return finance.FinanceAssessmentRequest(
+        farmer_name="Meera",
+        crop_type="rice",
+        acreage=8,
+        annual_revenue=1200000,
+        annual_operating_cost=700000,
+        existing_debt=90000,
+        emergency_fund=200000,
+        credit_score=770,
+        requested_loan_amount=320000,
+        loan_tenure_months=36,
+    )
+
+
+class _FakeRBAC:
+    def __init__(self):
+        self.resolve_calls = 0
+
+    async def resolve_auth_context(self, request, *, allow_unauthenticated=False):
+        self.resolve_calls += 1
+        return AuthContext(uid="farmer-123", role="farmer")
+
+    async def raise_if_unauthorized(self, *args, **kwargs):
+        raise AssertionError("finance handler should use the resolved auth context")
+
+    def can_admin_or_expert_override(self, *args, **kwargs):
+        return False
+
+
+class _FakeFinanceAI:
+    def __init__(self):
+        self.created_owner_uid = None
+        self.read_owner_uid = None
+
+    def create_application(self, payload, owner_uid=None):
+        self.created_owner_uid = owner_uid
+        return {"application_id": "app-1", "owner_uid": owner_uid}
+
+    def get_application(self, application_id, owner_uid=None):
+        self.read_owner_uid = owner_uid
+        return {"application_id": application_id, "owner_uid": owner_uid}
+
+
+@pytest.mark.asyncio
+async def test_create_application_uses_resolved_auth_context_uid():
+    engine = _FakeFinanceAI()
+    rbac = _FakeRBAC()
+    finance.init_finance(engine, rbac, Permission)
+
+    response = await finance.create_finance_application(_request(), _body())
+
+    assert response["success"] is True
+    assert engine.created_owner_uid == "farmer-123"
+    assert rbac.resolve_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_get_application_uses_resolved_auth_context_uid():
+    engine = _FakeFinanceAI()
+    rbac = _FakeRBAC()
+    finance.init_finance(engine, rbac, Permission)
+
+    response = await finance.get_finance_application("app-1", _request())
+
+    assert response["success"] is True
+    assert engine.read_owner_uid == "farmer-123"
+    assert rbac.resolve_calls == 1


### PR DESCRIPTION
Closes #1800

Updated the finance application create/read handlers to use the resolved AuthContext UID instead of verifying the Firebase JWT again.

Changes:
- Removed _extract_uid_from_verified_token()
- Added a context-based authorization helper for the affected finance handlers
- Used ctx.uid for application ownership binding and read filtering
- Added regression tests for create_finance_application() and get_finance_application()

Verification:
- Direct finance auth context regression checks passed.
- Could not run pytest locally because pytest is not installed in this environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive unit tests for finance application creation and retrieval with authorization validation.

* **Refactor**
  * Improved authorization handling for finance application operations to streamline permission checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->