### PR TITLE
fix: remove duplicate finance router mount under /api/farm-finance 

### DIFF
--- a/main.py
+++ b/main.py
@@ -1637,8 +1637,7 @@ except Exception as exc:
 # Router registration
 app.include_router(ml.router, prefix="/api/yield", tags=["ML Prediction"])
 app.include_router(governance.router, prefix="/api/ml-governance", tags=["ML Governance"])
-app.include_router(finance.router, prefix="/api/farm-finance", tags=["Finance"])
-app.include_router(finance.router, prefix="/api/finance", tags=["Finance Legacy"])
+app.include_router(finance.router, prefix="/api/finance", tags=["Finance"])
 app.include_router(quality.router, prefix="/api/crop-quality", tags=["Quality"])
 app.include_router(blockchain.router, prefix="/api/supply-chain", tags=["Blockchain"])
 app.include_router(reports.router, prefix="/api/admin", tags=["Reports"])


### PR DESCRIPTION
closes #2776 

The finance router was mounted twice:
- /api/farm-finance (redundant)
- /api/finance (primary)

This created duplicate endpoints serving identical marketplace data through both paths, causing unnecessary confusion and potential routing conflicts.

Removed the duplicate /api/farm-finance mount and kept only /api/finance as the single source of truth for all finance-related endpoints including:
- POST /api/finance/analyze
- POST /api/finance/applications
- GET /api/finance/applications/{id}
- GET /api/finance/products
- GET /api/finance/marketplace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated finance API endpoints under a single `/api/finance` prefix.
  * Removed legacy finance route variants (`/api/farm-finance` and legacy-tagged endpoints).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->