### PR TITLE
fix: correct indentation of experiment status check in evaluate_winner (#2661)

### DIFF
--- a/feature_flags/ab_testing_runner.py
+++ b/feature_flags/ab_testing_runner.py
@@ -110,8 +110,7 @@ class ABTestingRunner:
                 "already_promoted",
                 metrics,
             )
-            
-            if experiment.get("status") != "running":
+        if experiment.get("status") != "running":
             return PromotionDecision(
                 self.experiment_id,
                 None,


### PR DESCRIPTION
## 📝 Description

This PR resolves an issue in `evaluate_winner` where an incorrectly indented status validation block became unreachable and could also trigger syntax/import failures.

The status check for non-running experiments has been corrected and aligned with the intended control flow, ensuring validation logic executes in the proper sequence.

---

## 🎯 Type of Change

* [x] 🐞 Bug fix
* [ ] ✨ New feature
* [ ] 📚 Documentation update
* [ ] ♻️ Refactoring
* [ ] 🎨 UI/UX improvement
* [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2661

---

## 🧪 Testing Done

* [x] Tested locally
* [x] Verified module imports successfully
* [x] Verified evaluate_winner execution flow
* [x] Confirmed no syntax or indentation errors

---

## 📸 Screenshots (if applicable)

N/A – Backend logic fix.

---

## ✅ Checklist

* [x] My code follows the project coding standards
* [x] I have self-reviewed my code
* [x] My changes do not generate new warnings
* [x] I have tested my changes properly
* [x] Existing features are not broken

---

## 📌 Additional Notes

This fix is intentionally minimal and only corrects the control-flow structure required to restore the intended validation behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal logic in experiment evaluation with more explicit status handling and clearer decision reasoning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->