### PR TITLE
feat(ensemble): lazy per-model loading with timeouts and health checks

### DIFF
--- a/celery_worker.py
+++ b/celery_worker.py
@@ -44,9 +44,11 @@ celery_app.conf.update(
 _model_lag = None
 _model_trend = None
 _ml_router = None
+_ensemble_stacker = None
 _model_lag_lock = threading.Lock()
 _model_trend_lock = threading.Lock()
 _ml_router_lock = threading.Lock()
+_ensemble_stacker_lock = threading.Lock()
 
 
 # =============================================================================
@@ -123,6 +125,24 @@ def _get_ml_router():
             raise
 
     return _ml_router
+
+
+def _get_ensemble_stacker():
+    global _ensemble_stacker
+
+    if _ensemble_stacker is None:
+        with _ensemble_stacker_lock:
+            if _ensemble_stacker is None:
+                try:
+                    from ml.ensemble import EnsembleStacker
+
+                    _ensemble_stacker = EnsembleStacker()
+                    logger.info("Ensemble stacker initialized successfully")
+                except Exception:
+                    logger.exception("Failed to initialize ensemble stacker")
+                    raise
+
+    return _ensemble_stacker
 
 
 # =============================================================================
@@ -262,6 +282,37 @@ def predict_yield_trend_task(self, data: list):
 
     except Exception:
         logger.exception("Trend prediction task failed")
+        raise
+
+
+@celery_app.task(
+    bind=True,
+    name="predict_ensemble_task",
+    autoretry_for=(Exception,),
+    retry_backoff=True,
+    retry_jitter=True,
+    retry_kwargs={"max_retries": 2},
+    soft_time_limit=30,
+    time_limit=45,
+)
+def predict_ensemble_task(self, input_data: dict):
+    """
+    Ensemble prediction with lazy per-model loading and graceful degradation.
+    """
+
+    try:
+        stacker = _get_ensemble_stacker()
+
+        result = stacker.predict(input_data)
+
+        return result
+
+    except RuntimeError as exc:
+        logger.error("Ensemble prediction failed: no models available")
+        raise
+
+    except Exception:
+        logger.exception("Ensemble prediction task failed")
         raise
 
 
@@ -652,6 +703,28 @@ def run_hyperparameter_optimization_task(
         "benchmark": benchmark,
         "config_path": str(config_path),
     }
+
+
+@celery_app.task(
+    bind=True,
+    name="ensemble_health_task",
+    soft_time_limit=10,
+    time_limit=15,
+)
+def ensemble_health_task(self):
+    """
+    Async ensemble health check for monitoring.
+    """
+    try:
+        stacker = _get_ensemble_stacker()
+
+        health = stacker.health()
+
+        return health
+
+    except Exception:
+        logger.exception("Ensemble health check failed")
+        raise
 
 
 @celery_app.task(

--- a/main.py
+++ b/main.py
@@ -85,6 +85,7 @@ from crop_quality_grading import CropQualityGrader
 from farm_finance_ai import FarmFinanceAI
 from feature_flags.routes import init_feature_flags, router as flags_router
 from ml.adapters.xgboost_adapter import XGBoostAdapter
+from ml.ensemble import get_ensemble_stacker
 from ml.governance import DriftDetector, ModelVersionManager, ShadowEvaluator
 from ml.registry import ModelRegistry
 from ml.router import ModelRouter
@@ -915,6 +916,20 @@ def _build_gdpr_deletion_targets(uid: str) -> list[DeletionTarget]:
 @limiter.limit("60/minute")
 def root(request: Request = None):
     return {"message": "Fasal Saathi API", "status": "running"}
+
+
+@app.get("/health/ensemble")
+@limiter.limit("60/minute")
+def health_ensemble(request: Request = None):
+    """
+    Per-model ensemble health with timeout-aware status.
+    Returns 200 if at least one model is available, 503 if none.
+    """
+    stacker = get_ensemble_stacker()
+    health = stacker.health()
+    if health["ensemble_ready"]:
+        return health
+    raise HTTPException(status_code=503, detail=health)
 
 @app.get("/predict")
 @limiter.limit("30/minute")

--- a/ml/ensemble.py
+++ b/ml/ensemble.py
@@ -5,6 +5,7 @@ Combines XGBoost, LSTM, and Random Forest predictions with learned weights,
 bootstrap confidence intervals, and inter-model disagreement detection.
 """
 
+import concurrent.futures
 import json
 import logging
 import math
@@ -16,6 +17,8 @@ from typing import Dict, List, Optional, Tuple
 import joblib
 import numpy as np
 import pandas as pd
+
+_DEFAULT_MODEL_TIMEOUT = 10.0  # seconds per model
 
 logger = logging.getLogger(__name__)
 
@@ -32,6 +35,23 @@ _BOOTSTRAP_SAMPLES = 1000
 # =============================================================================
 # MODEL LOADERS
 # =============================================================================
+
+def _load_model_with_timeout(loader_fn, timeout: float, model_name: str):
+    """
+    Execute a model loader in a thread with a timeout.
+    Returns the loaded model on success, None on timeout/failure.
+    """
+    with concurrent.futures.ThreadPoolExecutor(max_workers=1) as executor:
+        future = executor.submit(loader_fn)
+        try:
+            return future.result(timeout=timeout)
+        except concurrent.futures.TimeoutError:
+            logger.warning("%s model loading timed out after %.1fs", model_name, timeout)
+            return None
+        except Exception as exc:
+            logger.warning("%s model loading failed: %s", model_name, exc)
+            return None
+
 
 def _load_xgboost_model():
     from ml.adapters.xgboost_adapter import XGBoostAdapter
@@ -70,18 +90,63 @@ def _load_rf_model():
 # ENSEMBLE STACKER
 # =============================================================================
 
+class _ModelStatus:
+    """Tracks health and metadata for a single model slot."""
+
+    def __init__(self, name: str):
+        self.name = name
+        self.available = False
+        self.load_error: Optional[str] = None
+        self.load_duration_ms: Optional[float] = None
+        self.last_loaded: Optional[str] = None
+
+
 class EnsembleStacker:
     """
     Stacked ensemble with learned weights, bootstrap CIs, and disagreement detection.
+    Supports lazy per-model loading with timeouts and graceful degradation.
     """
 
-    def __init__(self, weights: Optional[Dict[str, float]] = None):
+    def __init__(
+        self,
+        weights: Optional[Dict[str, float]] = None,
+        model_timeout: float = _DEFAULT_MODEL_TIMEOUT,
+    ):
         self.xgb_adapter = None
         self.lstm_model = None
         self.lstm_scaler = None
         self.rf_model = None
         self.weights = weights or self._load_or_default_weights()
         self._models_loaded = False
+        self._model_timeout = model_timeout
+        self._status = {
+            "xgboost": _ModelStatus("xgboost"),
+            "lstm": _ModelStatus("lstm"),
+            "random_forest": _ModelStatus("random_forest"),
+        }
+
+    # -------------------------------------------------------------------------
+    # HEALTH
+    # -------------------------------------------------------------------------
+
+    def health(self) -> Dict[str, any]:
+        """
+        Return per-model health status for monitoring.
+        """
+        return {
+            "ensemble_ready": any(s.available for s in self._status.values()),
+            "models": {
+                name: {
+                    "available": status.available,
+                    "load_error": status.load_error,
+                    "load_duration_ms": status.load_duration_ms,
+                    "last_loaded": status.last_loaded,
+                }
+                for name, status in self._status.items()
+            },
+            "weights": self.weights,
+            "timestamp": _dt.utcnow().isoformat(),
+        }
 
     # -------------------------------------------------------------------------
     # WEIGHTS
@@ -114,25 +179,43 @@ class EnsembleStacker:
     # MODEL LOADING
     # -------------------------------------------------------------------------
 
+    def _load_single(self, name: str, loader_fn):
+        """Load one model with timeout, updating status metadata."""
+        status = self._status[name]
+        start = _dt.utcnow()
+        try:
+            result = _load_model_with_timeout(loader_fn, self._model_timeout, name)
+            if result is not None:
+                status.available = True
+                status.load_error = None
+                status.load_duration_ms = round(
+                    (_dt.utcnow() - start).total_seconds() * 1000, 2
+                )
+                status.last_loaded = _dt.utcnow().isoformat()
+                return result
+            else:
+                status.available = False
+                status.load_error = "timeout_or_failure"
+        except Exception as exc:
+            status.available = False
+            status.load_error = str(exc)
+        return None
+
     def load_models(self):
-        """Lazy-load all three models. Safe to call multiple times."""
+        """Lazy-load all three models with per-model timeouts. Safe to call multiple times."""
         if self._models_loaded:
             return
 
-        try:
-            self.xgb_adapter = _load_xgboost_model()
-        except Exception as exc:
-            logger.warning("XGBoost model unavailable for ensemble: %s", exc)
+        self.xgb_adapter = self._load_single("xgboost", _load_xgboost_model)
 
-        try:
-            self.lstm_model, self.lstm_scaler = _load_lstm_model()
-        except Exception as exc:
-            logger.warning("LSTM model unavailable for ensemble: %s", exc)
+        lstm_result = self._load_single("lstm", _load_lstm_model)
+        if lstm_result is not None:
+            self.lstm_model, self.lstm_scaler = lstm_result
+        else:
+            self.lstm_model = None
+            self.lstm_scaler = None
 
-        try:
-            self.rf_model = _load_rf_model()
-        except Exception as exc:
-            logger.warning("RF model unavailable for ensemble: %s", exc)
+        self.rf_model = self._load_single("random_forest", _load_rf_model)
 
         self._models_loaded = True
 


### PR DESCRIPTION
Closes #1837

## Problem
`EnsembleStacker.load_models()` loaded all three models eagerly on first request with no per-model timeout. When TensorFlow/LSTM artifacts were missing or slow, this caused 30+ second cold starts and request timeouts.

## Changes by file

| File | Change |
|------|--------|
| `ml/ensemble.py` | Added `_load_model_with_timeout()` using `ThreadPoolExecutor`; replaced eager loading with per-model timeout loading; added `_ModelStatus` tracking and `health()` method |
| `main.py` | Imported `get_ensemble_stacker`; added `/health/ensemble` endpoint returning 200/503 based on `ensemble_ready` |
| `celery_worker.py` | Added `_get_ensemble_stacker()` with thread-safe lazy init; added `predict_ensemble_task` (45s limit, 2 retries); added `ensemble_health_task` for async monitoring |

## Technical Notes
- Default timeout is **10s per model** (configurable via `EnsembleStacker` constructor).
- Graceful degradation preserved: if LSTM fails, XGBoost + RF still produce weighted predictions.
- Bootstrap CI and disagreement detection remain unchanged.
- `ThreadPoolExecutor` used instead of `signal` (Windows-safe, no SIGALRM issues).
- `load_models()` is still idempotent — safe to call multiple times.
- Celery tasks use the same lazy-loading pattern — no eager loading at worker startup.
- `predict_ensemble_task` has a 45s hard limit to accommodate first-call model loading; subsequent calls reuse cached models.
- `ensemble_health_task` (15s limit) is suitable for periodic monitoring checks.

## Verification
- [ ] `curl /health/ensemble` returns per-model status
- [ ] Rename `lstm_yield_model.h5` → predictions still succeed via Celery task
- [ ] Cold start &lt; 15s even with one slow/missing model
- [ ] Worker startup logs show no ensemble loading (lazy)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `/health/ensemble` endpoint (rate-limited to 60 requests/minute) for monitoring ensemble model health
  * Asynchronous health checking capability for ensemble models
  * Per-model health status tracking including availability, load errors, and load duration metrics
  * Configurable model loading timeouts for improved initialization resilience

<!-- end of auto-generated comment: release notes by coderabbit.ai -->