### PR TITLE
Fix/concurrent uid tracking capacity 1849

### DIFF
--- a/backend/routers/advisory.py
+++ b/backend/routers/advisory.py
@@ -71,13 +71,24 @@ class _BoundedUidStore:
         """Ensure *uid* has a deque entry, evicting the LRU entry if needed.
 
         Must be called with ``self._lock`` already held.
+
+        Uses a retry loop to guarantee the size limit is respected even
+        under high concurrency where multiple threads may observe the
+        same pre-eviction size.  Each iteration evicts one LRU entry and
+        rechecks the size, ensuring that when we finally add the new entry
+        the store is guaranteed to be within capacity.
         """
-        if uid in self._data:
-            self._data.move_to_end(uid)
-        else:
-            if len(self._data) >= self._max_uids:
-                self._data.popitem(last=False)  # evict LRU
-            self._data[uid] = deque(maxlen=self._deque_maxlen)
+        with self._lock:
+            while True:
+                if uid in self._data:
+                    self._data.move_to_end(uid)
+                    return
+                if len(self._data) < self._max_uids:
+                    self._data[uid] = deque(maxlen=self._deque_maxlen)
+                    return
+                # Capacity reached — evict one entry and retry to ensure we
+                # never exceed _max_uids even under concurrent contention.
+                self._data.popitem(last=False)
 
 
 _stored_alerts = _BoundedUidStore(deque_maxlen=_MAX_STORED_ALERTS)


### PR DESCRIPTION
Closes #1849

## Problem

The original `_touch()` method checked `len(self._data) >= self._max_uids` once.
Under high concurrency, multiple threads could observe the same pre-eviction
size, all pass the check, and temporarily exceed the capacity limit, causing
unbounded memory consumption during traffic spikes.

## Fix

Use a retry loop inside the lock that evicts one LRU entry and rechecks until
there's room:

```python
with self._lock:
    while True:
        if uid in self._data:
            self._data.move_to_end(uid)
            return
        if len(self._data) < self._max_uids:
            self._data[uid] = deque(maxlen=self._deque_maxlen)
            return
        # Capacity reached — evict one entry and retry
        self._data.popitem(last=False)
