### PR TITLE
fix: image_processing_queue.py drops EXIF-rotated images silently — no orientation normalization before MobileNet inference

### DIFF
--- a/image_processing_queue.py
+++ b/image_processing_queue.py
@@ -22,6 +22,8 @@ import heapq
 import threading
 import time
 import random
+from PIL import Image, ExifTags
+import io
 
 logger = logging.getLogger(__name__)
 
@@ -101,6 +103,7 @@ class ImageProcessingTask:
 
     worker_id: Optional[str] = None
     metadata: Dict = field(default_factory=dict)
+    orientation_metadata: Optional[Dict] = None
 
 
 # -----------------------------
@@ -350,9 +353,85 @@ class ImageProcessingPipeline:
         self.workers: Dict[str, ImageProcessingWorker] = {}
         self.max_workers = max_workers
 
-    def submit(self, **kwargs) -> str:
+    def _extract_exif_orientation(self, image_data: bytes) -> tuple[int, Optional[Dict]]:
+        """Extract EXIF orientation from raw image bytes. Returns (orientation, metadata_dict)."""
+        try:
+            img = Image.open(io.BytesIO(image_data))
+            exif = img._getexif()
+            if exif is None:
+                return 1, None
+
+            orientation_tag = next(
+                (tag for tag, name in ExifTags.TAGS.items() if name == "Orientation"),
+                None,
+            )
+            if orientation_tag is None:
+                return 1, None
+
+            orientation = exif.get(orientation_tag, 1)
+            metadata = {
+                "original_orientation": orientation,
+                "width": img.width,
+                "height": img.height,
+                "format": img.format,
+            }
+            return orientation, metadata
+        except Exception as exc:
+            logger.warning("EXIF extraction failed: %s", exc)
+            return 1, None
+
+    def _normalize_orientation(self, image_data: bytes, orientation: int) -> bytes:
+        """Apply rotation/flop based on EXIF orientation tag, return normalized JPEG bytes."""
+        if orientation == 1:
+            return image_data  # Normal, no change
+
+        try:
+            img = Image.open(io.BytesIO(image_data))
+
+            # Orientation mapping: https://jdhao.github.io/2019/07/31/image_rotation_exif_info/
+            transforms = {
+                2: (Image.FLIP_LEFT_RIGHT,),
+                3: (Image.ROTATE_180,),
+                4: (Image.FLIP_TOP_BOTTOM,),
+                5: (Image.TRANSPOSE,),  # Mirror across top-left diagonal
+                6: (Image.ROTATE_270,),  # 90° CW
+                7: (Image.TRANSVERSE,),  # Mirror across top-right diagonal
+                8: (Image.ROTATE_90,),    # 90° CCW
+            }
+
+            for transform in transforms.get(orientation, ()):
+                img = img.transpose(transform)
+
+            # Strip EXIF and save as JPEG
+            output = io.BytesIO()
+            img.save(output, format="JPEG", quality=95)
+            normalized = output.getvalue()
+
+            logger.info(
+                "Normalized EXIF orientation %d for image (size: %d -> %d bytes)",
+                orientation,
+                len(image_data),
+                len(normalized),
+            )
+            return normalized
+        except Exception as exc:
+            logger.error("Orientation normalization failed: %s", exc)
+            return image_data  # Fallback to original
+
+    def submit(self, image_data: bytes, **kwargs) -> str:
+        orientation, orientation_meta = self._extract_exif_orientation(image_data)
+
+        if orientation != 1 and orientation_meta:
+            logger.warning(
+                "Image submitted with EXIF orientation %d (expected 1). Normalizing before queueing.",
+                orientation,
+            )
+            image_data = self._normalize_orientation(image_data, orientation)
+
         task = ImageProcessingTask(
             task_id=f"task-{uuid.uuid4().hex[:12]}",
+            image_data=image_data,
+            orientation_metadata=orientation_meta,
             **kwargs,
         )
         return self.queue.enqueue(task)

--- a/test_image_processing_queue.py
+++ b/test_image_processing_queue.py
@@ -425,5 +425,114 @@ class TestImageProcessingPipeline:
         assert status["status"] == "queued"
 
 
+class TestExifOrientationNormalization:
+    """Test EXIF orientation extraction and normalization"""
+
+    def test_orientation_1_no_change(self):
+        """Test orientation 1 (normal) returns identical bytes"""
+        pipeline = ImageProcessingPipeline()
+
+        # Create a minimal valid JPEG (1x1 pixel, no EXIF)
+        from PIL import Image
+        import io
+        img = Image.new("RGB", (10, 10), color="red")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw = buf.getvalue()
+
+        orientation, meta = pipeline._extract_exif_orientation(raw)
+        assert orientation == 1
+        assert meta is None or meta.get("original_orientation") == 1
+
+        normalized = pipeline._normalize_orientation(raw, 1)
+        assert normalized == raw
+
+    def test_orientation_3_180_degrees(self):
+        """Test orientation 3 (180° rotation)"""
+        pipeline = ImageProcessingPipeline()
+
+        from PIL import Image
+        import io
+        img = Image.new("RGB", (20, 10), color="blue")  # Wide rectangle
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw = buf.getvalue()
+
+        # Manually rotate 180° to simulate orientation 3
+        img_rot = img.rotate(180)
+        buf_rot = io.BytesIO()
+        img_rot.save(buf_rot, format="JPEG")
+        raw_rot = buf_rot.getvalue()
+
+        # Normalize should flip it back to original dimensions
+        normalized = pipeline._normalize_orientation(raw_rot, 3)
+        result_img = Image.open(io.BytesIO(normalized))
+        assert result_img.size == (20, 10)
+
+    def test_orientation_6_90_cw(self):
+        """Test orientation 6 (90° CW) — portrait photo from mobile"""
+        pipeline = ImageProcessingPipeline()
+
+        from PIL import Image
+        import io
+        img = Image.new("RGB", (10, 20), color="green")  # Tall rectangle
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw = buf.getvalue()
+
+        # Simulate 90° CW rotation (width/height swap)
+        img_rot = img.rotate(270, expand=True)  # PIL rotate is CCW, so 270 = 90 CW
+        buf_rot = io.BytesIO()
+        img_rot.save(buf_rot, format="JPEG")
+        raw_rot = buf_rot.getvalue()
+
+        # Normalize should restore original portrait dimensions
+        normalized = pipeline._normalize_orientation(raw_rot, 6)
+        result_img = Image.open(io.BytesIO(normalized))
+        assert result_img.size == (10, 20)
+
+    def test_orientation_8_90_ccw(self):
+        """Test orientation 8 (90° CCW)"""
+        pipeline = ImageProcessingPipeline()
+
+        from PIL import Image
+        import io
+        img = Image.new("RGB", (10, 20), color="yellow")  # Tall rectangle
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw = buf.getvalue()
+
+        # Simulate 90° CCW rotation
+        img_rot = img.rotate(90, expand=True)
+        buf_rot = io.BytesIO()
+        img_rot.save(buf_rot, format="JPEG")
+        raw_rot = buf_rot.getvalue()
+
+        # Normalize should restore original portrait dimensions
+        normalized = pipeline._normalize_orientation(raw_rot, 8)
+        result_img = Image.open(io.BytesIO(normalized))
+        assert result_img.size == (10, 20)
+
+    def test_submit_with_orientation_metadata(self):
+        """Test that submit() attaches orientation metadata to task"""
+        pipeline = ImageProcessingPipeline()
+
+        from PIL import Image
+        import io
+        img = Image.new("RGB", (10, 20), color="purple")
+        buf = io.BytesIO()
+        img.save(buf, format="JPEG")
+        raw = buf.getvalue()
+
+        task_id = pipeline.submit(image_data=raw, crop_type="wheat", processor_type="disease_detection")
+        task = pipeline.queue._tasks_by_id.get(task_id)
+
+        assert task is not None
+        assert task.orientation_metadata is not None
+        assert task.orientation_metadata["original_orientation"] == 1
+        assert task.orientation_metadata["width"] == 10
+        assert task.orientation_metadata["height"] == 20
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])


### PR DESCRIPTION
Closes #1921

## Changes by file

| File | Change |
|------|--------|
| `image_processing_queue.py` | Add `_extract_exif_orientation()` and `_normalize_orientation()` helpers; integrate into `submit()`; add `orientation_metadata` field to `ImageProcessingTask` |
| `test_image_processing_queue.py` | Add `TestExifOrientationNormalization` with tests for Orientation 1, 3, 6, 8 |

## Technical Notes

- **No new dependencies**: Uses existing `Pillow` (already in `requirements.txt`)
- **All 8 EXIF orientations handled**: 1=normal, 2=flip H, 3=180°, 4=flip V, 5=transpose, 6=90° CW, 7=transverse, 8=90° CCW
- **Silent failure prevention**: Images are normalized at submission time, before queueing — model always sees upright images
- **Audit trail**: `orientation_metadata` captures original orientation, dimensions, and format for debugging
- **Mobile portrait fix**: Orientation 6 (90° CW) is the most common mobile camera case; now correctly normalized

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Images with EXIF orientation metadata are now automatically corrected and normalized, ensuring they display in the proper orientation regardless of how they were captured or rotated
  * The image processing pipeline now detects and corrects image orientation internally, rotating or flipping images as needed to restore proper dimensions and visual appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->