### PR TITLE
fix: ensure tenant_id is defined during tenant validation (#2557)

### DIFF
--- a/rbac.py
+++ b/rbac.py
@@ -416,6 +416,17 @@ class RBACManager:
                 detail="Authentication database lookup failed",
             ) from exc
 
+        if not user_doc.exists:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail="User profile not found",
+            )
+
+        profile = user_doc.to_dict() or {}
+        roles = RBACManager._normalize_roles(profile)
+        role_str = RBACManager._effective_role(roles)
+        tenant_id = RBACManager._extract_tenant(profile)
+
         claim_tenant = RBACManager._extract_tenant(decoded_token)
         if claim_tenant and tenant_id and claim_tenant != tenant_id:
             logger.warning(

--- a/rbac.py
+++ b/rbac.py
@@ -396,16 +396,12 @@ class RBACManager:
                 detail="Invalid or expired authorization token",
             )
 
-            # Verify Firebase token
-            try:
-                decoded_token = firebase_auth.verify_id_token(token, check_revoked=True)
-                uid = decoded_token.get("uid")
-            except Exception as exc:
-                logger.error("Token verification failed: %s", exc)
-                raise HTTPException(
-                    status_code=status.HTTP_401_UNAUTHORIZED,
-                    detail="Invalid or expired authorization token"
-                )
+        db = RBACManager.get_db()
+        if not db:
+            raise HTTPException(
+                status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+                detail="Authentication database unavailable",
+            )
 
         try:
             # Firestore's .get() is a blocking network call; run it off the
@@ -419,17 +415,6 @@ class RBACManager:
                 status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
                 detail="Authentication database lookup failed",
             ) from exc
-
-            try:
-                user_doc = await asyncio.to_thread(
-                    db.collection("users").document(uid).get,
-                )
-            except Exception as exc:
-                logger.error("Firestore query failed for user %s: %s", uid, exc)
-                raise HTTPException(
-                    status_code=status.HTTP_403_FORBIDDEN,
-                    detail=STALE_TOKEN_DETAIL,
-                )
 
         claim_tenant = RBACManager._extract_tenant(decoded_token)
         if claim_tenant and tenant_id and claim_tenant != tenant_id:


### PR DESCRIPTION
## 📝 Description

This PR resolves an issue in the authentication workflow where `tenant_id` could be referenced before being properly initialized during tenant validation.

The validation logic has been updated to ensure a valid tenant identifier is always available before performing tenant consistency checks. This prevents runtime errors and improves the reliability of the authentication flow.

---

## 🎯 Type of Change

* [x] 🐞 Bug fix
* [ ] ✨ New feature
* [ ] 📚 Documentation update
* [ ] ♻️ Refactoring
* [ ] 🎨 UI/UX improvement
* [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2557

---

## 🧪 Testing Done

* [x] Tested locally
* [ ] Checked UI responsiveness
* [x] Verified API / backend changes (if applicable)

### Verification Performed

* Reviewed tenant validation workflow.
* Verified `tenant_id` is initialized before use.
* Confirmed authentication flow executes without runtime errors.
* Verified existing authorization behavior remains unchanged.

---

## 📸 Screenshots (if applicable)

N/A – Backend authentication fix.

---

## ✅ Checklist

* [x] My code follows the project coding standards
* [x] I have self-reviewed my code
* [x] My changes do not generate new warnings
* [x] I have tested my changes properly
* [x] Existing features are not broken

---

## 📌 Additional Notes

This fix focuses on the minimal change required to ensure safe tenant validation while preserving existing authentication behavior.
