### PR TITLE
fix: use safe request body caching in middleware

### DIFF
--- a/middleware_utils.py
+++ b/middleware_utils.py
@@ -1,15 +1,35 @@
-import json
 from starlette.requests import Request
 
-async def ensure_body_available(request: Request):
+
+async def ensure_body_available(request: Request) -> bytes:
     """
-    Read and cache the request body, then re-inject it so downstream handlers
-    can still consume it.
+    Safely read and cache the request body.
+
+    Starlette caches request.body() internally, so downstream
+    middleware and endpoint handlers can continue accessing the
+    body without mutating request._receive or other private APIs.
     """
+
+    if hasattr(request.state, "_body_cache"):
+        return request.state._body_cache
+
     body = await request.body()
+    request.state._body_cache = body
 
-    async def receive():
-        return {"type": "http.request", "body": body, "more_body": False}
-
-    request._receive = receive
     return body
+
+
+async def get_cached_body(request: Request) -> bytes:
+    """
+    Return cached body if available, otherwise load it.
+    """
+
+    return await ensure_body_available(request)
+
+
+def has_cached_body(request: Request) -> bool:
+    """
+    Check whether request body has already been cached.
+    """
+
+    return hasattr(request.state, "_body_cache")

--- a/security_hygiene.py
+++ b/security_hygiene.py
@@ -12,6 +12,11 @@ from typing import Any, Tuple, Pattern, List, Dict, Optional
 from fastapi import Request
 from starlette.middleware.base import BaseHTTPMiddleware
 from starlette.responses import JSONResponse
+from middleware_utils import (
+    ensure_body_available,
+    get_cached_body,
+    has_cached_body,
+)
 
 # Maximum body size to scan (256 KB)
 MAX_SCAN_BODY_SIZE = 256 * 1024
@@ -172,7 +177,16 @@ class RuntimeProtectionMiddleware(BaseHTTPMiddleware):
 
         if should_scan:
             try:
-                body_bytes = await request.body()
+
+                # Safe request body access.
+                # request.body() is cached by Starlette, allowing middleware
+                # and downstream handlers to access the same payload without
+                # modifying request._receive.
+                
+                if has_cached_body(request):
+                    body_bytes = await get_cached_body(request)
+                else:
+                    body_bytes = await ensure_body_available(request)
                 path = request.url.path
 
                 # --- DoS fix: check cache before running any regex (#2366) ---
@@ -195,10 +209,6 @@ class RuntimeProtectionMiddleware(BaseHTTPMiddleware):
                         content={"error": "Request blocked by secrets hygiene policy"}
                     )
 
-                # Reset body read pointer so downstream handlers can consume it
-                async def receive():
-                    return {"type": "http.request", "body": body_bytes, "more_body": False}
-                request._receive = receive
             except Exception:
                 # Fallback in case of body read failures to avoid crashing the server
                 pass


### PR DESCRIPTION
## 📝 Description
Fixed unsafe request body handling in middleware by replacing direct `request._receive` mutation with a safe request body caching approach. Centralized request body access through reusable utilities and updated middleware to use cached request payloads without interfering with downstream handlers.

This ensures request bodies remain available to middleware and endpoint handlers while avoiding reliance on Starlette/FastAPI private internals.

---

## 🎯 Type of Change

- [x] 🐞 Bug fix
- [ ] ✨ New feature
- [ ] 📚 Documentation update
- [ ] ♻️ Refactoring
- [ ] 🎨 UI/UX improvement
- [ ] 🔧 Other

---

## 🔗 Related Issue

Closes #2611 

---

## 🧪 Testing Done

- [x] Tested locally
- [ ] Checked UI responsiveness
- [x] Verified API / backend changes (if applicable)

---

## 📸 Screenshots (if applicable)

N/A

---

## ✅ Checklist

- [x] My code follows the project coding standards
- [x] I have self-reviewed my code
- [x] I have commented complex logic where needed
- [x] My changes do not generate new warnings
- [x] I have tested my changes properly
- [x] Existing features are not broken

---

## 📌 Additional Notes

- Replaced unsafe request body restoration logic.
- Introduced safe request body caching utility.
- Updated middleware to reuse cached request bodies.
- Improved compatibility with FastAPI/Starlette request lifecycle.
- Reduced dependence on private framework APIs.

### Expected Labels
`level3` `NSoC'26`