### PR TITLE
fix(feature-flags): Fix feature flag seeding race condition with idempotent Firestore initialization

### DIFF
--- a/feature_flags/flag_store.py
+++ b/feature_flags/flag_store.py
@@ -114,10 +114,17 @@ def _refresh_cache_locked() -> None:
     loaded = _load_from_firestore()
     if not loaded:
         loaded = {fid: _enrich(fid, fdata) for fid, fdata in DEFAULT_FLAGS.items()}
-        if _FIRESTORE_AVAILABLE and not _defaults_seeded:
+        if _FIRESTORE_AVAILABLE:
             for fid, fdata in loaded.items():
-                _write_to_firestore(fid, fdata)
-            _defaults_seeded = True
+                 doc_ref = _fs_client.collection(COLLECTION).document(fid)
+                 try:
+                     
+                     doc_ref = _fs_client.collection(COLLECTION).document(fid)
+                     if not doc_ref.get().exists:
+                         doc_ref.set(fdata)
+                 except Exception as e:
+                     logger.error("Seeding failed for flag '%s': %s", fid, e)
+
     _cache = loaded
     _cache_loaded_at = time.monotonic()
 


### PR DESCRIPTION
### Description

Fixes a race condition in feature flag default seeding logic.
Replaces the in-memory seeding guard (_defaults_seeded) with an idempotent Firestore existence check to prevent duplicate writes across multiple instances.

This ensures feature flags are seeded safely in distributed / multi-instance environments without relying on local process state.

### Type of Change
 Bug fix

###  Related Issue
Closes #3014 

 ### Testing Done

1.  Tested locally
2.  Verified no duplicate writes in Firestore
3.  Confirmed flags are seeded correctly on first run
4.  Restarted app multiple times to verify idempotency

### Screenshots (if applicable)
N/A

### Checklist
 

- [x] My code follows the project coding standards
- [x]  I have self-reviewed my code
- [x]  I have commented complex logic where needed
- [x]  My changes do not generate new warnings
- [x]  I have tested my changes properly
- [x]  Existing features are not broken

### Additional Notes

1. Removes dependency on _defaults_seeded
2. Makes seeding safe for multi-instance deployments
3. No API or interface changes
4. Fully backward compatible



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved feature flag cache refresh to more intelligently seed Firestore data. The system now checks for and only creates missing Firestore documents on a per-flag basis.
  * Enhanced error logging for Firestore seeding failures to provide better visibility into synchronization issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->