### PR TITLE
fix(alerts): remove duplicate logging import and organize module imports

### DIFF
--- a/backend/routers/alerts.py
+++ b/backend/routers/alerts.py
@@ -1,10 +1,9 @@
 """Alerts & Notifications Router"""
 import asyncio
+import logging
 import re
 from datetime import datetime
-import logging
 from typing import Optional
-import logging
 
 from fastapi import APIRouter, Form, HTTPException, Query, Request
 from twilio_webhook_security import handle_inbound_whatsapp_webhook


### PR DESCRIPTION
fixes #1845

The logging module was imported twice on lines 5 and 7. Duplicate imports consume module lookup overhead and create ambiguous dependency metadata that confuses static analysis tools, linters, and IDE introspection during refactoring.

Fix: remove the duplicate import and reorganize the import block to follow Python import conventions (builtins, then from-imports).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code maintenance and organization updates.

---

**Note:** This release contains no user-visible changes or feature updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->