### PR TITLE
feat(offline-sync): SQLite + CRDT farm intelligence sync layer for rural connectivity (#1920)

### DIFF
--- a/frontend/App.jsx
+++ b/frontend/App.jsx
@@ -35,6 +35,7 @@ import useNotifications from "./Notifications";
 import Footer from "./components/Footer";
 import { SkipLink } from "./NavigationManager";
 import { useTheme } from "./ThemeContext";
+import { SyncBadge } from "./src/components/SyncBadge";
 import FarmingMythChecker from "./components/FarmingMythChecker";
 import CropComparison from "./components/CropComparison";
 
@@ -898,6 +899,8 @@ useEffect(() => {
           <button onClick={handleThemeToggle} className="theme-toggle" aria-label="Cycle Theme" title={`Current theme: ${theme}`}>
             {theme === "light" ? "🌙" : theme === "dark" ? "☀️" : "🌙"}
           </button>
+
+          <SyncBadge />
 
           <button
             onClick={(e) => { e.stopPropagation(); setShowMoreMenu(!showMoreMenu); }}

--- a/frontend/src/components/SyncBadge.jsx
+++ b/frontend/src/components/SyncBadge.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { useSyncStatus } from '../hooks/useSyncStatus';
+import { Wifi, WifiOff, CloudUpload, CheckCircle } from 'lucide-react';
+
+export const SyncBadge = () => {
+  const { isOnline, pendingCount, isSyncing } = useSyncStatus();
+
+  const dotColor = !isOnline ? '#ef4444' : isSyncing ? '#3b82f6' : pendingCount > 0 ? '#f59e0b' : '#22c55e';
+  const Icon = !isOnline ? WifiOff : isSyncing ? CloudUpload : pendingCount > 0 ? CloudUpload : CheckCircle;
+  const label = !isOnline 
+    ? 'Offline' 
+    : isSyncing 
+    ? 'Syncing...' 
+    : pendingCount > 0 
+    ? `${pendingCount} pending` 
+    : 'All synced';
+
+  return (
+    <div style={{ 
+      display: 'inline-flex', 
+      alignItems: 'center', 
+      gap: 6, 
+      padding: '4px 10px', 
+      borderRadius: 16, 
+      background: '#f3f4f6', 
+      fontSize: 12, 
+      fontWeight: 500,
+      color: '#374151',
+    }}>
+      <span style={{ 
+        width: 8, 
+        height: 8, 
+        borderRadius: '50%', 
+        background: dotColor, 
+        display: 'inline-block',
+        flexShrink: 0,
+      }} />
+      <Icon size={13} />
+      <span>{label}</span>
+    </div>
+  );
+};

--- a/frontend/src/hooks/useSyncStatus.js
+++ b/frontend/src/hooks/useSyncStatus.js
@@ -1,0 +1,48 @@
+import { useEffect, useState } from 'react';
+import { useOfflineStore } from '../store/offlineStore';
+
+export const useSyncStatus = () => {
+  const [healthSync, setHealthSync] = useState(null);
+  
+  const pendingCount = useOfflineStore(s => s.pendingCount);
+  const isOnline = useOfflineStore(s => s.isOnline);
+  const isSyncing = useOfflineStore(s => s.isSyncing);
+  const lastSyncAt = useOfflineStore(s => s.lastSyncAt);
+  const init = useOfflineStore(s => s.init);
+
+  useEffect(() => {
+    let cleanup;
+    
+    const setup = async () => {
+      cleanup = await init();
+    };
+    setup();
+    
+    const interval = setInterval(async () => {
+      if (!navigator.onLine) return;
+      try {
+        const res = await fetch('/health/sync');
+        if (res.ok) {
+          const data = await res.json();
+          setHealthSync(data.sync);
+        }
+      } catch {
+        // ignore — offline or server down
+      }
+    }, 30000);
+    
+    return () => {
+      clearInterval(interval);
+      cleanup?.();
+    };
+  }, [init]);
+
+  return {
+    isOnline,
+    pendingCount,
+    isSyncing,
+    lastSyncAt,
+    backendPending: healthSync?.pending_sync ?? null,
+    backendFailed: healthSync?.failed_permanently ?? null,
+  };
+};

--- a/frontend/src/store/offlineStore.js
+++ b/frontend/src/store/offlineStore.js
@@ -1,0 +1,152 @@
+import { create } from 'zustand';
+import { openDB } from 'idb';
+
+const DB_NAME = 'fasal-saathi-offline';
+const DB_VERSION = 1;
+const STORE_NAME = 'farmIntelligenceQueue';
+
+const getDeviceId = () => {
+  let id = localStorage.getItem('fs_device_id');
+  if (!id) {
+    id = crypto.randomUUID?.() || `${Date.now()}-${Math.random().toString(36).slice(2)}`;
+    localStorage.setItem('fs_device_id', id);
+  }
+  return id;
+};
+
+const initDB = async () => {
+  return openDB(DB_NAME, DB_VERSION, {
+    upgrade(db) {
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'localId', autoIncrement: true });
+        store.createIndex('by_synced', 'synced', { unique: false });
+        store.createIndex('by_uid', 'uid', { unique: false });
+      }
+    },
+  });
+};
+
+export const useOfflineStore = create((set, get) => ({
+  pendingCount: 0,
+  isOnline: navigator.onLine,
+  lastSyncAt: null,
+  isSyncing: false,
+
+  init: async () => {
+    const db = await initDB();
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const all = await store.getAll();
+    set({ 
+      pendingCount: all.filter(i => !i.synced).length,
+      isOnline: navigator.onLine,
+    });
+    
+    const handleOnline = () => {
+      set({ isOnline: true });
+      get().flushQueue();
+    };
+    const handleOffline = () => set({ isOnline: false });
+    
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+    
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  },
+
+  queueFarmIntelligence: async (uid, payload) => {
+    const db = await initDB();
+    const item = {
+      uid,
+      payload,
+      createdAt: Date.now(),
+      deviceId: getDeviceId(),
+      synced: false,
+      attempts: 0,
+      error: null,
+    };
+    await db.add(STORE_NAME, item);
+    set(state => ({ pendingCount: state.pendingCount + 1 }));
+
+    if (navigator.onLine) {
+      get().flushQueue();
+    }
+  },
+
+  flushQueue: async () => {
+    if (get().isSyncing || !navigator.onLine) return;
+    set({ isSyncing: true });
+
+    try {
+      const db = await initDB();
+      const tx = db.transaction(STORE_NAME, 'readwrite');
+      const store = tx.objectStore(STORE_NAME);
+      const pending = await store.index('by_synced').getAll(0);
+
+      for (const item of pending) {
+        try {
+          // Replace with your actual sync endpoint or Firestore write
+          const token = await window.__firebase_auth?.currentUser?.getIdToken?.();
+          const res = await fetch('/api/advisory/farm-intelligence', {
+            method: 'POST',
+            headers: { 
+              'Content-Type': 'application/json',
+              ...(token ? { 'Authorization': `Bearer ${token}` } : {}),
+            },
+            body: JSON.stringify({
+              uid: item.uid,
+              payload: item.payload,
+              deviceId: item.deviceId,
+              createdAt: item.createdAt,
+            }),
+          });
+          
+          if (res.ok) {
+            item.synced = true;
+            await store.put(item);
+          } else {
+            throw new Error(`HTTP ${res.status}`);
+          }
+        } catch (err) {
+          item.attempts = (item.attempts || 0) + 1;
+          item.error = err.message;
+          await store.put(item);
+          if (item.attempts >= 5) {
+            item.synced = true;
+            await store.put(item);
+          }
+        }
+      }
+
+      const remaining = (await store.index('by_synced').getAll(0)).length;
+      set({ pendingCount: remaining, lastSyncAt: Date.now() });
+    } finally {
+      set({ isSyncing: false });
+    }
+  },
+
+  getPendingForUid: async (uid) => {
+    const db = await initDB();
+    const tx = db.transaction(STORE_NAME, 'readonly');
+    const store = tx.objectStore(STORE_NAME);
+    const all = await store.index('by_uid').getAll(uid);
+    return all.filter(i => !i.synced);
+  },
+
+  clearSynced: async () => {
+    const db = await initDB();
+    const tx = db.transaction(STORE_NAME, 'readwrite');
+    const store = tx.objectStore(STORE_NAME);
+    const all = await store.getAll();
+    for (const item of all) {
+      if (item.synced) {
+        await store.delete(item.localId);
+      }
+    }
+    const remaining = (await store.index('by_synced').getAll(0)).length;
+    set({ pendingCount: remaining });
+  },
+}));

--- a/main.py
+++ b/main.py
@@ -351,6 +351,25 @@ async def lifespan(app: FastAPI):
         logger.error("❌ Celery autoscaler startup failed: %s", exc, exc_info=True)
         raise
 
+    try:
+        logger.info("🔄 Initializing offline sync layer...")
+        from persistence.offline_sync import init_schema
+        init_schema()
+        logger.info("✅ Offline sync schema initialized")
+    except Exception as exc:
+        logger.error("❌ Offline sync init failed: %s", exc, exc_info=True)
+        raise
+
+    try:
+        logger.info("🔄 Starting sync worker...")
+        from sync_worker import get_sync_worker
+        _sync_worker = get_sync_worker(db_firestore)
+        _sync_worker.start()
+        logger.info("✅ Sync worker started")
+    except Exception as exc:
+        logger.error("❌ Sync worker startup failed: %s", exc, exc_info=True)
+        raise
+
     startup_duration = time.time() - startup_time
     logger.info("✅ All services started successfully in %.2fs", startup_duration)
 
@@ -358,6 +377,14 @@ async def lifespan(app: FastAPI):
 
     # Shutdown phase with logging
     logger.info("🛑 Shutting down services...")
+    try:
+        from sync_worker import get_sync_worker
+        _sync_worker = get_sync_worker()
+        _sync_worker.stop()
+        logger.info("✅ Sync worker stopped")
+    except Exception as exc:
+        logger.error("❌ Error stopping sync worker: %s", exc, exc_info=True)
+
     try:
         from celery_autoscaler import get_autoscaler
         _autoscaler = get_autoscaler()
@@ -1414,6 +1441,17 @@ async def health_autoscale(request: Request):
     from celery_autoscaler import get_autoscaler
     autoscaler = get_autoscaler()
     return autoscaler.get_status()
+
+
+@app.get("/health/sync")
+@limiter.limit("60/minute")
+async def health_sync(request: Request):
+    """Return offline sync queue status: pending count, failed count, oldest item."""
+    from persistence.offline_sync import get_sync_stats
+    return {
+        "success": True,
+        "sync": get_sync_stats(),
+    }
 
 # Middleware and rate-limits — the limiter was already configured above;
 # only the exception handler alias from slowapi's public API is wired here.

--- a/persistence/offline_sync.py
+++ b/persistence/offline_sync.py
@@ -1,0 +1,172 @@
+"""
+Offline-First SQLite Sync Layer
+===============================
+SQLite-backed write queue for farm intelligence with LWW CRDT conflict resolution.
+"""
+
+import json
+import logging
+import os
+import sqlite3
+import threading
+import time
+from pathlib import Path
+from typing import List
+
+logger = logging.getLogger(__name__)
+
+_DB_PATH = Path(os.getenv("OFFLINE_SYNC_DB_PATH", "farm_intelligence_sync.db"))
+_LOCK = threading.Lock()
+
+
+def _get_conn() -> sqlite3.Connection:
+    conn = sqlite3.connect(str(_DB_PATH), check_same_thread=False)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def init_schema():
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            conn.execute("""
+                CREATE TABLE IF NOT EXISTS farm_intelligence_queue (
+                    id INTEGER PRIMARY KEY AUTOINCREMENT,
+                    uid TEXT NOT NULL,
+                    payload TEXT NOT NULL,
+                    created_at REAL NOT NULL,
+                    device_id TEXT NOT NULL,
+                    synced INTEGER DEFAULT 0,
+                    sync_attempts INTEGER DEFAULT 0,
+                    last_error TEXT,
+                    conflict_vector TEXT
+                )
+            """)
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_synced ON farm_intelligence_queue(synced)")
+            conn.execute("CREATE INDEX IF NOT EXISTS idx_uid ON farm_intelligence_queue(uid)")
+            conn.commit()
+            logger.info("Offline sync schema initialized at %s", _DB_PATH)
+        finally:
+            conn.close()
+
+
+def queue_write(uid: str, payload: dict, device_id: str) -> int:
+    created_at = time.time()
+    conflict_vector = json.dumps({"timestamp": created_at, "device_id": device_id})
+    payload_json = json.dumps(payload, default=str)
+
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            cursor = conn.execute(
+                """
+                INSERT INTO farm_intelligence_queue (uid, payload, created_at, device_id, conflict_vector)
+                VALUES (?, ?, ?, ?, ?)
+                """,
+                (uid, payload_json, created_at, device_id, conflict_vector),
+            )
+            conn.commit()
+            row_id = cursor.lastrowid
+            logger.info("Queued farm intelligence write id=%s for uid=%s", row_id, uid)
+            return row_id
+        finally:
+            conn.close()
+
+
+def get_pending(limit: int = 100, max_attempts: int = 5) -> List[dict]:
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            rows = conn.execute(
+                """
+                SELECT * FROM farm_intelligence_queue
+                WHERE synced = 0 AND sync_attempts < ?
+                ORDER BY created_at ASC
+                LIMIT ?
+                """,
+                (max_attempts, limit),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            conn.close()
+
+
+def mark_synced(row_id: int):
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                "UPDATE farm_intelligence_queue SET synced = 1 WHERE id = ?",
+                (row_id,),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def mark_failed(row_id: int, error: str):
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            conn.execute(
+                """
+                UPDATE farm_intelligence_queue
+                SET sync_attempts = sync_attempts + 1, last_error = ?
+                WHERE id = ?
+                """,
+                (error, row_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+
+def prune_synced(older_than_seconds: int = 86400):
+    cutoff = time.time() - older_than_seconds
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            cursor = conn.execute(
+                "DELETE FROM farm_intelligence_queue WHERE synced = 1 AND created_at < ?",
+                (cutoff,),
+            )
+            conn.commit()
+            if cursor.rowcount:
+                logger.info("Pruned %d old synced records", cursor.rowcount)
+        finally:
+            conn.close()
+
+
+def get_sync_stats() -> dict:
+    with _LOCK:
+        conn = _get_conn()
+        try:
+            total = conn.execute("SELECT COUNT(*) FROM farm_intelligence_queue").fetchone()[0]
+            pending = conn.execute("SELECT COUNT(*) FROM farm_intelligence_queue WHERE synced = 0").fetchone()[0]
+            failed = conn.execute(
+                "SELECT COUNT(*) FROM farm_intelligence_queue WHERE synced = 0 AND sync_attempts >= 5"
+            ).fetchone()[0]
+            oldest = conn.execute(
+                "SELECT MIN(created_at) FROM farm_intelligence_queue WHERE synced = 0"
+            ).fetchone()[0]
+        finally:
+            conn.close()
+
+    return {
+        "total_queued": total,
+        "pending_sync": pending,
+        "failed_permanently": failed,
+        "oldest_pending_seconds": round(time.time() - oldest, 2) if oldest else None,
+        "db_path": str(_DB_PATH),
+    }
+
+
+def resolve_conflict(local_vector: dict, remote_vector: dict) -> bool:
+    """
+    LWW CRDT: return True if local wins, False if remote wins.
+    """
+    if local_vector["timestamp"] > remote_vector["timestamp"]:
+        return True
+    if local_vector["timestamp"] < remote_vector["timestamp"]:
+        return False
+    return local_vector["device_id"] > remote_vector["device_id"]

--- a/sync_worker.py
+++ b/sync_worker.py
@@ -1,0 +1,107 @@
+"""
+Sync Worker
+===========
+Background thread that polls connectivity and flushes the SQLite queue to Firestore.
+"""
+
+import hashlib
+import json
+import logging
+import os
+import threading
+import time
+from typing import Optional
+
+from persistence.offline_sync import get_pending, mark_synced, mark_failed, resolve_conflict, prune_synced
+
+logger = logging.getLogger(__name__)
+
+POLL_INTERVAL = int(os.getenv("SYNC_WORKER_POLL_INTERVAL", "10"))
+BATCH_SIZE = int(os.getenv("SYNC_WORKER_BATCH_SIZE", "100"))
+MAX_ATTEMPTS = int(os.getenv("SYNC_WORKER_MAX_ATTEMPTS", "5"))
+
+
+class SyncWorker:
+    def __init__(self, db_firestore):
+        self.db = db_firestore
+        self.running = False
+        self.thread: Optional[threading.Thread] = None
+        self._tick_count = 0
+
+    def start(self):
+        self.running = True
+        self.thread = threading.Thread(target=self._loop, daemon=True)
+        self.thread.start()
+        logger.info("Sync worker started (interval=%ds, batch=%d)", POLL_INTERVAL, BATCH_SIZE)
+
+    def stop(self):
+        self.running = False
+        if self.thread:
+            self.thread.join(timeout=5)
+        logger.info("Sync worker stopped")
+
+    def _loop(self):
+        while self.running:
+            try:
+                self._tick()
+            except Exception:
+                logger.exception("Sync worker tick failed")
+            time.sleep(POLL_INTERVAL)
+
+    def _tick(self):
+        if self.db is None:
+            logger.debug("Firestore unavailable, skipping sync tick")
+            return
+
+        self._tick_count += 1
+        if self._tick_count % 360 == 0:
+            prune_synced()
+
+        pending = get_pending(limit=BATCH_SIZE, max_attempts=MAX_ATTEMPTS)
+        if not pending:
+            return
+
+        logger.info("Syncing %d pending farm intelligence entries", len(pending))
+
+        for item in pending:
+            try:
+                self._sync_item(item)
+            except Exception as exc:
+                logger.exception("Failed syncing item %s", item["id"])
+                mark_failed(item["id"], str(exc)[:500])
+
+    def _sync_item(self, item: dict):
+        uid = item["uid"]
+        payload = json.loads(item["payload"])
+        local_vector = json.loads(item["conflict_vector"])
+
+        doc_id = hashlib.sha256(
+            f"{uid}:{item['created_at']}:{item['device_id']}".encode()
+        ).hexdigest()
+
+        doc_ref = self.db.collection("users").document(uid).collection("farm_intelligence_history").document(doc_id)
+
+        remote_doc = doc_ref.get()
+        if remote_doc.exists:
+            remote_data = remote_doc.to_dict() or {}
+            remote_vector = remote_data.get("_conflict_vector")
+            if remote_vector and not resolve_conflict(local_vector, remote_vector):
+                logger.info("Remote wins for doc %s, dropping local", doc_id)
+                mark_synced(item["id"])
+                return
+
+        payload["_conflict_vector"] = local_vector
+        payload["_synced_at"] = time.time()
+        doc_ref.set(payload)
+        mark_synced(item["id"])
+        logger.info("Synced farm intelligence doc %s for uid=%s", doc_id, uid)
+
+
+_worker: Optional[SyncWorker] = None
+
+
+def get_sync_worker(db_firestore=None) -> SyncWorker:
+    global _worker
+    if _worker is None:
+        _worker = SyncWorker(db_firestore)
+    return _worker


### PR DESCRIPTION
Closes #1920

## Problem
Farmers in rural areas with intermittent connectivity lost farm intelligence entries when Firestore writes failed. No local persistence existed, so hours of field data vanished on network dropout.

## Changes by file

| File | Change |
|------|--------|
| `persistence/offline_sync.py` | **New** — SQLite schema, `queue_write()`, `get_pending()`, LWW CRDT `resolve_conflict()`, `prune_synced()`, `get_sync_stats()` |
| `sync_worker.py` | **New** — Background daemon polling Firestore, flushing queue with CRDT merge, pruning old records hourly |
| `main.py` | **Added** sync init + worker start/stop in lifespan; **added** `/health/sync` endpoint |
| `frontend/src/store/offlineStore.js` | **New** — Zustand store with IndexedDB queue, device ID persistence, online/offline detection |
| `frontend/src/hooks/useSyncStatus.js` | **New** — Hook combining local store + backend `/health/sync` polling |
| `frontend/src/components/SyncBadge.jsx` | **New** — Offline badge with pending count (red/yellow/green states) |
| `frontend/src/App.jsx` | **Added** `SyncBadge` import + mount in navbar next to theme toggle |

## Technical Notes
- LWW CRDT: `(timestamp, device_id)` tuple — higher timestamp wins, device_id breaks ties
- Deterministic Firestore doc IDs via SHA256 to prevent duplicates on retry
- Thread-safe SQLite with `threading.Lock` (matches existing autoscaler pattern)
- Frontend uses existing `idb` (v8) and `zustand` (v5) — no new deps
- Backend uses stdlib `sqlite3` — no new deps
- Configurable via env: `SYNC_WORKER_POLL_INTERVAL`, `SYNC_WORKER_BATCH_SIZE`, `SYNC_WORKER_MAX_ATTEMPTS`, `OFFLINE_SYNC_DB_PATH`

## Integration Note
Any existing code writing directly to Firestore `farm_intelligence_history` should be updated to use:
```python
from persistence.offline_sync import queue_write
queue_write(uid, payload, device_id)