### PR TITLE
fix: improve client IP resolution for rate limiting

### DIFF
--- a/backend/compute_rate_limit.py
+++ b/backend/compute_rate_limit.py
@@ -22,6 +22,7 @@ import logging
 import os
 from datetime import datetime, timezone
 from math import ceil
+from ipaddress import ip_address
 from threading import Lock
 from time import monotonic
 from typing import Optional
@@ -72,12 +73,44 @@ def reset_compute_rate_limit_state() -> None:
         _last_compute_rate_limit_prune = 0.0
 
 
+def _extract_client_ip(request: Request) -> Optional[str]:
+    forwarded_for = request.headers.get("x-forwarded-for")
+
+    if forwarded_for:
+        for candidate in forwarded_for.split(","):
+            candidate = candidate.strip()
+
+            try:
+                ip_address(candidate)
+                return candidate.lower()
+            except ValueError:
+                continue
+
+    real_ip = request.headers.get("x-real-ip")
+    if real_ip:
+        try:
+            ip_address(real_ip.strip())
+            return real_ip.strip().lower()
+        except ValueError:
+            pass
+
+    if request.client and request.client.host:
+        try:
+            ip_address(request.client.host.strip())
+            return request.client.host.strip().lower()
+        except ValueError:
+            pass
+
+    return None
+
 def _request_actor_key(request: Request, uid: Optional[str]) -> str:
     if uid:
         return f"uid:{uid.strip().lower()}"
 
-    if request.client and request.client.host:
-        return f"ip:{request.client.host.strip().lower()}"
+    client_ip = _extract_client_ip(request)
+
+    if client_ip:
+        return f"ip:{client_ip}"
 
     return "ip:unknown"
 


### PR DESCRIPTION
## 📝 Description

This PR improves rate-limit actor identification for unauthenticated requests when the application is deployed behind reverse proxies, load balancers, API gateways, or ingress controllers.

Previously, the rate limiter relied solely on `request.client.host`, which can resolve to the proxy IP instead of the actual client IP. This could cause multiple users to share the same rate-limit bucket, resulting in unintended throttling and inaccurate rate-limit tracking.

### Changes Made

- Added support for extracting client IPs from `X-Forwarded-For` headers.
- Added support for extracting client IPs from `X-Real-IP` headers.
- Added IP address validation before accepting forwarded values.
- Introduced a dedicated helper function to centralize client IP resolution logic.
- Preserved fallback behavior using `request.client.host` when forwarded headers are unavailable.

---

## 🎯 Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2314 

---

## 🧪 Testing Done

- [x] Tested locally
- [ ] Checked UI responsiveness
- [x] Verified API / backend changes (if applicable)

### Test Scenarios

- Verified authenticated users continue using UID-based rate limiting.
- Verified `X-Forwarded-For` client IP extraction.
- Verified `X-Real-IP` fallback behavior.
- Verified fallback to `request.client.host`.
- Verified malformed IP values are ignored safely.

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

---

## 📌 Additional Notes

This change is backward compatible and only affects how client identities are derived for IP-based rate limiting. Existing UID-based rate limiting behavior remains unchanged.