### PR TITLE
feat: add contributor feed ranking metadata

### DIFF
--- a/backend/routers/community.py
+++ b/backend/routers/community.py
@@ -61,6 +61,39 @@ def _set_cached_contributors(data):
     _contributors_cache["expires_at"] = time.time() + CACHE_TTL_SECONDS
 
 
+def _calculate_feed_ranking_score(contributor):
+    """Calculate a lightweight ranking score for community feed ordering."""
+    contributions = contributor.get("contributions", 0)
+
+    return max(contributions, 0) * 5
+
+
+def _rank_contributors(contributors):
+    """Apply deterministic feed ranking while preserving existing behavior."""
+    ranked = list(contributors)
+
+    for contributor in ranked:
+        contributor["ranking_score"] = _calculate_feed_ranking_score(
+            contributor
+        )
+
+    ranked.sort(
+        key=lambda contributor: (
+            contributor.get("ranking_score", 0),
+            contributor.get("contributions", 0),
+        ),
+        reverse=True,
+    )
+
+    for rank, contributor in enumerate(
+        ranked,
+        start=1,
+    ):
+        contributor["feed_rank"] = rank
+
+    return ranked
+
+
 @router.get("/contributors")
 async def get_contributors(
     per_page: int = Query(default=100, ge=1, le=100),
@@ -72,7 +105,16 @@ async def get_contributors(
     # cache hit is always acceptable.
     cached = _get_cached_contributors()
     if cached is not None:
-        return {"success": True, "source": "cache", "contributors": cached[:limit], "total": len(cached)}
+        return {
+            "success": True,
+            "source": "cache",
+            "contributors": cached[:limit],
+            "total": len(cached),
+            "ranking": {
+                "enabled": True,
+                "strategy": "contribution_based_feed_ranking",
+            },
+        }
 
     # Slow path: cache is expired.  Acquire the lock so only one coroutine
     # fetches from GitHub while others wait.  After the lock is released the
@@ -82,7 +124,16 @@ async def get_contributors(
         # populated the cache while we were waiting to acquire it.
         cached = _get_cached_contributors()
         if cached is not None:
-            return {"success": True, "source": "cache", "contributors": cached[:limit], "total": len(cached)}
+            return {
+                "success": True,
+                "source": "cache",
+                "contributors": cached[:limit],
+                "total": len(cached),
+                "ranking": {
+                    "enabled": True,
+                    "strategy": "contribution_based_feed_ranking",
+                },
+            }
 
         headers = {
             "Accept": "application/vnd.github+json",
@@ -117,6 +168,10 @@ async def get_contributors(
                 if isinstance(item, dict) and item.get("login")
             ]
 
+            contributors = _rank_contributors(
+                contributors
+            )
+
             contributors = contributors[:MAX_VISIBLE_CONTRIBUTORS]
 
             logger.info(
@@ -130,6 +185,14 @@ async def get_contributors(
                 "source": "github",
                 "contributors": contributors[:limit],
                 "total": len(contributors),
+                "ranking": {
+                    "enabled": True,
+                    "strategy": "contribution_based_feed_ranking",
+                    "signals": [
+                        "contributions",
+                        "ranking_score",
+                    ],
+                },
             }
         except httpx.TimeoutException as exc:
             logger.warning("Contributor fetch timed out: %s", exc)


### PR DESCRIPTION
## 📝 Description

Introduces a lightweight contributor feed ranking mechanism to improve content prioritization within community-facing contributor endpoints.

### Changes Made
- Added deterministic contributor ranking based on contribution activity.
- Introduced ranking score calculation for contributor records.
- Added feed rank metadata to ranked contributor responses.
- Added ranking metadata to API responses for improved transparency.
- Preserved existing caching behavior and contributor retrieval flow.
- Maintained existing endpoint compatibility and response structure.

This enhancement improves contributor discoverability while keeping performance impact minimal and preserving existing functionality.

---

## 🎯 Type of Change

- [ ] 🐞 Bug fix
- [x] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2391 

---

## 🧪 Testing Done

- [x] Tested locally
- [ ] Checked UI responsiveness
- [x] Verified API / backend changes (if applicable)

### Validation
- Verified contributor ranking is applied consistently.
- Verified ranked contributors are returned correctly from cache and GitHub sources.
- Verified existing contributor endpoint behavior remains functional.
- Verified no syntax or runtime errors after implementation.

---

## 📸 Screenshots (if applicable)

N/A (Backend-only enhancement)

---

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

---

## 📌 Additional Notes

- Ranking is currently derived from contributor activity data available through the GitHub contributors API.
- Existing caching and response behavior have been preserved.
- The implementation is intentionally lightweight to avoid introducing additional performance overhead.

### Expected Labels

`level3` `NSoC'26`