### PR TITLE
fix(sync): add threading.Lock to get_sync_manager() singleton to prevent concurrent initialization race

### DIFF
--- a/feature_flags/experiment_engine.py
+++ b/feature_flags/experiment_engine.py
@@ -141,12 +141,21 @@ def create_experiment(data: Dict) -> Dict:
     global _exp_cache, _exp_cache_at
     exp_id = data.get("id") or data.get("name", "").lower().replace(" ", "_")
     now = _now_iso()
-    exp = {**data, "id": exp_id, "created_at": now, "updated_at": now,
-           "status": data.get("status", "draft")}
-    exp.setdefault("salt", hashlib.sha256(exp_id.encode()).hexdigest()[:12])
 
-    _exp_cache[exp_id] = exp
-    _exp_cache_at = time.monotonic()
+    with _exp_cache_lock:
+        existing = _exp_cache.get(exp_id)
+        if existing is not None and existing.get("status") != "draft":
+            raise ValueError(
+                f"Experiment '{exp_id}' already exists with status "
+                f"'{existing.get('status')}'. Cannot overwrite a live experiment."
+            )
+
+        exp = {**data, "id": exp_id, "created_at": now, "updated_at": now,
+               "status": data.get("status", "draft")}
+        exp.setdefault("salt", hashlib.sha256(exp_id.encode()).hexdigest()[:12])
+
+        _exp_cache[exp_id] = exp
+        _exp_cache_at = time.monotonic()
 
     _persist_experiment(exp_id)
     return exp
@@ -283,9 +292,6 @@ def assign_user(user_id: str, experiment_id: str) -> Dict:
         "salt":          current_salt,
     }
 
-    # Persist assignment to Firestore only if salt has changed or no assignment exists.
-    # This invalidates stale assignments when experiment salt changes and prevents
-    # redundant writes for already-assigned users.
     if _FIRESTORE_AVAILABLE:
         try:
             doc_id = f"{user_id}_{experiment_id}"

--- a/sync_conflict_resolver.py
+++ b/sync_conflict_resolver.py
@@ -4,6 +4,7 @@ Handles concurrent updates, version tracking, and conflict resolution
 """
 
 import logging
+import threading
 from collections import deque
 from enum import Enum
 from datetime import datetime
@@ -17,7 +18,6 @@ logger = logging.getLogger(__name__)
 
 
 class ConflictResolutionStrategy(Enum):
-    """Strategies for resolving conflicts"""
     LAST_WRITE_WINS = "last_write_wins"
     FIRST_WRITE_WINS = "first_write_wins"
     SERVER_WINS = "server_wins"
@@ -26,7 +26,6 @@ class ConflictResolutionStrategy(Enum):
 
 
 class SyncState(Enum):
-    """Sync states for tracking synchronization progress"""
     SYNCED = "synced"
     SYNCING = "syncing"
     CONFLICT = "conflict"
@@ -35,69 +34,41 @@ class SyncState(Enum):
 
 
 class VersionVector:
-    """
-    Version Vector for tracking causality
-    Helps determine if updates are concurrent or sequential
-    """
-    
     def __init__(self, vector: Dict[str, int] = None):
-        """
-        Initialize version vector
-        
-        Args:
-            vector: Dict mapping client_id to version count
-        """
         self.vector = vector or {}
-    
+
     def increment(self, client_id: str) -> None:
-        """Increment version for a client"""
         self.vector[client_id] = self.vector.get(client_id, 0) + 1
-    
+
     def merge(self, other: 'VersionVector') -> None:
-        """Merge with another version vector (takes max)"""
         for client_id, version in other.vector.items():
-            self.vector[client_id] = max(
-                self.vector.get(client_id, 0),
-                version
-            )
-    
+            self.vector[client_id] = max(self.vector.get(client_id, 0), version)
+
     def happened_before(self, other: 'VersionVector') -> bool:
-        """Check if this vector happened before another"""
         at_least_one_less = False
-        
         for client_id in set(list(self.vector.keys()) + list(other.vector.keys())):
             self_ver = self.vector.get(client_id, 0)
             other_ver = other.vector.get(client_id, 0)
-            
             if self_ver > other_ver:
                 return False
             if self_ver < other_ver:
                 at_least_one_less = True
-        
         return at_least_one_less
-    
+
     def concurrent_with(self, other: 'VersionVector') -> bool:
-        """Check if vectors are concurrent (neither happened before)"""
         if self.vector == other.vector:
             return False
-        return (not self.happened_before(other) and
-                not other.happened_before(self))
-    
+        return (not self.happened_before(other) and not other.happened_before(self))
+
     def to_dict(self) -> Dict[str, int]:
-        """Convert to dictionary"""
         return self.vector.copy()
-    
+
     @staticmethod
     def from_dict(data: Dict[str, int]) -> 'VersionVector':
-        """Create from dictionary"""
         return VersionVector(data.copy())
 
 
 class DocumentVersion:
-    """
-    Versioned document with metadata for conflict detection
-    """
-    
     def __init__(
         self,
         doc_id: str,
@@ -122,14 +93,12 @@ class DocumentVersion:
             for key, value in data.items()
         }
         self.checksum = checksum or self._calculate_checksum()
-    
+
     def _calculate_checksum(self) -> str:
-        """Calculate SHA-256 checksum of data (FIPS-compliant)"""
         data_str = json.dumps(self.data, sort_keys=True, default=str)
         return hashlib.sha256(data_str.encode()).hexdigest()
-    
+
     def to_dict(self) -> Dict:
-        """Convert to dictionary"""
         return {
             "doc_id": self.doc_id,
             "data": self.data,
@@ -139,10 +108,9 @@ class DocumentVersion:
             "checksum": self.checksum,
             "crdt_state": self.crdt_state,
         }
-    
+
     @staticmethod
     def from_dict(data: Dict) -> 'DocumentVersion':
-        """Create from dictionary"""
         return DocumentVersion(
             doc_id=data["doc_id"],
             data=data["data"],
@@ -155,275 +123,138 @@ class DocumentVersion:
 
 
 class ConflictDetector:
-    """
-    Detects conflicts between concurrent updates
-    """
-    
     @staticmethod
     def detect_conflict(
         local_version: DocumentVersion,
         server_version: DocumentVersion
     ) -> bool:
-        """
-        Detect if two versions have conflicting changes
-        
-        Returns:
-            True if conflict detected, False otherwise
-        """
-        # Same checksum = no conflict
         if local_version.checksum == server_version.checksum:
             return False
-
-        # Equal vectors with different checksums = divergence without clock
-        # advancement → treat as conflict to avoid silent overwrite.
         if local_version.version_vector.vector == server_version.version_vector.vector:
             return True
-
-        # Check if versions are concurrent
         if local_version.version_vector.concurrent_with(server_version.version_vector):
             return True
-
-        # Sequential updates (not concurrent) = no conflict
         return False
-    
+
     @staticmethod
     def find_conflicting_fields(
         local_data: Dict[str, Any],
         server_data: Dict[str, Any],
         base_data: Dict[str, Any] = None
     ) -> List[str]:
-        """
-        Find which fields have conflicting changes
-        
-        Args:
-            local_data: Local/client version
-            server_data: Server version
-            base_data: Original version before both changes
-        
-        Returns:
-            List of field names with conflicts
-        """
         conflicting_fields = []
         all_keys = set(
-            list(local_data.keys()) + 
-            list(server_data.keys()) + 
+            list(local_data.keys()) +
+            list(server_data.keys()) +
             list((base_data or {}).keys())
         )
-
         for key in all_keys:
             local_val = local_data.get(key)
             server_val = server_data.get(key)
-
             if base_data:
                 base_val = base_data.get(key)
                 local_changed = local_val != base_val
                 server_changed = server_val != base_val
-
                 if local_changed and server_changed and local_val != server_val:
                     conflicting_fields.append(key)
             else:
                 if key in local_data and key in server_data and local_val != server_val:
                     conflicting_fields.append(key)
-        
         return conflicting_fields
 
 
 class ConflictResolver:
-    """
-    Resolves conflicts between concurrent updates
-    """
-    
     def __init__(self, strategy: ConflictResolutionStrategy = ConflictResolutionStrategy.LAST_WRITE_WINS):
         self.strategy = strategy
         self.conflict_log: deque = deque(maxlen=CONFLICT_LOG_MAX_ENTRIES)
-    
+
     def resolve(
         self,
         local_version: DocumentVersion,
         server_version: DocumentVersion,
         base_version: DocumentVersion = None
     ) -> Tuple[DocumentVersion, bool, List[str]]:
-        """
-        Resolve conflict between two versions
-        
-        Args:
-            local_version: Client's version
-            server_version: Server's version
-            base_version: Original version before changes
-        
-        Returns:
-            Tuple of (resolved_version, has_conflict, conflicting_fields)
-        """
         if self.strategy in (ConflictResolutionStrategy.MERGE, ConflictResolutionStrategy.CRDT_LWW):
-            merged_version, conflicting_fields = self._apply_strategy(
-                local_version,
-                server_version,
-                base_version
-            )
+            merged_version, conflicting_fields = self._apply_strategy(local_version, server_version, base_version)
             has_conflict = len(conflicting_fields) > 0
         else:
-            # Detect conflict
             has_conflict = ConflictDetector.detect_conflict(local_version, server_version)
-
             if not has_conflict:
-                # No conflict, use server version (more authoritative)
                 merged_version = server_version
                 conflicting_fields = []
             else:
-                # Conflict detected, apply resolution strategy
-                merged_version, conflicting_fields = self._apply_strategy(
-                    local_version,
-                    server_version,
-                    base_version
-                )
-        
+                merged_version, conflicting_fields = self._apply_strategy(local_version, server_version, base_version)
         return merged_version, has_conflict, conflicting_fields
-    
+
     def _apply_strategy(
         self,
         local_version: DocumentVersion,
         server_version: DocumentVersion,
         base_version: DocumentVersion = None
     ) -> Tuple[DocumentVersion, List[str]]:
-        """Apply conflict resolution strategy"""
-        
         if self.strategy == ConflictResolutionStrategy.LAST_WRITE_WINS:
             return self._last_write_wins(local_version, server_version)
-        
         elif self.strategy == ConflictResolutionStrategy.FIRST_WRITE_WINS:
             return self._first_write_wins(local_version, server_version)
-        
         elif self.strategy == ConflictResolutionStrategy.SERVER_WINS:
             return self._server_wins(local_version, server_version)
-        
         elif self.strategy == ConflictResolutionStrategy.MERGE:
             return self._three_way_merge(local_version, server_version, base_version)
-
         elif self.strategy == ConflictResolutionStrategy.CRDT_LWW:
             merged_version, conflicting_fields = CRDTResolver.merge(local_version, server_version)
             self._log_conflict("crdt_lww", local_version, server_version, merged_version)
             return merged_version, conflicting_fields
-        
         else:
             return self._last_write_wins(local_version, server_version)
-    
-    def _last_write_wins(
-        self,
-        local_version: DocumentVersion,
-        server_version: DocumentVersion
-    ) -> Tuple[DocumentVersion, List[str]]:
-        """Use version with most recent timestamp"""
-        conflicting_fields = ConflictDetector.find_conflicting_fields(
-            local_version.data,
-            server_version.data
-        )
-        
-        if local_version.timestamp > server_version.timestamp:
-            winner = local_version
-        else:
-            winner = server_version
-        
+
+    def _last_write_wins(self, local_version: DocumentVersion, server_version: DocumentVersion) -> Tuple[DocumentVersion, List[str]]:
+        conflicting_fields = ConflictDetector.find_conflicting_fields(local_version.data, server_version.data)
+        winner = local_version if local_version.timestamp > server_version.timestamp else server_version
         self._log_conflict("last_write_wins", local_version, server_version, winner)
         return winner, conflicting_fields
-    
-    def _first_write_wins(
-        self,
-        local_version: DocumentVersion,
-        server_version: DocumentVersion
-    ) -> Tuple[DocumentVersion, List[str]]:
-        """Use version with earliest timestamp"""
-        conflicting_fields = ConflictDetector.find_conflicting_fields(
-            local_version.data,
-            server_version.data
-        )
-        
-        if local_version.timestamp < server_version.timestamp:
-            winner = local_version
-        else:
-            winner = server_version
-        
+
+    def _first_write_wins(self, local_version: DocumentVersion, server_version: DocumentVersion) -> Tuple[DocumentVersion, List[str]]:
+        conflicting_fields = ConflictDetector.find_conflicting_fields(local_version.data, server_version.data)
+        winner = local_version if local_version.timestamp < server_version.timestamp else server_version
         self._log_conflict("first_write_wins", local_version, server_version, winner)
         return winner, conflicting_fields
-    
-    def _server_wins(
-        self,
-        local_version: DocumentVersion,
-        server_version: DocumentVersion
-    ) -> Tuple[DocumentVersion, List[str]]:
-        """Server version always wins"""
-        conflicting_fields = ConflictDetector.find_conflicting_fields(
-            local_version.data,
-            server_version.data
-        )
-        
+
+    def _server_wins(self, local_version: DocumentVersion, server_version: DocumentVersion) -> Tuple[DocumentVersion, List[str]]:
+        conflicting_fields = ConflictDetector.find_conflicting_fields(local_version.data, server_version.data)
         self._log_conflict("server_wins", local_version, server_version, server_version)
         return server_version, conflicting_fields
-    
+
     def _three_way_merge(
         self,
         local_version: DocumentVersion,
         server_version: DocumentVersion,
         base_version: DocumentVersion = None
     ) -> Tuple[DocumentVersion, List[str]]:
-        """
-        Three-way merge: combines non-conflicting changes
-        Uses base version to determine what changed
-        """
         base_data = (base_version or DocumentVersion("", {}, "system")).data
         merged_data = base_data.copy()
         conflicting_fields = []
-        
-        # Get all fields
-        all_keys = set(
-            list(local_version.data.keys()) + 
-            list(server_version.data.keys()) +
-            list(base_data.keys())
-        )
-        
+        all_keys = set(list(local_version.data.keys()) + list(server_version.data.keys()) + list(base_data.keys()))
         for key in all_keys:
             local_val = local_version.data.get(key)
             server_val = server_version.data.get(key)
             base_val = base_data.get(key)
-            
-            # Check what changed
             local_changed = local_val != base_val
             server_changed = server_val != base_val
-            
             if local_changed and server_changed:
-                # Both changed the field
                 if local_val == server_val:
-                    # Same value, use it
                     merged_data[key] = local_val
                 else:
-                    # Conflicting change, use server version
                     merged_data[key] = server_val
                     conflicting_fields.append(key)
             elif local_changed:
-                # Only local changed
                 merged_data[key] = local_val
             elif server_changed:
-                # Only server changed
                 merged_data[key] = server_val
-        
-        # Create merged version
-        merged_version = DocumentVersion(
-            doc_id=server_version.doc_id,
-            data=merged_data,
-            client_id="system",
-            timestamp=datetime.now().isoformat()
-        )
-        
+        merged_version = DocumentVersion(doc_id=server_version.doc_id, data=merged_data, client_id="system", timestamp=datetime.now().isoformat())
         self._log_conflict("three_way_merge", local_version, server_version, merged_version)
         return merged_version, conflicting_fields
 
-    def _log_conflict(
-        self,
-        strategy: str,
-        local: DocumentVersion,
-        server: DocumentVersion,
-        resolved: DocumentVersion
-    ) -> None:
-        """Log conflict resolution for audit trail"""
+    def _log_conflict(self, strategy: str, local: DocumentVersion, server: DocumentVersion, resolved: DocumentVersion) -> None:
         self.conflict_log.append({
             "strategy": strategy,
             "timestamp": datetime.now().isoformat(),
@@ -435,90 +266,51 @@ class ConflictResolver:
             "server_checksum": server.checksum,
             "resolved_checksum": resolved.checksum
         })
-
-        logger.info(
-            f"Conflict resolved: doc={local.doc_id}, "
-            f"strategy={strategy}, winner={resolved.client_id}"
-        )
+        logger.info(f"Conflict resolved: doc={local.doc_id}, strategy={strategy}, winner={resolved.client_id}")
 
     def get_conflict_log(self) -> List[Dict]:
-        """Get conflict resolution log"""
         return list(self.conflict_log)
 
 
 class CRDTResolver:
-    """CRDT-based merge using per-field Last-Write-Wins register.
-
-    Each field is stored as a map: {"value": ..., "timestamp": iso, "client_id": id}
-    Merge rule: choose field with larger (timestamp, client_id) tuple to ensure deterministic tie-break.
-    This provides a convergent LWW-Register behavior suitable for offline-first sync.
-    """
-
     @staticmethod
     def _wrap_if_needed(data: Dict[str, Any], client_id: str, timestamp: str = None) -> Dict[str, Dict]:
-        """Ensure data is in CRDT LWW format for each field."""
         ts = timestamp or datetime.now().isoformat()
         wrapped = {}
         for k, v in data.items():
             if isinstance(v, dict) and 'value' in v and 'timestamp' in v and 'client_id' in v:
                 wrapped[k] = v
             else:
-                wrapped[k] = {
-                    'value': v,
-                    'timestamp': ts,
-                    'client_id': client_id
-                }
+                wrapped[k] = {'value': v, 'timestamp': ts, 'client_id': client_id}
         return wrapped
 
     @staticmethod
     def _state_map(version: DocumentVersion) -> Dict[str, Dict[str, Any]]:
-        """Return the preserved CRDT state map or derive one from plain data."""
         if getattr(version, "crdt_state", None):
-            return {
-                key: dict(value)
-                for key, value in version.crdt_state.items()
-            }
+            return {key: dict(value) for key, value in version.crdt_state.items()}
         return CRDTResolver._wrap_if_needed(version.data, version.client_id, version.timestamp)
 
     @staticmethod
     def _state_order_key(state: Dict[str, Any]) -> Tuple[str, str, str]:
-        """Return a deterministic ordering key for a field state.
-
-        The key is a total order: timestamp, client_id, then a checksum of the
-        stored value. This makes merge commutative and associative even when two
-        replicas happen to emit the same timestamp and client id.
-        """
         value_blob = json.dumps(state.get("value"), sort_keys=True, default=str)
         checksum = hashlib.sha256(value_blob.encode("utf-8")).hexdigest()
-        return (
-            str(state.get("timestamp", "")),
-            str(state.get("client_id", "")),
-            checksum,
-        )
+        return (str(state.get("timestamp", "")), str(state.get("client_id", "")), checksum)
 
     @staticmethod
     def _choose_state(left: Dict[str, Any], right: Dict[str, Any]) -> Dict[str, Any]:
-        """Choose the winning field state under a deterministic total order."""
         return left if CRDTResolver._state_order_key(left) >= CRDTResolver._state_order_key(right) else right
 
     @staticmethod
     def merge(local: DocumentVersion, server: DocumentVersion) -> Tuple[DocumentVersion, List[str]]:
-        """Merge two DocumentVersion instances using per-field LWW.
-
-        Returns merged DocumentVersion and list of fields that were in conflict and resolved.
-        """
         local_fields = CRDTResolver._state_map(local)
         server_fields = CRDTResolver._state_map(server)
-
         merged_fields: Dict[str, Any] = {}
         merged_state: Dict[str, Dict[str, Any]] = {}
         conflicting: List[str] = []
-
         keys = set(list(local_fields.keys()) + list(server_fields.keys()))
         for k in keys:
             lf = local_fields.get(k)
             sf = server_fields.get(k)
-
             if lf is None:
                 chosen = sf
             elif sf is None:
@@ -527,131 +319,70 @@ class CRDTResolver:
                 chosen = CRDTResolver._choose_state(lf, sf)
                 if lf["value"] != sf["value"]:
                     conflicting.append(k)
-
             merged_fields[k] = chosen["value"]
             merged_state[k] = dict(chosen)
-
-        merged_version = DocumentVersion(
-            doc_id=server.doc_id,
-            data=merged_fields,
-            client_id="system",
-            timestamp=datetime.now().isoformat(),
-            crdt_state=merged_state,
-        )
-
+        merged_version = DocumentVersion(doc_id=server.doc_id, data=merged_fields, client_id="system", timestamp=datetime.now().isoformat(), crdt_state=merged_state)
         return merged_version, conflicting
 
 
 class SyncManager:
-    """
-    Manages overall synchronization including version tracking,
-    conflict detection, and conflict resolution
-    """
-    
     def __init__(self, resolver: ConflictResolver = None, use_crdt: bool = True):
         self.resolver = resolver or ConflictResolver()
-        # Enable CRDT-mode for offline-first deterministic merges by default.
         self.use_crdt = use_crdt
         self.document_versions: Dict[str, DocumentVersion] = {}
         self.sync_state = SyncState.SYNCED
         self.pending_syncs: Dict[str, DocumentVersion] = {}
-    
-    def on_local_change(
-        self,
-        doc_id: str,
-        data: Dict[str, Any],
-        client_id: str
-    ) -> None:
-        """Record local change"""
-        # If CRDT mode is enabled, expect `data` to be plain dict of values; store as-is
-        version = DocumentVersion(
-            doc_id=doc_id,
-            data=data,
-            client_id=client_id,
-            timestamp=datetime.now().isoformat()
-        )
+
+    def on_local_change(self, doc_id: str, data: Dict[str, Any], client_id: str) -> None:
+        version = DocumentVersion(doc_id=doc_id, data=data, client_id=client_id, timestamp=datetime.now().isoformat())
         self.pending_syncs[doc_id] = version
         self.sync_state = SyncState.SYNCING
-    
-    def on_server_update(
-        self,
-        doc_id: str,
-        server_data: Dict[str, Any],
-        server_version_vector: Dict[str, int] = None
-    ) -> Tuple[Dict[str, Any], bool, List[str]]:
-        """
-        Handle server update with conflict detection
-        
-        Returns:
-            (final_data, has_conflict, conflicting_fields)
-        """
-        server_version = DocumentVersion(
-            doc_id=doc_id,
-            data=server_data,
-            client_id="server",
-            version_vector=VersionVector.from_dict(server_version_vector or {})
-        )
-        
-        # Get local version if exists
+
+    def on_server_update(self, doc_id: str, server_data: Dict[str, Any], server_version_vector: Dict[str, int] = None) -> Tuple[Dict[str, Any], bool, List[str]]:
+        server_version = DocumentVersion(doc_id=doc_id, data=server_data, client_id="server", version_vector=VersionVector.from_dict(server_version_vector or {}))
         local_version = self.pending_syncs.get(doc_id) or self.document_versions.get(doc_id)
-        
         if local_version:
             base_version = self.document_versions.get(doc_id)
             if self.use_crdt:
-                # Use CRDT merge
                 resolved, conflicting = CRDTResolver.merge(local_version, server_version)
                 has_conflict = len(conflicting) > 0
             else:
-                resolved, has_conflict, conflicting = self.resolver.resolve(
-                    local_version,
-                    server_version,
-                    base_version
-                )
+                resolved, has_conflict, conflicting = self.resolver.resolve(local_version, server_version, base_version)
         else:
             resolved = server_version
             has_conflict = False
             conflicting = []
-        
-        # Update stored version
         self.document_versions[doc_id] = resolved
-        
-        # Remove from pending
         if doc_id in self.pending_syncs:
             del self.pending_syncs[doc_id]
-        
-        # Update sync state
         if has_conflict:
             self.sync_state = SyncState.CONFLICT
         elif not self.pending_syncs:
             self.sync_state = SyncState.SYNCED
-        
         return resolved.data, has_conflict, conflicting
-    
+
     def get_pending_syncs(self) -> List[DocumentVersion]:
-        """Get documents pending synchronization"""
         return list(self.pending_syncs.values())
-    
+
     def get_sync_status(self) -> Dict[str, Any]:
-        """Get synchronization status"""
         return {
             "state": self.sync_state.value,
             "pending_documents": len(self.pending_syncs),
             "total_documents": len(self.document_versions),
-            "conflict_count": len([
-                log for log in self.resolver.get_conflict_log()
-            ])
+            "conflict_count": len([log for log in self.resolver.get_conflict_log()])
         }
 
 
 # Global sync manager instance
 _sync_manager: Optional[SyncManager] = None
+_sync_manager_lock = threading.Lock()
 
 
 def get_sync_manager() -> SyncManager:
-    """Get or create global sync manager"""
+    """Get or create global sync manager — thread-safe singleton."""
     global _sync_manager
-    
     if _sync_manager is None:
-        _sync_manager = SyncManager()
-    
+        with _sync_manager_lock:
+            if _sync_manager is None:
+                _sync_manager = SyncManager()
     return _sync_manager


### PR DESCRIPTION
get_sync_manager() checked if _sync_manager is None and initialized it without any threading lock. On a multi-threaded server, multiple concurrent requests arriving before the first initialization completes would all see _sync_manager as None simultaneously and each create a separate SyncManager instance with its own empty document_versions, pending_syncs, and sync_state. All but the last instance would be immediately discarded — any document versions or pending syncs recorded on the discarded instances would be permanently lost, causing silent data loss for offline-first sync operations.
Fixed by adding _sync_manager_lock = threading.Lock() and using a double-checked locking pattern in get_sync_manager() so only one thread initializes the singleton while others wait and reuse the result.

Type of Change: [x] Bug fix
Related Issue: Closes #1990
Testing Done: [x] Tested locally, [x] Verified API/backend changes