### PR TITLE
fix(feature_flags): replace unbounded _event_buffer with bounded deque to prevent PII retention

### DIFF
--- a/feature_flags/metrics_collector.py
+++ b/feature_flags/metrics_collector.py
@@ -22,7 +22,7 @@ from collections import defaultdict
 from copy import deepcopy
 from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
-
+from collections import deque
 logger = logging.getLogger(__name__)
 
 try:
@@ -37,7 +37,7 @@ except Exception:
 
 EVENTS_COLLECTION = "experiment_events"
 
-_event_buffer: list[dict[str, Any]] = []
+_event_buffer: deque = deque(maxlen=10000)
 _event_lock = threading.Lock()
 
 VALID_EVENT_TYPES = frozenset({


### PR DESCRIPTION
_event_buffer was declared as a plain list with no size limit. On a long-running server, every call to log_event() and log_events_batch() appended events permanently. Each event contains user_id, session_id, and arbitrary metadata, so this caused both unbounded memory growth and indefinite PII retention in memory.
Fixed by replacing the list with collections.deque(maxlen=10000), which automatically evicts the oldest entries when the buffer is full. The append and extend calls throughout the file remain compatible with deque without any changes.

Type of Change: [x] Bug fix
Related Issue: Closes #1901
Testing Done: [x] Tested locally, [x] Verified API/backend changes