### PR TITLE
fix: correct FileLock usage in subscriber store

### DIFF
--- a/whatsapp_store.py
+++ b/whatsapp_store.py
@@ -33,7 +33,7 @@ import os
 import tempfile
 import threading
 from typing import Dict, Optional
-
+from filelock import FileLock
 
 logger = logging.getLogger(__name__)
 
@@ -49,10 +49,15 @@ class SubscriberStore:
     - snapshot reads
     """
 
-    def __init__(self, storage_path: str = "subscribers.json"):
+    def __init__(self, storage_path: str = "subscribers.json", timeout: int = 10):
         self.storage_path = storage_path
         self._lock = threading.Lock()
+        self._lock_filepath = f"{storage_path}.lock"
+        self._timeout = timeout
         self._filelock = FileLock(self._lock_filepath, timeout=self._timeout)
+        self._subscribers: Dict[str, Dict] = {}
+        self._load()
+
 
     # ------------------------------------------------------------------
     # Private helpers (must be called with locks already held)
@@ -97,11 +102,12 @@ class SubscriberStore:
         """
         Safely load subscribers from disk.
         """
-
-        with self._lock:
-            if not os.path.exists(self.storage_path):
-                self._subscribers = {}
-                return
+    
+        with self._filelock:   # distributed-safe lock
+            with self._lock:   # thread-safe lock
+                if not os.path.exists(self.storage_path):
+                    self._subscribers = {}
+                    return
 
             try:
                 with open(self.storage_path, "r", encoding="utf-8") as f:
@@ -111,60 +117,59 @@ class SubscriberStore:
                     raise ValueError("Subscriber data must be a dictionary")
 
                 self._subscribers = data
+                logger.info("Loaded %s subscribers", len(self._subscribers))
 
-                logger.info(
-                    "Loaded %s subscribers",
-                    len(self._subscribers),
-                )
+            except json.JSONDecodeError:
+
+                # backup corrupted file
+                backup = self.storage_path + ".bak"
+                os.replace(self.storage_path, backup)
+
+                logger.error("Subscriber file corrupt, backed up to %s", backup)
+                self._subscribers = {}
+
 
             except Exception:
-                logger.exception(
-                    "Failed loading subscriber store"
-                )
-
+                logger.exception("Failed loading subscriber store")
                 self._subscribers = {}
+
 
     def _save(self) -> None:
         """
         Atomically save subscribers to disk.
         """
 
-        with self._lock:
-            directory = os.path.dirname(self.storage_path) or "."
+        with self._filelock: 
+              # distributed-safe lock
+            with self._lock:   # thread-safe lock
 
-            os.makedirs(directory, exist_ok=True)
+                directory = os.path.dirname(self.storage_path) or "."
+                os.makedirs(directory, exist_ok=True)
 
-            fd, temp_path = tempfile.mkstemp(
-                dir=directory,
-                prefix="subs_",
-                suffix=".tmp",
-            )
-
+            fd, temp_path = tempfile.mkstemp(dir=directory, prefix="subs_", suffix=".tmp")
+            
             try:
-                with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
-                    json.dump(
-                        self._subscribers,
-                        tmp_file,
-                        indent=2,
-                        ensure_ascii=False,
-                    )
 
+                with os.fdopen(fd, "w", encoding="utf-8") as tmp_file:
+
+                    json.dump(self._subscribers, tmp_file, indent=2, ensure_ascii=False)
                     tmp_file.flush()
                     os.fsync(tmp_file.fileno())
+                    os.replace(temp_path, self.storage_path)
 
-                os.replace(temp_path, self.storage_path)
 
             except Exception:
-                logger.exception(
-                    "Failed saving subscriber store"
-                )
+
+                logger.exception("Failed saving subscriber store")
 
                 try:
                     os.remove(temp_path)
                 except OSError:
-                    pass
 
+                    pass
+                
                 raise
+
 
     # =========================================================================
     # PUBLIC API


### PR DESCRIPTION
## 📝 Description
Fixed incorrect `FileLock` usage in `whatsapp_store.py`.  
- Defined `_lock_filepath` and `_timeout` in `SubscriberStore.__init__`.  
- Ensured `_load` and `_save` use file-based locking for distributed safety.  
- Implemented atomic writes with `.tmp` + `os.replace()` for crash safety.  
- Added backup handling when JSON is corrupted.  
- Improves reliability under concurrent access across multiple workers/threads.

---

## 🎯 Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2369

---

## 🧪 Testing Done

- [x] Tested locally  
- [x] Verified concurrent upsert/remove with threads does not corrupt file  
- [x] Verified corrupted JSON triggers backup and resets store  
- [ ] Verified API / backend changes (if applicable)  

---


## ✅ Checklist
- [x] My code follows the project coding standards  
- [x] I have self-reviewed my code  
- [x] I have commented complex logic where needed  
- [x] My changes do not generate new warnings  
- [x] I have tested my changes properly  
- [x] Existing features are not broken  

---

## 📌 Additional Notes

- Ensures subscriber persistence is safe in distributed deployments.  
- Prevents startup crashes and silent data loss.  
- Future improvement: consider migrating to SQLite for stronger transactional guarantees.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved data persistence reliability to prevent subscriber data loss during unexpected shutdowns.
  * Enhanced recovery and automatic handling of corrupted data files.
  * Added safer concurrent access support for subscriber data storage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->