### PR TITLE
fix: centralize crop thresholds and add missing typing imports (#2670)

### DIFF
--- a/advisory_rules.py
+++ b/advisory_rules.py
@@ -4,16 +4,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+from backend.core.constants import CROP_THRESHOLDS
+
 LOW_LEVELS = {"verylow", "very low", "low", "deficient"}
 HIGH_LEVELS = {"veryhigh", "very high", "high", "excess"}
-
-CROP_THRESHOLDS = {
-    "rice": {"temp_ideal": (20, 30), "moisture_min": 50, "ph_range": (6.0, 7.5)},
-    "paddy": {"temp_ideal": (20, 30), "moisture_min": 50, "ph_range": (6.0, 7.5)},
-    "wheat": {"temp_ideal": (10, 25), "moisture_min": 30, "ph_range": (6.5, 7.5)},
-    "cotton": {"temp_ideal": (21, 27), "moisture_min": 35, "ph_range": (6.0, 7.5)},
-    "maize": {"temp_ideal": (18, 26), "moisture_min": 40, "ph_range": (6.0, 7.0)},
-}
 
 NUTRIENT_THRESHOLDS = {
     "nitrogen": {"low": 140, "high": 360},

--- a/alert_rules.py
+++ b/alert_rules.py
@@ -1,52 +1,11 @@
 from datetime import datetime
-from typing import Optional
+from typing import Optional, Dict, Any, List
 import logging
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
-CROP_THRESHOLDS = {
-    "rice": {
-        "temp_min": 20,
-        "temp_max": 30,
-        "moisture_min": 50,
-        "ph_min": 6.0,
-        "ph_max": 7.5,
-        "critical_stages": ["tillering", "flowering", "grain-filling"]
-    },
-    "wheat": {
-        "temp_min": 10,
-        "temp_max": 25,
-        "moisture_min": 30,
-        "ph_min": 6.5,
-        "ph_max": 7.5,
-        "critical_stages": ["crown-root-initiation", "tillering", "flowering"]
-    },
-    "cotton": {
-        "temp_min": 21,
-        "temp_max": 27,
-        "moisture_min": 35,
-        "ph_min": 6.0,
-        "ph_max": 7.5,
-        "critical_stages": ["flowering", "boll-formation"]
-    },
-    "maize": {
-        "temp_min": 18,
-        "temp_max": 26,
-        "moisture_min": 40,
-        "ph_min": 6.0,
-        "ph_max": 7.0,
-        "critical_stages": ["tasseling", "silking", "grain-filling"]
-    },
-    "sugarcane": {
-        "temp_min": 20,
-        "temp_max": 28,
-        "moisture_min": 45,
-        "ph_min": 6.5,
-        "ph_max": 8.0,
-        "critical_stages": ["sprouting", "grand-growth-phase"]
-    }
-}
+from backend.core.constants import CROP_THRESHOLDS
 
 
 def validate_inputs(

--- a/backend/core/constants.py
+++ b/backend/core/constants.py
@@ -1,0 +1,67 @@
+"""
+Shared configuration constants for the Fasal Saathi application.
+"""
+
+# Consolidated crop thresholds for advisory and alert engines
+CROP_THRESHOLDS = {
+    "rice": {
+        "temp_min": 20,
+        "temp_max": 30,
+        "moisture_min": 50,
+        "ph_min": 6.0,
+        "ph_max": 7.5,
+        "temp_ideal": (20, 30),
+        "ph_range": (6.0, 7.5),
+        "critical_stages": ["tillering", "flowering", "grain-filling"]
+    },
+    "paddy": {
+        "temp_min": 20,
+        "temp_max": 30,
+        "moisture_min": 50,
+        "ph_min": 6.0,
+        "ph_max": 7.5,
+        "temp_ideal": (20, 30),
+        "ph_range": (6.0, 7.5),
+        "critical_stages": ["tillering", "flowering", "grain-filling"]
+    },
+    "wheat": {
+        "temp_min": 10,
+        "temp_max": 25,
+        "moisture_min": 30,
+        "ph_min": 6.5,
+        "ph_max": 7.5,
+        "temp_ideal": (10, 25),
+        "ph_range": (6.5, 7.5),
+        "critical_stages": ["crown-root-initiation", "tillering", "flowering"]
+    },
+    "cotton": {
+        "temp_min": 21,
+        "temp_max": 27,
+        "moisture_min": 35,
+        "ph_min": 6.0,
+        "ph_max": 7.5,
+        "temp_ideal": (21, 27),
+        "ph_range": (6.0, 7.5),
+        "critical_stages": ["flowering", "boll-formation"]
+    },
+    "maize": {
+        "temp_min": 18,
+        "temp_max": 26,
+        "moisture_min": 40,
+        "ph_min": 6.0,
+        "ph_max": 7.0,
+        "temp_ideal": (18, 26),
+        "ph_range": (6.0, 7.0),
+        "critical_stages": ["tasseling", "silking", "grain-filling"]
+    },
+    "sugarcane": {
+        "temp_min": 20,
+        "temp_max": 28,
+        "moisture_min": 45,
+        "ph_min": 6.5,
+        "ph_max": 8.0,
+        "temp_ideal": (20, 28),
+        "ph_range": (6.5, 8.0),
+        "critical_stages": ["sprouting", "grand-growth-phase"]
+    }
+}

--- a/test_advisory_rules.py
+++ b/test_advisory_rules.py
@@ -29,3 +29,27 @@ def test_advisory_recommends_watering_for_high_temperature():
     )
 
     assert any("Water early morning" in alert["action"] for alert in alerts)
+
+
+def test_crop_thresholds_consistency():
+    import alert_rules
+    import advisory_rules
+    from backend.core.constants import CROP_THRESHOLDS
+    
+    assert alert_rules.CROP_THRESHOLDS is CROP_THRESHOLDS
+    assert advisory_rules.CROP_THRESHOLDS is CROP_THRESHOLDS
+    
+    # Check that keys required by advisory_rules are present
+    for crop, data in CROP_THRESHOLDS.items():
+        assert "temp_ideal" in data
+        assert "ph_range" in data
+        assert "moisture_min" in data
+        
+    # Check that keys required by alert_rules are present
+    for crop in ["rice", "wheat", "cotton", "maize", "sugarcane"]:
+        data = CROP_THRESHOLDS[crop]
+        assert "temp_min" in data
+        assert "temp_max" in data
+        assert "ph_min" in data
+        assert "ph_max" in data
+        assert "critical_stages" in data


### PR DESCRIPTION
## 📝 Description

This PR resolves Issues #2669 and #2670 by improving configuration management and type safety within the alert and advisory rule engines.

### Changes Made

#### Issue #2669

* Added missing typing imports:

  * `Dict`
  * `Any`
  * `List`
* Eliminated potential runtime and static-analysis issues.

#### Issue #2670

* Added centralized crop threshold configuration:

  * `backend/core/constants.py`
* Removed duplicate `CROP_THRESHOLDS` definitions from:

  * `alert_rules.py`
  * `advisory_rules.py`
* Updated both modules to consume the shared configuration source.
* Added consistency validation tests.

### Testing

* Added `test_crop_thresholds_consistency`
* Verified both modules reference the same configuration source.
* Executed advisory rule tests.

---

## 🎯 Type of Change

* [x] 🐞 Bug fix

---

## 🔗 Related Issue



Closes #2670

---

## ✅ Checklist

* [x] Code follows project standards
* [x] Self-reviewed changes
* [x] Existing functionality preserved
* [x] Added test coverage
* [x] No new warnings introduced

---

## 📌 Additional Notes

This change establishes a single source of truth for crop thresholds and reduces the risk of future configuration drift.
