### PR TITLE
fix: update autoscaler dependencies when singleton already exists

### DIFF
--- a/celery_autoscaler.py
+++ b/celery_autoscaler.py
@@ -267,6 +267,14 @@ _autoscaler: Optional[CeleryAutoscaler] = None
 
 def get_autoscaler(celery_app: Celery = None, price_forecaster=None) -> CeleryAutoscaler:
     global _autoscaler
+
     if _autoscaler is None:
         _autoscaler = CeleryAutoscaler(celery_app, price_forecaster)
+    else:
+        if celery_app is not None:
+            _autoscaler.celery_app = celery_app
+
+        if price_forecaster is not None:
+            _autoscaler.price_forecaster = price_forecaster
+
     return _autoscaler


### PR DESCRIPTION
## Summary

This PR fixes an issue where `get_autoscaler()` ignored updated dependencies after the singleton instance was initialized.

## Problem

The current implementation only uses the provided `celery_app` and `price_forecaster` during the first call:

```python
if _autoscaler is None:
    _autoscaler = CeleryAutoscaler(celery_app, price_forecaster)
```

Subsequent calls always return the existing instance without updating dependencies, causing stale references to be retained.

## Changes Made

* Preserved singleton behavior.
* Updated `celery_app` when a new instance is supplied.
* Updated `price_forecaster` when a new dependency is supplied.
* Ensured existing callers continue to work without modification.

## Proof of the Issue

Example:

```python
autoscaler1 = get_autoscaler(app1, forecaster1)
autoscaler2 = get_autoscaler(app2, forecaster2)
```

Before this fix, the singleton continued using `app1` and `forecaster1` because the existing instance was always returned unchanged.

After this fix, supplied dependencies are refreshed when non-None values are provided.

<img width="827" height="357" alt="Screenshot 2026-06-13 091636" src="https://github.com/user-attachments/assets/a5b9e298-264e-433d-aa1a-017a8bc930bb" />

## Impact

* Prevents stale dependency references.
* Improves consistency across application initialization paths.
* Maintains singleton semantics while respecting updated dependencies.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved autoscaler configuration to allow updating application settings and forecasting parameters after initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->