### PR TITLE
fix: unify feedback API rate limiting configuration (#2666)

### DIFF
--- a/backend/tests/test_feedback_rate_limit.py
+++ b/backend/tests/test_feedback_rate_limit.py
@@ -1,6 +1,8 @@
 import pytest
 from fastapi.testclient import TestClient
 from backend.main import app
+import os
+import feedback_api
 
 client = TestClient(app)
 
@@ -23,3 +25,10 @@ def test_rate_limit_by_uid(monkeypatch):
         client.post("/submit-feedback", json={"message": "spam"})
     r2 = client.post("/submit-feedback", json={"message": "spam"})
     assert r2.status_code == 429  # Too Many Requests
+
+def test_limiter_env_config(monkeypatch):
+    # Verify that the limiter reads from FEEDBACK_RATE_LIMIT environment variable
+    monkeypatch.setenv("FEEDBACK_RATE_LIMIT", "100/minute")
+    import importlib
+    importlib.reload(feedback_api)
+    assert any("100/minute" in str(limit) for limit in feedback_api.limiter.default_limits)

--- a/feedback_api.py
+++ b/feedback_api.py
@@ -221,13 +221,6 @@ def _feedback_rate_key(request: Request) -> str:
         return token[-32:] if len(token) >= 32 else token
     return extract_client_ip(request)
 
-# The limiter is attached to app.state so the @limiter.limit() decorator
-# can resolve it at request time.
-limiter = build_limiter(default_limits=["120/minute"])
-app.state.limiter = limiter
-app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
-# ─────────────────────────────────────────────────────────────────────────────
-
 from slowapi.util import get_remote_address
 
 def feedback_rate_limit_key(request: Request):
@@ -241,7 +234,12 @@ def feedback_rate_limit_key(request: Request):
     return get_remote_address(request)
 
 # ── Rate limiting ─────────────────────────────────────────────────────────────
-limiter = Limiter(key_func=feedback_rate_limit_key, default_limits=["120/minute"])
+# The limiter is attached to app.state so the @limiter.limit() decorator
+# can resolve it at request time.
+limiter = Limiter(
+    key_func=feedback_rate_limit_key,
+    default_limits=[os.getenv("FEEDBACK_RATE_LIMIT", "120/minute")]
+)
 app.state.limiter = limiter
 app.add_exception_handler(RateLimitExceeded, rate_limit_exceeded_handler)
 # ─────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## 📝 Description

This PR resolves inconsistent request throttling behavior caused by multiple rate limiter configurations being applied within the feedback API.

The implementation has been simplified to use a single authoritative rate limiting configuration, ensuring predictable throttling behavior and easier maintenance.

### Changes Made

* Removed duplicate rate limiter registrations.
* Retained a single rate limiting configuration.
* Updated associated test coverage.
* Preserved existing feedback submission functionality.

---

## 🎯 Type of Change

* [x] 🐞 Bug fix
* [ ] ✨ New feature
* [ ] 📚 Documentation update
* [ ] ♻️ Refactoring
* [ ] 🎨 UI/UX improvement
* [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2666

---

## 🧪 Testing Done

* [x] Tested locally
* [x] Verified feedback API functionality
* [x] Verified rate limiting behavior
* [x] Updated and executed related tests

---

## 📸 Screenshots (if applicable)

N/A – Backend API fix.

---

## ✅ Checklist

* [x] My code follows the project coding standards
* [x] I have self-reviewed my code
* [x] My changes do not generate new warnings
* [x] I have tested my changes properly
* [x] Existing features are not broken

---

## 📌 Additional Notes

This fix focuses on eliminating duplicate rate limiter configuration while preserving existing API behavior.
