### PR TITLE
Fix/graph history firestore failures 

### DIFF
--- a/backend/routers/advisory.py
+++ b/backend/routers/advisory.py
@@ -440,8 +440,12 @@ def _load_graph_history(uid: str) -> list[dict[str, Any]]:
             if items:
                 items.sort(key=lambda item: item.get("createdAt", ""), reverse=True)
                 return items
-        except Exception:
-            pass
+        except Exception as exc:
+            logger.warning(
+                "Firestore history lookup failed for uid=%s, falling back to in-memory store: %s",
+                uid,
+                exc,
+            )
 
     return _graph_history.get(uid)
 


### PR DESCRIPTION
Closes #1850

## Problem

In `_load_graph_history`, the bare `except Exception: pass` silently swallowed
all Firestore errors. When Firestore was temporarily unavailable, users saw
empty history even when valid records existed in the database, giving the
false impression that their data was deleted.

## Fix

Log the exception at warning level before falling back to the in-memory store:

```python
except Exception as exc:
    logger.warning(
        "Firestore history lookup failed for uid=%s, falling back to in-memory store: %s",
        uid,
        exc,
    )
