### PR TITLE
fix(marketplace): eliminate partial-completion window in book_equipment

### DIFF
--- a/backend/routers/marketplace.py
+++ b/backend/routers/marketplace.py
@@ -304,9 +304,12 @@ async def book_equipment(request: Request, data: BookEquipmentRequest):
             "createdAt": datetime.now(timezone.utc).isoformat(),
         }
 
-        _bookings[bid] = booking
-        # Mark the listing as unavailable while a booking is pending.
+        # Mark the listing unavailable BEFORE inserting the booking so that
+        # if the process crashes between the two writes the listing is already
+        # locked and a concurrent request cannot observe available=True while
+        # a booking record for the same equipment already exists.
         _listings[data.equipmentId] = {**listing, "available": False}
+        _bookings[bid] = booking
 
     logger.info(
         "Booking %s created: equipment=%s booker=%s date=%s",


### PR DESCRIPTION
closes #1853

In book_equipment, _bookings[bid] was written before _listings[equipmentId] was marked available=False.  A process crash between those two dict mutations left the booking recorded but the listing still flagged as available, allowing a second concurrent request to book the same equipment — a classic partial-state / double-booking bug.

Fix: swap the write order inside the lock so the listing is marked unavailable first, then the booking is inserted.  A crash after the listing update but before the booking insert leaves the equipment locked (safe — no phantom booking exists), while a crash after both writes is fully consistent.  No API surface changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability of equipment booking operations by ensuring availability status is properly managed during the booking process. This prevents potential data consistency issues when booking equipment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->