### PR TITLE
fix(lms): Use centralized logging configuration instead of bypassing it

### DIFF
--- a/backend/routers/lms.py
+++ b/backend/routers/lms.py
@@ -9,7 +9,6 @@ authorization decisions.
 """
 import asyncio
 import hashlib
-import logging
 import secrets
 import time
 from collections import OrderedDict
@@ -20,8 +19,10 @@ from fastapi import APIRouter, HTTPException, Request
 from google.cloud import firestore
 from pydantic import BaseModel, Field
 
+from backend.core.logging_config import setup_logging
+
 router = APIRouter()
-logger = logging.getLogger(__name__)
+logger = setup_logging(__name__)
 
 # Per-user per-course certificate request cooldown (seconds).
 _CERT_COOLDOWN_SECONDS = 60


### PR DESCRIPTION
closes #1932)

- Replace logging.getLogger(__name__) with setup_logging(__name__)
- Add import: from backend.core.logging_config import setup_logging
- Remove direct import of logging module (no longer needed)
- LMS router now uses same centralized logging setup as other routers (advisory, community, etc.)
- Enables proper JSON formatting, context injection, OpenTelemetry trace ID propagation, and ContextFilter integration
- Fixes log structure inconsistency across application

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal logging configuration to use a standardized helper function across the LMS router module.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->