### PR TITLE
fix(metrics_collector): return 0.0 rates when impressions is zero

### DIFF
--- a/feature_flags/metrics_collector.py
+++ b/feature_flags/metrics_collector.py
@@ -183,11 +183,17 @@ def _empty_metrics(experiment_id: str) -> Dict:
 def _summarize_counts(experiment_id: str, total: int, counts: Dict[str, Dict[str, int]]) -> Dict:
     summary = {}
     for variant, c in counts.items():
-        imp = c["impressions"] or 1
+        imp = c["impressions"]
+        if imp == 0:
+            conversion_rate = 0.0
+            error_rate = 0.0
+        else:
+            conversion_rate = round(c["conversions"] / imp * 100, 2)
+            error_rate = round(c["errors"] / imp * 100, 2)
         summary[variant] = {
             **c,
-            "conversion_rate": round(c["conversions"] / imp * 100, 2),
-            "error_rate": round(c["errors"] / imp * 100, 2),
+            "conversion_rate": conversion_rate,
+            "error_rate": error_rate,
         }
 
     return {


### PR DESCRIPTION
_summarize_counts() used `imp = c["impressions"] or 1` as a zero-division guard. When a variant has 0 impressions but existing conversions or errors (e.g. from direct API calls or mis-tagged events), this fabricates a non-zero conversion_rate and error_rate, which can incorrectly promote a treatment variant as winner.

Fix: explicitly check if impressions == 0 and set both conversion_rate and error_rate to 0.0 in that case, instead of substituting a fake denominator of 1.

Type of Change: [x] Bug fix
Related Issue: Closes #1975
Testing Done: [x] Tested locally, [x] Verified API/backend changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed metric calculations for variants with zero impressions. Conversion rate and error rate now correctly return 0.0 instead of producing incorrect values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->